### PR TITLE
contracts: Add interfaces

### DIFF
--- a/contracts/src/Interfaces/IBorrowerOperations.sol
+++ b/contracts/src/Interfaces/IBorrowerOperations.sol
@@ -24,25 +24,29 @@ interface IBorrowerOperations is ILiquityBase {
         address _boldTokenAddress
     ) external;
 
-    function openTrove(uint _maxFee, uint256 _ETHAmount, uint _boldAmount, address _upperHint, address _lowerHint, uint256 _annualInterestRate) external;
+    function openTrove(address _owner, uint256 _ownerIndex, uint _maxFee, uint256 _ETHAmount, uint _boldAmount, address _upperHint, address _lowerHint, uint256 _annualInterestRate, uint256 _spDeposit) external;
 
-    function addColl(uint256 _ETHAmount) external;
+    function addColl(uint256 _troveId, uint256 _ETHAmount) external;
 
-    function moveETHGainToTrove(address _user, uint256 _ETHAmount) external;
+    function moveETHGainToTrove(uint256 _troveId, uint256 _ETHAmount) external;
 
-    function withdrawColl(uint _amount) external;
+    function withdrawColl(uint256 _troveId, uint _amount) external;
 
-    function withdrawBold(uint _maxFee, uint _amount) external;
+    function withdrawBold(uint256 _troveId, uint _maxFee, uint _amount) external;
 
-    function repayBold(uint _amount) external;
+    function repayBold(uint256 _troveId, uint _amount) external;
 
-    function closeTrove() external;
+    function closeTrove(uint256 _troveId) external;
 
-    function adjustTrove(uint _maxFee, uint _collChange, bool _isCollIncrease, uint _debtChange, bool isDebtIncrease) external;
+    function adjustTrove(uint256 _troveId, uint _maxFee, uint _collChange, bool _isCollIncrease, uint _debtChange, bool isDebtIncrease) external;
 
-    function claimCollateral() external;
+    function delegateInterest(uint256 _troveId, address _delegate) external;
+
+    function claimCollateral(uint256 _troveId) external;
+
+    // TODO: addRepayWhitelistedAddress?(see github issue #64)
 
     function getCompositeDebt(uint _debt) external pure returns (uint);
 
-    function adjustTroveInterestRate(uint _newAnnualInterestRate, address _upperHint, address _lowerHint) external;
+    function adjustTroveInterestRate(uint256 _troveId, uint _newAnnualInterestRate, address _upperHint, address _lowerHint) external;
 }

--- a/contracts/src/Interfaces/IStabilityPool.sol
+++ b/contracts/src/Interfaces/IStabilityPool.sol
@@ -54,7 +54,7 @@ interface IStabilityPool is ILiquityBase {
     */
     function provideToSP(uint _amount) external;
 
-   
+
     /*  withdrawFromSP():
     * - Calculates depositor's ETH gain
     * - Calculates the compounded deposit
@@ -80,6 +80,21 @@ interface IStabilityPool is ILiquityBase {
      * Only called by liquidation functions in the TroveManager.
      */
     function offset(uint _debt, uint _coll) external;
+
+    /* setETHSellIntent():
+     * Opt-in swap facility liquidation gains
+     */
+    function setETHSellIntent(uint256 _ethAmount, uint256 _priceDiscount) external;
+
+    /* buyETH():
+     * Swap ETH to Bold using opt-in swap facility liquidation gains, from one depositor
+     */
+    function buyETH(address _depositor, uint256 _ethAmount) external;
+
+    /* buyETHBatch():
+     * Swap ETH to Bold using opt-in swap facility liquidation gains, from multiple depositors
+     */
+    function buyETHBatch(address[] calldata _depositors, uint256 _ethAmount) external;
 
     /*
      * Returns the total amount of ETH held by the pool, accounted in an internal variable instead of `balance`,

--- a/contracts/src/Interfaces/ITroveManager.sol
+++ b/contracts/src/Interfaces/ITroveManager.sol
@@ -32,12 +32,12 @@ interface ITroveManager is ILiquityBase {
 
     function getTroveFromTroveOwnersArray(uint _index) external view returns (address);
 
-    function getNominalICR(address _borrower) external view returns (uint);
-    function getCurrentICR(address _borrower, uint _price) external view returns (uint);
+    function getNominalICR(uint256 _troveId) external view returns (uint);
+    function getCurrentICR(uint256 _troveId, uint _price) external view returns (uint);
 
-    function liquidate(address _borrower) external;
+    function liquidate(uint256 _troveId) external;
 
-    function batchLiquidateTroves(address[] calldata _troveArray) external;
+    function batchLiquidateTroves(uint256[] calldata _troveArray) external;
 
     function redeemCollateral(
         uint _boldAmount,
@@ -49,55 +49,57 @@ interface ITroveManager is ILiquityBase {
         uint _maxFee
     ) external; 
 
-    function updateStakeAndTotalStakes(address _borrower) external returns (uint);
+    function updateStakeAndTotalStakes(uint256 _troveId) external returns (uint);
 
-    function addTroveOwnerToArray(address _borrower) external returns (uint index);
+    function addTroveOwnerToArray(uint256 _troveId) external returns (uint index);
 
-    function applyPendingRewards(address _borrower) external;
+    function applyPendingRewards(uint256 _troveId) external;
 
-    function getPendingETHReward(address _borrower) external view returns (uint);
+    function appyInterestToTroves(uint256[] calldata _troveIds) external;
 
-    function getPendingBoldDebtReward(address _borrower) external view returns (uint);
+    function getPendingETHReward(uint256 _troveId) external view returns (uint);
 
-     function hasPendingRewards(address _borrower) external view returns (bool);
+    function getPendingBoldDebtReward(uint256 _troveId) external view returns (uint);
 
-    function getEntireDebtAndColl(address _borrower) external view returns (
+     function hasPendingRewards(uint256 _troveId) external view returns (bool);
+
+    function getEntireDebtAndColl(uint256 _troveId) external view returns (
         uint debt, 
         uint coll, 
         uint pendingBoldDebtReward, 
         uint pendingETHReward
     );
 
-    function closeTrove(address _borrower) external;
+    function closeTrove(uint256 _troveId) external;
 
-    function removeStake(address _borrower) external;
+    function removeStake(uint256 _troveId) external;
 
     function getRedemptionRate() external view returns (uint);
     function getRedemptionRateWithDecay() external view returns (uint);
 
     function getRedemptionFeeWithDecay(uint _ETHDrawn) external view returns (uint);
 
-    function getTroveStatus(address _borrower) external view returns (uint);
+    function getTroveStatus(uint256 _troveId) external view returns (uint);
     
-    function getTroveStake(address _borrower) external view returns (uint);
+    function getTroveStake(uint256 _troveId) external view returns (uint);
 
-    function getTroveDebt(address _borrower) external view returns (uint);
+    function getTroveDebt(uint256 _troveId) external view returns (uint);
 
-    function getTroveColl(address _borrower) external view returns (uint);
+    function getTroveColl(uint256 _troveId) external view returns (uint);
 
-    function getTroveAnnualInterestRate(address _borrower) external view returns (uint);
+    function getTroveAnnualInterestRate(uint256 _troveId) external view returns (uint);
 
-    function setTrovePropertiesOnOpen(address _borrower, uint256 _coll, uint256 _debt, uint256 _annualInterestRate) external returns (uint256);
+    function setTrovePropertiesOnOpen(uint256 _troveId, uint256 _coll, uint256 _debt, uint256 _annualInterestRate) external returns (uint256);
 
-    function increaseTroveColl(address _borrower, uint _collIncrease) external returns (uint);
+    function increaseTroveColl(uint256 _troveId, uint _collIncrease) external returns (uint);
 
-    function decreaseTroveColl(address _borrower, uint _collDecrease) external returns (uint); 
+    function decreaseTroveColl(uint256 _troveId, uint _collDecrease) external returns (uint);
 
-    function increaseTroveDebt(address _borrower, uint _debtIncrease) external returns (uint); 
+    function increaseTroveDebt(uint256 _troveId, uint _debtIncrease) external returns (uint);
 
-    function decreaseTroveDebt(address _borrower, uint _collDecrease) external returns (uint); 
+    function decreaseTroveDebt(uint256 _troveId, uint _collDecrease) external returns (uint);
 
-    function changeAnnualInterestRate(address _borrower, uint256 _newAnnualInterestRate) external;
+    function changeAnnualInterestRate(uint256 _troveId, uint256 _newAnnualInterestRate) external;
 
     function getTCR(uint _price) external view returns (uint);
 


### PR DESCRIPTION
First draft of interfaces changes for the frontend.
I skipped:
- Anything related to redemptions, as they won’t be implemented in the frontend
- Combined operations. Let’s do this the other way around: once we know which operations the frontend is adding, I’ll add them to the contracts.