### PR TITLE
Fix FeeArithmeticTest

### DIFF
--- a/contracts/test/CollSurplusPool.js
+++ b/contracts/test/CollSurplusPool.js
@@ -1,3 +1,4 @@
+const { time } = require('@nomicfoundation/hardhat-network-helpers');
 const deploymentHelper = require("../utils/deploymentHelpers.js");
 const testHelpers = require("../utils/testHelpers.js");
 const { fundAccounts } = require("../utils/fundAccounts.js");
@@ -64,10 +65,7 @@ contract("CollSurplusPool", async (accounts) => {
     });
 
     // skip bootstrapping phase
-    await th.fastForwardTime(
-      timeValues.SECONDS_IN_ONE_WEEK * 2,
-      web3.currentProvider
-    );
+    await time.increase(timeValues.SECONDS_IN_ONE_WEEK * 2);
 
     // At ETH:USD = 100, this redemption should leave 1 ether of coll surplus
     await th.redeemCollateralAndGetTxObject(A, contracts, B_netDebt);

--- a/contracts/test/FeeArithmeticTest.js
+++ b/contracts/test/FeeArithmeticTest.js
@@ -1,3 +1,4 @@
+const { time } = require('@nomicfoundation/hardhat-network-helpers');
 const Decimal = require("decimal.js");
 const deploymentHelper = require("../utils/deploymentHelpers.js")
 const { BNConverter } = require("../utils/BNConverter.js")
@@ -19,7 +20,7 @@ contract('Fee arithmetic tests', async accounts => {
   const [bountyAddress, lpRewardsAddress, multisig] = accounts.slice(997, 1000)
 
   // see: https://docs.google.com/spreadsheets/d/1RbD8VGzq7xFgeK1GOkz_9bbKVIx-xkOz0VsVelnUFdc/edit#gid=0
-  // Results array, maps seconds to expected hours passed output (rounded down to nearest hour).
+  // Results array, maps seconds to expected minutes passed output (rounded down to nearest hour).
 
   const secondsToMinutesRoundedDown = [
     [0, 0],
@@ -351,16 +352,16 @@ contract('Fee arithmetic tests', async accounts => {
   })
 
   it("minutesPassedSinceLastFeeOp(): returns minutes passed between time of last fee operation and current block.timestamp, rounded down to nearest minutes", async () => {
-    for (const [seconds, expectedHoursPassed] of secondsToMinutesRoundedDown) {
+    for (const [seconds, expectedMinutesPassed] of secondsToMinutesRoundedDown) {
       await troveManagerTester.setLastFeeOpTimeToNow()
 
       if (seconds > 0) {
-        await th.fastForwardTime(seconds, web3.currentProvider)
+        await time.increase(seconds)
       }
 
       const minutesPassed = await troveManagerTester.minutesPassedSinceLastFeeOp()
 
-      assert.equal(expectedHoursPassed.toString(), minutesPassed.toString())
+      assert.equal(expectedMinutesPassed.toString(), minutesPassed.toString())
     }
   })
 

--- a/contracts/test/StabilityPoolTest.js
+++ b/contracts/test/StabilityPoolTest.js
@@ -1,3 +1,4 @@
+const { time } = require('@nomicfoundation/hardhat-network-helpers');
 const deploymentHelper = require("../utils/deploymentHelpers.js");
 const testHelpers = require("../utils/testHelpers.js");
 const { fundAccounts } = require("../utils/fundAccounts.js");
@@ -1102,10 +1103,7 @@ contract("StabilityPool", async (accounts) => {
       await stabilityPool.provideToSP(dec(105, 18), { from: D });
 
       // time passes
-      await th.fastForwardTime(
-        timeValues.SECONDS_IN_ONE_HOUR,
-        web3.currentProvider
-      );
+      await time.increase(timeValues.SECONDS_IN_ONE_HOUR);
 
       // B deposits
       await stabilityPool.provideToSP(dec(5, 18), { from: B });
@@ -2210,10 +2208,7 @@ contract("StabilityPool", async (accounts) => {
         await th.ICRbetween100and110(defaulter_1_TroveId, troveManager, price)
       );
 
-      await th.fastForwardTime(
-        timeValues.MINUTES_IN_ONE_WEEK,
-        web3.currentProvider
-      );
+      await time.increase(timeValues.MINUTES_IN_ONE_WEEK);
 
       // Liquidate d1
       await troveManager.liquidate(defaulter_1_TroveId);
@@ -2897,10 +2892,7 @@ contract("StabilityPool", async (accounts) => {
       await stabilityPool.provideToSP(dec(10000, 18), { from: E });
 
       // Fast-forward time and make a second deposit
-      await th.fastForwardTime(
-        timeValues.SECONDS_IN_ONE_HOUR,
-        web3.currentProvider
-      );
+      await time.increase(timeValues.SECONDS_IN_ONE_HOUR);
       await stabilityPool.provideToSP(dec(10000, 18), { from: E });
 
       // perform a liquidation to make 0 < P < 1, and S > 0
@@ -3008,10 +3000,7 @@ contract("StabilityPool", async (accounts) => {
       //  SETUP: Execute a series of operations to trigger ETH rewards for depositor A
 
       // Fast-forward time and make a second deposit
-      await th.fastForwardTime(
-        timeValues.SECONDS_IN_ONE_HOUR,
-        web3.currentProvider
-      );
+      await time.increase(timeValues.SECONDS_IN_ONE_HOUR);
       await stabilityPool.provideToSP(dec(100, 18), { from: A });
 
       // perform a liquidation to make 0 < P < 1, and S > 0
@@ -3711,10 +3700,7 @@ contract("StabilityPool", async (accounts) => {
       await stabilityPool.provideToSP(dec(40, 18), { from: D });
 
       // fastforward time, and E makes a deposit
-      await th.fastForwardTime(
-        timeValues.SECONDS_IN_ONE_HOUR,
-        web3.currentProvider
-      );
+      await time.increase(timeValues.SECONDS_IN_ONE_HOUR);
       await openTrove({
         extraBoldAmount: toBN(dec(3000, 18)),
         ICR: toBN(dec(2, 18)),

--- a/contracts/test/TroveManagerTest.js
+++ b/contracts/test/TroveManagerTest.js
@@ -1,3 +1,4 @@
+const { time } = require('@nomicfoundation/hardhat-network-helpers');
 const deploymentHelper = require("../utils/deploymentHelpers.js");
 const testHelpers = require("../utils/testHelpers.js");
 const { fundAccounts } = require("../utils/fundAccounts.js");
@@ -2407,10 +2408,7 @@ contract("TroveManager", async (accounts) => {
       );
 
     // skip bootstrapping phase
-    await th.fastForwardTime(
-      timeValues.SECONDS_IN_ONE_WEEK * 2,
-      web3.currentProvider
-    );
+    await time.increase(timeValues.SECONDS_IN_ONE_WEEK * 2);
 
     // Dennis redeems 20 Bold
     // Don't pay for gas, as it makes it easier to calculate the received Ether
@@ -2525,10 +2523,7 @@ contract("TroveManager", async (accounts) => {
       );
 
     // skip bootstrapping phase
-    await th.fastForwardTime(
-      timeValues.SECONDS_IN_ONE_WEEK * 2,
-      web3.currentProvider
-    );
+    await time.increase(timeValues.SECONDS_IN_ONE_WEEK * 2);
 
     // Dennis redeems 20 Bold
     // Don't pay for gas, as it makes it easier to calculate the received Ether
@@ -2634,10 +2629,7 @@ contract("TroveManager", async (accounts) => {
       );
 
     // skip bootstrapping phase
-    await th.fastForwardTime(
-      timeValues.SECONDS_IN_ONE_WEEK * 2,
-      web3.currentProvider
-    );
+    await time.increase(timeValues.SECONDS_IN_ONE_WEEK * 2);
 
     // Dennis redeems 20 Bold
     // Don't pay for gas, as it makes it easier to calculate the received Ether
@@ -2748,10 +2740,7 @@ contract("TroveManager", async (accounts) => {
       );
 
     // skip bootstrapping phase
-    await th.fastForwardTime(
-      timeValues.SECONDS_IN_ONE_WEEK * 2,
-      web3.currentProvider
-    );
+    await time.increase(timeValues.SECONDS_IN_ONE_WEEK * 2);
 
     // Dennis redeems 20 Bold
     // Don't pay for gas, as it makes it easier to calculate the received Ether
@@ -2848,10 +2837,7 @@ contract("TroveManager", async (accounts) => {
     });
 
     // skip bootstrapping phase
-    await th.fastForwardTime(
-      timeValues.SECONDS_IN_ONE_WEEK * 2,
-      web3.currentProvider
-    );
+    await time.increase(timeValues.SECONDS_IN_ONE_WEEK * 2);
 
     // Flyn redeems collateral
     await troveManager.redeemCollateral(
@@ -2936,10 +2922,7 @@ contract("TroveManager", async (accounts) => {
     });
 
     // skip bootstrapping phase
-    await th.fastForwardTime(
-      timeValues.SECONDS_IN_ONE_WEEK * 2,
-      web3.currentProvider
-    );
+    await time.increase(timeValues.SECONDS_IN_ONE_WEEK * 2);
 
     // Flyn redeems collateral with only two iterations
     await troveManager.redeemCollateral(
@@ -3008,10 +2991,7 @@ contract("TroveManager", async (accounts) => {
     await troveManager.setBaseRate(0);
 
     // skip bootstrapping phase
-    await th.fastForwardTime(
-      timeValues.SECONDS_IN_ONE_WEEK * 2,
-      web3.currentProvider
-    );
+    await time.increase(timeValues.SECONDS_IN_ONE_WEEK * 2);
 
     // Bold redemption is 55000 US
     const BoldRedemption = dec(55000, 18);
@@ -3062,10 +3042,7 @@ contract("TroveManager", async (accounts) => {
     await troveManager.setBaseRate(0);
 
     // Skip bootstrapping phase
-    await th.fastForwardTime(
-      timeValues.SECONDS_IN_ONE_WEEK * 2,
-      web3.currentProvider
-    );
+    await time.increase(timeValues.SECONDS_IN_ONE_WEEK * 2);
 
     // Bold redemption is 55000 Bold
     const BoldRedemption = dec(55000, 18);
@@ -3150,10 +3127,7 @@ contract("TroveManager", async (accounts) => {
         );
 
       // skip bootstrapping phase
-      await th.fastForwardTime(
-        timeValues.SECONDS_IN_ONE_WEEK * 2,
-        web3.currentProvider
-      );
+      await time.increase(timeValues.SECONDS_IN_ONE_WEEK * 2);
 
       // Alice redeems 1 Bold from Carol's Trove
       await troveManager.redeemCollateral(
@@ -3241,10 +3215,7 @@ contract("TroveManager", async (accounts) => {
     const carol_ETHBalance_Before = toBN(await contracts.WETH.balanceOf(carol));
 
     // skip bootstrapping phase
-    await th.fastForwardTime(
-      timeValues.SECONDS_IN_ONE_WEEK * 2,
-      web3.currentProvider
-    );
+    await time.increase(timeValues.SECONDS_IN_ONE_WEEK * 2);
 
     const redemptionTx = await troveManager.redeemCollateral(
       amount,
@@ -3299,10 +3270,7 @@ contract("TroveManager", async (accounts) => {
     // --- TEST ---
 
     // skip bootstrapping phase
-    await th.fastForwardTime(
-      timeValues.SECONDS_IN_ONE_WEEK * 2,
-      web3.currentProvider
-    );
+    await time.increase(timeValues.SECONDS_IN_ONE_WEEK * 2);
 
     await troveManager.redeemCollateral(
       A_debt,
@@ -3370,10 +3338,7 @@ contract("TroveManager", async (accounts) => {
     });
 
     // skip bootstrapping phase
-    await th.fastForwardTime(
-      timeValues.SECONDS_IN_ONE_WEEK * 2,
-      web3.currentProvider
-    );
+    await time.increase(timeValues.SECONDS_IN_ONE_WEEK * 2);
 
     const tx = await troveManager.redeemCollateral(
       redemptionAmount,
@@ -3415,10 +3380,7 @@ contract("TroveManager", async (accounts) => {
     assert.isTrue(TCR.lt(toBN("1100000000000000000")));
 
     // skip bootstrapping phase
-    await th.fastForwardTime(
-      timeValues.SECONDS_IN_ONE_WEEK * 2,
-      web3.currentProvider
-    );
+    await time.increase(timeValues.SECONDS_IN_ONE_WEEK * 2);
 
     await assertRevert(
       th.redeemCollateral(carolTroveId, contracts, GAS_PRICE, dec(270, 18)),
@@ -3443,10 +3405,7 @@ contract("TroveManager", async (accounts) => {
     await openTrove({ ICR: toBN(dec(200, 16)), extraParams: { from: dennis } });
 
     // skip bootstrapping phase
-    await th.fastForwardTime(
-      timeValues.SECONDS_IN_ONE_WEEK * 2,
-      web3.currentProvider
-    );
+    await time.increase(timeValues.SECONDS_IN_ONE_WEEK * 2);
 
     // Erin attempts to redeem with _amount = 0
     const redemptionTxPromise = troveManager.redeemCollateral(
@@ -3488,10 +3447,7 @@ contract("TroveManager", async (accounts) => {
     });
 
     // skip bootstrapping phase
-    await th.fastForwardTime(
-      timeValues.SECONDS_IN_ONE_WEEK * 2,
-      web3.currentProvider
-    );
+    await time.increase(timeValues.SECONDS_IN_ONE_WEEK * 2);
 
     await assertRevert(
       th.redeemCollateralAndGetTxObject(
@@ -3538,10 +3494,7 @@ contract("TroveManager", async (accounts) => {
     });
 
     // skip bootstrapping phase
-    await th.fastForwardTime(
-      timeValues.SECONDS_IN_ONE_WEEK * 2,
-      web3.currentProvider
-    );
+    await time.increase(timeValues.SECONDS_IN_ONE_WEEK * 2);
 
     await assertRevert(
       th.redeemCollateralAndGetTxObject(
@@ -3600,10 +3553,7 @@ contract("TroveManager", async (accounts) => {
     await troveManager.setBaseRate(0);
 
     // skip bootstrapping phase
-    await th.fastForwardTime(
-      timeValues.SECONDS_IN_ONE_WEEK * 2,
-      web3.currentProvider
-    );
+    await time.increase(timeValues.SECONDS_IN_ONE_WEEK * 2);
 
     // Bold redemption is 27 USD: a redemption that incurs a fee of 27/(270 * 2) = 5%
     const attemptedBoldRedemption = expectedTotalSupply.div(toBN(10));
@@ -3749,10 +3699,7 @@ contract("TroveManager", async (accounts) => {
     assert.isTrue(ETHinSP.gte(mv._zeroBN));
 
     // skip bootstrapping phase
-    await th.fastForwardTime(
-      timeValues.SECONDS_IN_ONE_WEEK * 2,
-      web3.currentProvider
-    );
+    await time.increase(timeValues.SECONDS_IN_ONE_WEEK * 2);
 
     // Erin redeems Bold
     await th.redeemCollateral(erin, contracts, redemptionAmount, th._100pct);
@@ -3848,10 +3795,7 @@ contract("TroveManager", async (accounts) => {
     const price = await priceFeed.getPrice();
 
     // skip bootstrapping phase
-    await th.fastForwardTime(
-      timeValues.SECONDS_IN_ONE_WEEK * 2,
-      web3.currentProvider
-    );
+    await time.increase(timeValues.SECONDS_IN_ONE_WEEK * 2);
 
     // Erin attempts to redeem 400 Bold
     const { firstRedemptionHint, partialRedemptionHintNICR } =
@@ -3951,10 +3895,7 @@ contract("TroveManager", async (accounts) => {
     let partialRedemptionHintNICR;
 
     // skip bootstrapping phase
-    await th.fastForwardTime(
-      timeValues.SECONDS_IN_ONE_WEEK * 2,
-      web3.currentProvider
-    );
+    await time.increase(timeValues.SECONDS_IN_ONE_WEEK * 2);
 
     // Erin tries to redeem 1000 Bold
     try {
@@ -4166,10 +4107,7 @@ contract("TroveManager", async (accounts) => {
       );
 
     // skip bootstrapping phase
-    await th.fastForwardTime(
-      timeValues.SECONDS_IN_ONE_WEEK * 2,
-      web3.currentProvider
-    );
+    await time.increase(timeValues.SECONDS_IN_ONE_WEEK * 2);
 
     const redemption_1 = await troveManager.redeemCollateral(
       _120_Bold,
@@ -4338,10 +4276,7 @@ contract("TroveManager", async (accounts) => {
       );
 
     // skip bootstrapping phase
-    await th.fastForwardTime(
-      timeValues.SECONDS_IN_ONE_WEEK * 2,
-      web3.currentProvider
-    );
+    await time.increase(timeValues.SECONDS_IN_ONE_WEEK * 2);
 
     // Bob attempts to redeem his ill-gotten 101 Bold, from a system that has 100 Bold outstanding debt
     try {
@@ -4365,10 +4300,7 @@ contract("TroveManager", async (accounts) => {
 
   it.skip("redeemCollateral(): a redemption sends the ETH remainder (ETHDrawn - gas) to the redeemer", async () => {
     // time fast-forwards 1 year, and multisig stakes 1 LQTY
-    await th.fastForwardTime(
-      timeValues.SECONDS_IN_ONE_YEAR,
-      web3.currentProvider
-    );
+    await time.increase(timeValues.SECONDS_IN_ONE_YEAR);
 
     const { totalDebt: W_totalDebt } = await openTrove({
       ICR: toBN(dec(20, 18)),
@@ -4431,10 +4363,7 @@ contract("TroveManager", async (accounts) => {
 
   it.skip("redeemCollateral(): a full redemption (leaving trove with 0 debt), closes the trove", async () => {
     // time fast-forwards 1 year, and multisig stakes 1 LQTY
-    await th.fastForwardTime(
-      timeValues.SECONDS_IN_ONE_YEAR,
-      web3.currentProvider
-    );
+    await time.increase(timeValues.SECONDS_IN_ONE_YEAR);
     
     const { netDebt: W_netDebt } = await openTrove({
       ICR: toBN(dec(20, 18)),
@@ -4484,10 +4413,7 @@ contract("TroveManager", async (accounts) => {
 
   const redeemCollateral3Full1Partial = async () => {
     // time fast-forwards 1 year, and multisig stakes 1 LQTY
-    await th.fastForwardTime(
-      timeValues.SECONDS_IN_ONE_YEAR,
-      web3.currentProvider
-    );
+    await time.increase(timeValues.SECONDS_IN_ONE_YEAR);
 
     const { netDebt: W_netDebt } = await openTrove({
       ICR: toBN(dec(20, 18)),
@@ -4627,10 +4553,7 @@ contract("TroveManager", async (accounts) => {
       .add(partialAmount);
 
     // skip bootstrapping phase
-    await th.fastForwardTime(
-      timeValues.SECONDS_IN_ONE_WEEK * 2,
-      web3.currentProvider
-    );
+    await time.increase(timeValues.SECONDS_IN_ONE_WEEK * 2);
 
     // whale redeems Bold.  Expect this to fully redeem A, B, C, and partially redeem 15 Bold from D.
     const redemptionTx = await th.redeemCollateralAndGetTxObject(

--- a/contracts/test/TroveManager_RecoveryModeTest.js
+++ b/contracts/test/TroveManager_RecoveryModeTest.js
@@ -1,3 +1,4 @@
+const { time } = require('@nomicfoundation/hardhat-network-helpers');
 const deploymentHelper = require("../utils/deploymentHelpers.js");
 const testHelpers = require("../utils/testHelpers.js");
 const { fundAccounts } = require("../utils/fundAccounts.js");
@@ -2245,10 +2246,7 @@ contract.skip("TroveManager - in Recovery Mode", async (accounts) => {
     );
 
     // skip bootstrapping phase
-    await th.fastForwardTime(
-      timeValues.SECONDS_IN_ONE_WEEK * 2,
-      web3.currentProvider
-    );
+    await time.increase(timeValues.SECONDS_IN_ONE_WEEK * 2);
 
     // Bob re-opens the trove, price 200, total debt 80 Bold, ICR = 120%, 0 interest rate (lowest one)
     // Dennis redeems 30, so Bob has a surplus of (200 * 0.48 - 30) / 200 = 0.33 ETH
@@ -2301,10 +2299,7 @@ contract.skip("TroveManager - in Recovery Mode", async (accounts) => {
 
     // --- TEST ---
     // skip bootstrapping phase
-    await th.fastForwardTime(
-      timeValues.SECONDS_IN_ONE_WEEK * 2,
-      web3.currentProvider
-    );
+    await time.increase(timeValues.SECONDS_IN_ONE_WEEK * 2);
 
     // Dennis redeems 40, hits Bob (lowest ICR) so Bob has a surplus of (200 * 1 - 40) / 200 = 0.8 ETH
     await th.redeemCollateral(dennis, contracts, B_netDebt);

--- a/contracts/utils/testHelpers.js
+++ b/contracts/utils/testHelpers.js
@@ -1631,31 +1631,6 @@ class TestHelper {
 
   // --- Time functions ---
 
-  static async fastForwardTime(seconds, currentWeb3Provider) {
-    await currentWeb3Provider.send(
-      {
-        id: 0,
-        jsonrpc: "2.0",
-        method: "evm_increaseTime",
-        params: [seconds],
-      },
-      (err) => {
-        if (err) console.log(err);
-      }
-    );
-
-    await currentWeb3Provider.send(
-      {
-        id: 0,
-        jsonrpc: "2.0",
-        method: "evm_mine",
-      },
-      (err) => {
-        if (err) console.log(err);
-      }
-    );
-  }
-
   static async getLatestBlockTimestamp(web3Instance) {
     const blockNumber = await web3Instance.eth.getBlockNumber();
     const block = await web3Instance.eth.getBlock(blockNumber);


### PR DESCRIPTION
`minutesPassedSinceLastFeeOp()` tests:

- Do not mine a new block if the time increase is `0`.
- Replace “hours” by “minutes”.

All tests:

- Migrate from `th.fastForwardTime()` to `time.increase()` (better reliability with the hardhat’s ethereum client).
