### PR TITLE
GitHub Actions: pin foundry version

### DIFF
--- a/.github/workflows/contracts-tests.yml
+++ b/.github/workflows/contracts-tests.yml
@@ -18,7 +18,7 @@ env:
 
 on:
   push:
-    branches: [gh-workflow-pin-foundry]
+    branches: [main]
     paths:
       - ".github/workflows/contracts.yml"
       - "contracts/**"

--- a/.github/workflows/testnet-deployment.yml
+++ b/.github/workflows/testnet-deployment.yml
@@ -6,7 +6,7 @@ name: Testnet Deployment
 
 on:
   push:
-    branches: [gh-workflow-pin-foundry]
+    branches: [main]
     paths:
       - ".github/workflows/testnet-deployment.yml"
       - "contracts/**"


### PR DESCRIPTION
This fixes an issue with the latest version (`nightly`) and contracts verification https://github.com/liquity/bold/actions/runs/8734315602/job/23964899137#step:7:194