### PR TITLE
test: Fix hardhat tests

### DIFF
--- a/contracts/src/BorrowerOperations.sol
+++ b/contracts/src/BorrowerOperations.sol
@@ -236,7 +236,7 @@ contract BorrowerOperations is LiquityBase, Ownable, CheckContract, IBorrowerOpe
         // TODO: Use oldColl and assert in fuzzing, remove before deployment
         uint256 oldColl = troveManager.getTroveEntireColl(_troveId);
         _adjustTrove(msg.sender, _troveId, _ETHAmount, true, 0, false, 0, contractsCache);
-        // assert(troveManager.getTroveEntireColl(_troveId) > oldColl);
+        assert(troveManager.getTroveEntireColl(_troveId) > oldColl);
     }
 
     // Send ETH as collateral to a trove. Called by only the Stability Pool.


### PR DESCRIPTION
2 remaining hardhat tests failing due to the Zombie Troves PR. 
- One addColl test fixed (new revert message)
- One"internal adjust loan" deleted as I don't see a need for it: we should rather test access control for all external/public functions.