### PR TITLE
App Earn screen: add withdraw + claim panels

### DIFF
--- a/frontend/app/src/app/contracts/ContractBorrowerOperations.tsx
+++ b/frontend/app/src/app/contracts/ContractBorrowerOperations.tsx
@@ -1,5 +1,5 @@
 import { BorrowerOperationsContract } from "@/src/contracts";
-import { formValue, parseInputInt, parseInputPercentage, parseInputValue, useForm } from "@/src/form-utils";
+import { formValue, parseInputInt, parseInputPercentage, parseInputFloat, useForm } from "@/src/form-utils";
 import { getTroveId, useCollTokenAllowance } from "@/src/liquity-utils";
 import { FormField, TextInput } from "@liquity2/uikit";
 import * as dn from "dnum";
@@ -29,10 +29,10 @@ function OpenTrove() {
   const { fieldsProps, values, fill } = useForm(() => ({
     ownerIndex: formValue(0n, parseInputInt),
     maxFeePercentage: formValue(dn.from(0, 18), parseInputPercentage),
-    ethAmount: formValue(dn.from(0, 18), parseInputValue),
-    boldAmount: formValue(dn.from(0, 18), parseInputValue),
-    upperHint: formValue(dn.from(0, 18), parseInputValue),
-    lowerHint: formValue(dn.from(0, 18), parseInputValue),
+    ethAmount: formValue(dn.from(0, 18), parseInputFloat),
+    boldAmount: formValue(dn.from(0, 18), parseInputFloat),
+    upperHint: formValue(dn.from(0, 18), parseInputFloat),
+    lowerHint: formValue(dn.from(0, 18), parseInputFloat),
     annualInterestRate: formValue(dn.from(0, 18), parseInputPercentage),
   }), writeOpenTrove.reset);
 
@@ -149,7 +149,7 @@ function RepayBold() {
 
   const { fieldsProps, values } = useForm(() => ({
     ownerIndex: formValue(0n, parseInputInt),
-    boldAmount: formValue(dn.from(0, 18), parseInputValue),
+    boldAmount: formValue(dn.from(0, 18), parseInputFloat),
   }), reset);
 
   const onSubmit = () => {
@@ -186,7 +186,7 @@ function AddCollateral() {
 
   const { fieldsProps, values } = useForm(() => ({
     ownerIndex: formValue(0n, parseInputInt),
-    ethAmount: formValue(dn.from(0, 18), parseInputValue),
+    ethAmount: formValue(dn.from(0, 18), parseInputFloat),
   }), reset);
 
   const onSubmit = () => {
@@ -224,7 +224,7 @@ function WithdrawCollateral() {
 
   const { fieldsProps, values } = useForm(() => ({
     ownerIndex: formValue(0n, parseInputInt),
-    ethAmount: formValue(dn.from(0, 18), parseInputValue),
+    ethAmount: formValue(dn.from(0, 18), parseInputFloat),
   }), reset);
 
   const onSubmit = () => {
@@ -263,8 +263,8 @@ function AdjustTroveInterestRate() {
   const { fieldsProps, values } = useForm(() => ({
     ownerIndex: formValue(0n, parseInputInt),
     newAnnualInterestRate: formValue(dn.from(0, 18), parseInputPercentage),
-    upperHint: formValue(dn.from(0, 18), parseInputValue),
-    lowerHint: formValue(dn.from(0, 18), parseInputValue),
+    upperHint: formValue(dn.from(0, 18), parseInputFloat),
+    lowerHint: formValue(dn.from(0, 18), parseInputFloat),
   }), reset);
 
   const onSubmit = () => {
@@ -310,10 +310,10 @@ function AdjustTrove() {
 
   const { fieldsProps, values } = useForm(() => ({
     ownerIndex: formValue(0n, parseInputInt),
-    maxFeePercentage: formValue(dn.from(0, 18), parseInputValue),
-    collChange: formValue(dn.from(0, 18), parseInputValue),
+    maxFeePercentage: formValue(dn.from(0, 18), parseInputFloat),
+    collChange: formValue(dn.from(0, 18), parseInputFloat),
     isCollIncrease: formValue(false, (value) => value === "true"),
-    boldChange: formValue(dn.from(0, 18), parseInputValue),
+    boldChange: formValue(dn.from(0, 18), parseInputFloat),
     isDebtIncrease: formValue(false, (value) => value === "true"),
   }), reset);
 
@@ -368,8 +368,8 @@ function WithdrawBold() {
 
   const { fieldsProps, values } = useForm(() => ({
     ownerIndex: formValue(0n, parseInputInt),
-    maxFeePercentage: formValue(dn.from(0, 18), parseInputValue),
-    boldAmount: formValue(dn.from(0, 18), parseInputValue),
+    maxFeePercentage: formValue(dn.from(0, 18), parseInputFloat),
+    boldAmount: formValue(dn.from(0, 18), parseInputFloat),
   }), reset);
 
   const onSubmit = () => {

--- a/frontend/app/src/app/contracts/ContractStabilityPool.tsx
+++ b/frontend/app/src/app/contracts/ContractStabilityPool.tsx
@@ -1,5 +1,5 @@
 import { StabilityPoolContract } from "@/src/contracts";
-import { formValue, parseInputInt, parseInputValue, useForm } from "@/src/form-utils";
+import { formValue, parseInputInt, parseInputFloat, useForm } from "@/src/form-utils";
 import { getTroveId } from "@/src/liquity-utils";
 import { FormField, TextInput } from "@liquity2/uikit";
 import * as dn from "dnum";
@@ -22,7 +22,7 @@ function ProvideToSp() {
   const { writeContract, error, reset } = useWriteContract();
 
   const { fieldsProps, values } = useForm(() => ({
-    amount: formValue(dn.from(0, 18), parseInputValue),
+    amount: formValue(dn.from(0, 18), parseInputFloat),
   }), reset);
 
   const onSubmit = () => {
@@ -55,7 +55,7 @@ function WithdrawFromSp() {
   const { writeContract, error, reset } = useWriteContract();
 
   const { fieldsProps, values } = useForm(() => ({
-    amount: formValue(dn.from(0, 18), parseInputValue),
+    amount: formValue(dn.from(0, 18), parseInputFloat),
   }), reset);
 
   const onSubmit = () => {

--- a/frontend/app/src/app/earn/[pool]/DepositPanel.tsx
+++ b/frontend/app/src/app/earn/[pool]/DepositPanel.tsx
@@ -1,0 +1,149 @@
+import content from "@/src/content";
+import { POOLS } from "@/src/demo-data";
+import { parseInputFloat } from "@/src/form-utils";
+import { css } from "@/styled-system/css";
+import { Button, Checkbox, InputField, TextButton, TokenIcon } from "@liquity2/uikit";
+import * as dn from "dnum";
+import { useState } from "react";
+
+export function DepositPanel({ pool }: { pool: typeof POOLS[number] }) {
+  const [value, setValue] = useState("");
+  const [focused, setFocused] = useState(false);
+  const [claimRewards, setClaimRewards] = useState(false);
+
+  const parsedValue = parseInputFloat(value);
+
+  const secondaryStart = "Share in the pool";
+
+  const secondaryEnd = (
+    <TextButton
+      label="Max. 10,000.00 BOLD"
+      onClick={() => setValue("10000")}
+    />
+  );
+
+  const value_ = (focused || !parsedValue) ? value : `${dn.format(parsedValue)} BOLD`;
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        width: "100%",
+        gap: 48,
+      }}
+    >
+      <div
+        className={css({
+          display: "flex",
+          flexDirection: "column",
+          gap: 16,
+        })}
+      >
+        <InputField
+          action={
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                height: 40,
+                padding: "0 16px",
+                paddingLeft: 8,
+                background: "#FFF",
+                borderRadius: 20,
+                userSelect: "none",
+              }}
+            >
+              <TokenIcon symbol="BOLD" />
+              <div
+                style={{
+                  fontSize: 24,
+                  fontWeight: 500,
+                }}
+              >
+                BOLD
+              </div>
+            </div>
+          }
+          label={content.earnScreen.depositPanel.label}
+          onFocus={() => setFocused(true)}
+          onChange={setValue}
+          onBlur={() => setFocused(false)}
+          value={value_}
+          placeholder="0.00"
+          secondaryStart={secondaryStart}
+          secondaryEnd={secondaryEnd}
+        />
+        <div
+          className={css({
+            display: "flex",
+            justifyContent: "space-between",
+          })}
+        >
+          <label
+            className={css({
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              cursor: "pointer",
+              userSelect: "none",
+            })}
+          >
+            <Checkbox
+              checked={claimRewards}
+              onChange={setClaimRewards}
+            />
+            {content.earnScreen.depositPanel.claimCheckbox}
+          </label>
+          {pool.rewards && (
+            <div
+              className={css({
+                display: "flex",
+                gap: 24,
+              })}
+            >
+              <div>
+                {pool.rewards.bold}{" "}
+                <span
+                  className={css({
+                    color: "contentAlt",
+                  })}
+                >
+                  BOLD
+                </span>
+              </div>
+              <div>
+                {pool.rewards.eth}{" "}
+                <span
+                  className={css({
+                    color: "contentAlt",
+                  })}
+                >
+                  BOLD
+                </span>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "center",
+          width: "100%",
+        }}
+      >
+        <Button
+          disabled={!parsedValue}
+          label="Add Deposit"
+          mode="primary"
+          size="large"
+          wide
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/src/app/earn/[pool]/EarnScreen.tsx
+++ b/frontend/app/src/app/earn/[pool]/EarnScreen.tsx
@@ -1,23 +1,20 @@
 "use client";
 
-import type { ReactNode } from "react";
-
 import { BackButton } from "@/src/comps/BackButton/BackButton";
 import content from "@/src/content";
 import { POOLS } from "@/src/demo-data";
 import { css } from "@/styled-system/css";
-import { Button, Checkbox, InputField, Tabs, TextButton, TokenIcon, TokenIconGroup } from "@liquity2/uikit";
-import * as dn from "dnum";
+import { Tabs, TokenIcon, TokenIconGroup } from "@liquity2/uikit";
 import { useParams, useRouter } from "next/navigation";
-import { useState } from "react";
+import { DepositPanel } from "./DepositPanel";
+import { RewardsPanel } from "./RewardsPanel";
+import { WithdrawPanel } from "./WithdrawPanel";
 
 const TABS = [
   { action: "deposit", label: content.earnScreen.tabs.deposit },
   { action: "withdraw", label: content.earnScreen.tabs.withdraw },
   { action: "claim", label: content.earnScreen.tabs.claim },
 ] as const;
-
-type Action = typeof TABS[number]["action"];
 
 export function EarnScreen() {
   const { pool: poolName, action = "deposit" } = useParams();
@@ -38,8 +35,8 @@ export function EarnScreen() {
       })}
     >
       <BackButton href="/earn" label={content.earnScreen.backButton} />
-      <PoolHeader pool={pool} />
-      <MyDeposit pool={pool} />
+      <PoolSummary pool={pool} />
+      <AccountPosition pool={pool} />
       <div
         className={css({
           display: "flex",
@@ -51,7 +48,9 @@ export function EarnScreen() {
         <Tabs
           selected={TABS.indexOf(tab)}
           onSelect={(index) => {
-            router.push(`/earn/${poolName}/${TABS[index].action}`);
+            router.push(`/earn/${poolName}/${TABS[index].action}`, {
+              scroll: false,
+            });
           }}
           items={TABS.map((tab) => ({
             label: tab.label,
@@ -59,47 +58,15 @@ export function EarnScreen() {
             tabId: `tab-${tab.action}`,
           }))}
         />
-        {tab.action === "deposit" && <DepositField pool={pool} />}
-        {tab.action === "withdraw" && (
-          <div
-            className={css({
-              display: "flex",
-              justifyContent: "center",
-              width: "100%",
-              paddingTop: 48,
-            })}
-          >
-            <Button
-              label={tab.label}
-              mode="primary"
-              size="large"
-              wide
-            />
-          </div>
-        )}
-        {tab.action === "claim" && (
-          <div
-            className={css({
-              display: "flex",
-              justifyContent: "center",
-              width: "100%",
-              paddingTop: 48,
-            })}
-          >
-            <Button
-              label={tab.label}
-              mode="primary"
-              size="large"
-              wide
-            />
-          </div>
-        )}
+        {tab.action === "deposit" && <DepositPanel pool={pool} />}
+        {tab.action === "withdraw" && <WithdrawPanel pool={pool} />}
+        {tab.action === "claim" && <RewardsPanel pool={pool} />}
       </div>
     </div>
   );
 }
 
-function PoolHeader({ pool }: { pool: typeof POOLS[number] }) {
+function PoolSummary({ pool }: { pool: typeof POOLS[number] }) {
   return (
     <div
       className={css({
@@ -180,7 +147,7 @@ function PoolHeader({ pool }: { pool: typeof POOLS[number] }) {
   );
 }
 
-function MyDeposit({ pool }: { pool: typeof POOLS[number] }) {
+function AccountPosition({ pool }: { pool: typeof POOLS[number] }) {
   return pool.deposit && (
     <div
       className={css({
@@ -204,7 +171,7 @@ function MyDeposit({ pool }: { pool: typeof POOLS[number] }) {
             color: "contentAlt",
           })}
         >
-          {content.earnScreen.myDeposit}
+          {content.earnScreen.accountPosition.depositLabel}
         </div>
         <div
           className={css({})}
@@ -224,7 +191,7 @@ function MyDeposit({ pool }: { pool: typeof POOLS[number] }) {
             color: "contentAlt",
           })}
         >
-          {content.earnScreen.unclaimedRewards}
+          {content.earnScreen.accountPosition.rewardsLabel}
         </div>
         {pool.rewards && (
           <div
@@ -236,7 +203,7 @@ function MyDeposit({ pool }: { pool: typeof POOLS[number] }) {
               color: "positive",
             })}
           >
-            {pool.rewards[0]}
+            {pool.rewards.bold} BOLD
             <div
               className={css({
                 display: "flex",
@@ -246,166 +213,9 @@ function MyDeposit({ pool }: { pool: typeof POOLS[number] }) {
                 backgroundColor: "dimmed",
               })}
             />
-            {pool.rewards[1]}
+            {pool.rewards.eth} ETH
           </div>
         )}
-      </div>
-    </div>
-  );
-}
-
-export function DepositField({ pool }: { pool: typeof POOLS[number] }) {
-  const [value, setValue] = useState("");
-  const [focused, setFocused] = useState(false);
-  const [claimRewards, setClaimRewards] = useState(false);
-
-  const parsedValue = parseInputValue(value);
-
-  const action = (
-    <Action
-      label="BOLD"
-      icon={<TokenIcon symbol="BOLD" />}
-    />
-  );
-
-  const secondaryStart = "Share in the pool";
-
-  const secondaryEnd = (
-    <TextButton
-      label="Max. 10,000.00 BOLD"
-      onClick={() => setValue("10000")}
-    />
-  );
-
-  const value_ = (focused || !parsedValue) ? value : `${dn.format(parsedValue)} BOLD`;
-
-  return (
-    <div
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        justifyContent: "center",
-        width: "100%",
-        gap: 48,
-      }}
-    >
-      <div
-        className={css({
-          display: "flex",
-          flexDirection: "column",
-          gap: 16,
-        })}
-      >
-        <InputField
-          action={action}
-          label="You deposit"
-          onFocus={() => setFocused(true)}
-          onChange={setValue}
-          onBlur={() => setFocused(false)}
-          value={value_}
-          placeholder="0.00"
-          secondaryStart={secondaryStart}
-          secondaryEnd={secondaryEnd}
-        />
-        <div
-          className={css({
-            display: "flex",
-            justifyContent: "space-between",
-          })}
-        >
-          <label
-            className={css({
-              display: "flex",
-              alignItems: "center",
-              gap: 8,
-              cursor: "pointer",
-              userSelect: "none",
-            })}
-          >
-            <Checkbox
-              checked={claimRewards}
-              onChange={setClaimRewards}
-            />
-            {content.earnScreen.depositField.claimCheckbox}
-          </label>
-          {pool.rewards && (
-            <div
-              className={css({
-                display: "flex",
-                gap: 24,
-              })}
-            >
-              <div>{pool.rewards[0]}</div>
-              <div>{pool.rewards[1]}</div>
-            </div>
-          )}
-        </div>
-      </div>
-
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "center",
-          width: "100%",
-        }}
-      >
-        <Button
-          disabled={!parsedValue}
-          label="Add Deposit"
-          mode="primary"
-          size="large"
-          wide
-        />
-      </div>
-    </div>
-  );
-}
-
-function parseInputValue(value: string) {
-  value = value.trim();
-  if (!isInputValueFloat(value)) {
-    return null;
-  }
-  value = value
-    .replace(/\.$/, "")
-    .replace(/^\./, "0.");
-  return dn.from(value === "" ? 0 : value, 18);
-}
-
-function isInputValueFloat(value: string) {
-  value = value.trim();
-  return value && /^[0-9]*\.?[0-9]*?$/.test(value);
-}
-
-function Action({
-  label,
-  icon,
-}: {
-  label: ReactNode;
-  icon?: ReactNode;
-}) {
-  return (
-    <div
-      style={{
-        display: "flex",
-        alignItems: "center",
-        gap: 8,
-        height: 40,
-        padding: "0 16px",
-        paddingLeft: icon ? 8 : 16,
-        background: "#FFF",
-        borderRadius: 20,
-        userSelect: "none",
-      }}
-    >
-      {icon}
-      <div
-        style={{
-          fontSize: 24,
-          fontWeight: 500,
-        }}
-      >
-        {label}
       </div>
     </div>
   );

--- a/frontend/app/src/app/earn/[pool]/RewardsPanel.tsx
+++ b/frontend/app/src/app/earn/[pool]/RewardsPanel.tsx
@@ -1,0 +1,120 @@
+import type { Dnum } from "dnum";
+
+import content from "@/src/content";
+import { POOLS } from "@/src/demo-data";
+import { css } from "@/styled-system/css";
+import { Button } from "@liquity2/uikit";
+import * as dn from "dnum";
+
+export function RewardsPanel({ pool }: { pool: typeof POOLS[number] }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        width: "100%",
+        gap: 58,
+      }}
+    >
+      <div
+        className={css({
+          display: "flex",
+          flexDirection: "column",
+          gap: 12,
+          padding: "0 16px",
+          background: "background",
+          border: "1px solid token(colors.fieldBorder)",
+          borderRadius: 8,
+        })}
+      >
+        <div
+          className={css({
+            paddingTop: 8,
+            fontSize: 16,
+            fontWeight: 500,
+            color: "contentAlt",
+          })}
+        >
+          {content.earnScreen.rewardsPanel.label}
+        </div>
+
+        {pool.rewards
+          ? (
+            <div
+              className={css({
+                display: "flex",
+                gap: 32,
+              })}
+            >
+              <Amount value={dn.from(pool.rewards?.bold)} symbol="BOLD" />
+              <Amount value={dn.from(pool.rewards?.eth)} symbol="ETH" />
+            </div>
+          )
+          : <div>N/A</div>}
+
+        <div
+          className={css({
+            display: "flex",
+            gap: 16,
+            marginTop: -1,
+            padding: "20px 0",
+            color: "contentAlt",
+            borderTop: "1px solid token(colors.fieldBorder)",
+          })}
+        >
+          {content.earnScreen.rewardsPanel.details("254", "9.78")}
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "center",
+          width: "100%",
+        }}
+      >
+        <Button
+          label="Claim rewards"
+          mode="primary"
+          size="large"
+          wide
+        />
+      </div>
+    </div>
+  );
+}
+
+function Amount({
+  symbol,
+  value,
+}: {
+  symbol: string;
+  value: Dnum;
+}) {
+  return (
+    <div
+      className={css({
+        display: "flex",
+        gap: 16,
+        alignItems: "flex-end",
+      })}
+    >
+      <div
+        className={css({
+          fontSize: 24,
+        })}
+      >
+        {dn.format(value)}
+      </div>
+      <div
+        className={css({
+          paddingBottom: 3,
+          color: "contentAlt",
+        })}
+      >
+        {symbol}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/src/app/earn/[pool]/WithdrawPanel.tsx
+++ b/frontend/app/src/app/earn/[pool]/WithdrawPanel.tsx
@@ -1,0 +1,149 @@
+import content from "@/src/content";
+import { POOLS } from "@/src/demo-data";
+import { parseInputFloat } from "@/src/form-utils";
+import { css } from "@/styled-system/css";
+import { Button, Checkbox, InputField, TextButton, TokenIcon } from "@liquity2/uikit";
+import * as dn from "dnum";
+import { useState } from "react";
+
+export function WithdrawPanel({ pool }: { pool: typeof POOLS[number] }) {
+  const [value, setValue] = useState("");
+  const [focused, setFocused] = useState(false);
+  const [claimRewards, setClaimRewards] = useState(false);
+
+  const parsedValue = parseInputFloat(value);
+
+  const secondaryStart = "Share in the pool";
+
+  const secondaryEnd = (
+    <TextButton
+      label="Max. 28,000.00 BOLD"
+      onClick={() => setValue("10000")}
+    />
+  );
+
+  const value_ = (focused || !parsedValue) ? value : `${dn.format(parsedValue)} BOLD`;
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        width: "100%",
+        gap: 48,
+      }}
+    >
+      <div
+        className={css({
+          display: "flex",
+          flexDirection: "column",
+          gap: 16,
+        })}
+      >
+        <InputField
+          action={
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                height: 40,
+                padding: "0 16px",
+                paddingLeft: 8,
+                background: "#FFF",
+                borderRadius: 20,
+                userSelect: "none",
+              }}
+            >
+              <TokenIcon symbol="BOLD" />
+              <div
+                style={{
+                  fontSize: 24,
+                  fontWeight: 500,
+                }}
+              >
+                BOLD
+              </div>
+            </div>
+          }
+          label={content.earnScreen.withdrawPanel.label}
+          onFocus={() => setFocused(true)}
+          onChange={setValue}
+          onBlur={() => setFocused(false)}
+          value={value_}
+          placeholder="0.00"
+          secondaryStart={secondaryStart}
+          secondaryEnd={secondaryEnd}
+        />
+        <div
+          className={css({
+            display: "flex",
+            justifyContent: "space-between",
+          })}
+        >
+          <label
+            className={css({
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              cursor: "pointer",
+              userSelect: "none",
+            })}
+          >
+            <Checkbox
+              checked={claimRewards}
+              onChange={setClaimRewards}
+            />
+            {content.earnScreen.withdrawPanel.claimCheckbox}
+          </label>
+          {pool.rewards && (
+            <div
+              className={css({
+                display: "flex",
+                gap: 24,
+              })}
+            >
+              <div>
+                {pool.rewards.bold}{" "}
+                <span
+                  className={css({
+                    color: "contentAlt",
+                  })}
+                >
+                  BOLD
+                </span>
+              </div>
+              <div>
+                {pool.rewards.eth}{" "}
+                <span
+                  className={css({
+                    color: "contentAlt",
+                  })}
+                >
+                  BOLD
+                </span>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "center",
+          width: "100%",
+        }}
+      >
+        <Button
+          disabled={!parsedValue}
+          label="Withdraw"
+          mode="primary"
+          size="large"
+          wide
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/src/app/earn/page.tsx
+++ b/frontend/app/src/app/earn/page.tsx
@@ -191,7 +191,7 @@ export default function EarnHomePage() {
                             color: "positive",
                           })}
                         >
-                          {rewards[0]}
+                          {rewards.bold} BOLD
                           <div
                             className={css({
                               display: "flex",
@@ -201,7 +201,7 @@ export default function EarnHomePage() {
                               backgroundColor: "dimmed",
                             })}
                           />
-                          {rewards[1]}
+                          {rewards.eth} ETH
                         </div>
                       )}
                     </div>

--- a/frontend/app/src/content.tsx
+++ b/frontend/app/src/content.tsx
@@ -41,15 +41,35 @@ export default {
         Current <abbr title="Annual percentage yield">APY</abbr>
       </>
     ),
-    myDeposit: "My deposit",
-    unclaimedRewards: "Unclaimed rewards",
+    accountPosition: {
+      depositLabel: "My deposit",
+      rewardsLabel: "My rewards",
+    },
     tabs: {
       deposit: "Deposit",
       withdraw: "Withdraw",
       claim: "Claim rewards",
     },
-    depositField: {
+    depositPanel: {
+      label: "You deposit",
+      shareLabel: (share: N) => (
+        <>
+          Share in the pool {share}
+        </>
+      ),
       claimCheckbox: "Also claim rewards",
+    },
+    withdrawPanel: {
+      label: "You withdraw",
+      claimCheckbox: "Also claim rewards",
+    },
+    rewardsPanel: {
+      label: "You claim",
+      details: (usdAmount: N, fee: N) => (
+        <>
+          ~{usdAmount} USD • Expected gas fee ~{fee} USD
+        </>
+      ),
     },
   },
 };

--- a/frontend/app/src/demo-data.ts
+++ b/frontend/app/src/demo-data.ts
@@ -5,10 +5,10 @@ export const POOLS = [
     apy: "6.8%",
     boldQty: "65.7M BOLD",
     deposit: "21,453.00 BOLD",
-    rewards: [
-      "234.24 BOLD",
-      "0.0054 ETH",
-    ],
+    rewards: {
+      bold: "234.24",
+      eth: "0.0054",
+    },
   },
   {
     symbol: "WSTETH",

--- a/frontend/app/src/form-utils.ts
+++ b/frontend/app/src/form-utils.ts
@@ -3,7 +3,7 @@ import * as dn from "dnum";
 import { useState } from "react";
 
 const inputValueRegex = /^[0-9]*\.?[0-9]*?$/;
-export function isInputValueFloat(value: string) {
+export function isInputFloat(value: string) {
   value = value.trim();
   return inputValueRegex.test(value);
 }
@@ -14,10 +14,10 @@ export function isInputValueInt(value: string) {
   return inputIntRegex.test(value);
 }
 
-export function parseInputValue(value: string) {
+export function parseInputFloat(value: string) {
   value = value.trim();
 
-  if (!isInputValueFloat(value)) {
+  if (!isInputFloat(value)) {
     return null;
   }
 
@@ -29,7 +29,7 @@ export function parseInputValue(value: string) {
 }
 
 export function parseInputPercentage(value: string) {
-  const parsedValue = parseInputValue(value);
+  const parsedValue = parseInputFloat(value);
   if (parsedValue === null || dn.lt(parsedValue, 0) || dn.gt(parsedValue, 100)) {
     return null;
   }

--- a/frontend/uikit-gallery/src/InputField/shared.tsx
+++ b/frontend/uikit-gallery/src/InputField/shared.tsx
@@ -14,7 +14,7 @@ function isInputValueFloat(value: string) {
   value = value.trim();
   return value && /^[0-9]*\.?[0-9]*?$/.test(value);
 }
-function parseInputValue(value: string) {
+function parseInputFloat(value: string) {
   value = value.trim();
   if (!isInputValueFloat(value)) {
     return null;
@@ -43,7 +43,7 @@ export function InputFieldFixture({
   const [value, setValue] = useFixtureInput("value", "");
   const [focused, setFocused] = useState(false);
 
-  const parsedValue = parseInputValue(value);
+  const parsedValue = parseInputFloat(value);
 
   const action = match(fixture)
     .with("deposit", () => <Token name="ETH" />)

--- a/frontend/uikit/src/InputField/InputField.tsx
+++ b/frontend/uikit/src/InputField/InputField.tsx
@@ -67,7 +67,7 @@ export function InputField({
           "peer",
           css({
             display: "block",
-            height: 120,
+            height: 120 - 2, // account for the 1px border
             padding: "0 16px",
             fontSize: 28,
             fontWeight: 500,


### PR DESCRIPTION
This PR also splits the Earn panels into separate components.

Other changes:

- parseInputValue() becomes parseInputFloat().
- use parseInputFloat() from form-utils in the Earn screens.
- Make InputField’s height a multiple of 8.
- Do not scroll when the tab selection changes.
- Move more things to content.tsx.

## Preview

![image](https://github.com/liquity/bold/assets/36158/2a29eea7-efc2-4d2b-982f-4aa658ddae3c)
![image](https://github.com/liquity/bold/assets/36158/b186fc17-350f-43f8-beff-dd924fb47bc0)
![image](https://github.com/liquity/bold/assets/36158/a45d5d01-60eb-447a-8934-aefee119039a)
