### PR TITLE
fix: Don't Panic™ when attempting to withdraw/repay too much

### DIFF
--- a/contracts/src/test/borrowerOperations.t.sol
+++ b/contracts/src/test/borrowerOperations.t.sol
@@ -25,4 +25,19 @@ contract BorrowerOperationsTest is DevTestSetup {
         borrowerOperations.closeTrove(ATroveId);
         vm.stopPrank();
     }
+
+    function testRepayingTooMuchDebtReverts() public {
+        uint256 troveId = openTroveNoHints100pctMaxFee(A, 100 ether, 2_000 ether, 0.01 ether);
+        deal(address(boldToken), A, 1_000 ether);
+        vm.prank(A);
+        vm.expectRevert("BorrowerOps: Amount repaid must not be larger than the Trove's debt");
+        borrowerOperations.repayBold(troveId, 3_000 ether);
+    }
+
+    function testWithdrawingTooMuchCollateralReverts() public {
+        uint256 troveId = openTroveNoHints100pctMaxFee(A, 100 ether, 2_000 ether, 0.01 ether);
+        vm.prank(A);
+        vm.expectRevert("BorrowerOps: Can't withdraw more than the Trove's entire collateral");
+        borrowerOperations.withdrawColl(troveId, 200 ether);
+    }
 }


### PR DESCRIPTION
There was a `require()` that was intended to check for too much repayment, but it was never being hit, as we were already panicking from arithmetic overflow inside `_getNewICRFromTroveChange()`.

There was a late assertion to make sure we were never withdrawing more than the Trove's entire collateral. Instead, we can do the check earlier and make it a `require()` for a more helpful error message.