### PR TITLE
Eliminate magic number "90 days" from `applyTroveInterestPermissionless()` tests

### DIFF
--- a/contracts/src/Interfaces/ILiquityBase.sol
+++ b/contracts/src/Interfaces/ILiquityBase.sol
@@ -15,5 +15,6 @@ interface ILiquityBase {
     function MIN_DEBT() external view returns (uint256);
     function UPFRONT_INTEREST_PERIOD() external view returns (uint256);
     function INTEREST_RATE_ADJ_COOLDOWN() external view returns (uint256);
+    function STALE_TROVE_DURATION() external view returns (uint256);
     function getEntireSystemDebt() external view returns (uint256);
 }

--- a/contracts/src/test/TestContracts/BaseTest.sol
+++ b/contracts/src/test/TestContracts/BaseTest.sol
@@ -45,6 +45,7 @@ contract BaseTest is Test {
     uint256 SP_YIELD_SPLIT;
     uint256 UPFRONT_INTEREST_PERIOD;
     uint256 INTEREST_RATE_ADJ_COOLDOWN;
+    uint256 STALE_TROVE_DURATION;
 
     // Core contracts
     IActivePool activePool;

--- a/contracts/src/test/TestContracts/DevTestSetup.sol
+++ b/contracts/src/test/TestContracts/DevTestSetup.sol
@@ -77,6 +77,7 @@ contract DevTestSetup is BaseTest {
         UPFRONT_INTEREST_PERIOD = troveManager.UPFRONT_INTEREST_PERIOD();
         INTEREST_RATE_ADJ_COOLDOWN = troveManager.INTEREST_RATE_ADJ_COOLDOWN();
         MCR = troveManager.MCR();
+        STALE_TROVE_DURATION = troveManager.STALE_TROVE_DURATION();
     }
 
     function _setupForWithdrawETHGainToTrove() internal returns (uint256, uint256, uint256) {

--- a/contracts/src/test/interestRateAggregate.t.sol
+++ b/contracts/src/test/interestRateAggregate.t.sol
@@ -1322,7 +1322,7 @@ contract InterestRateAggregate is DevTestSetup {
         uint256 ATroveId = openTroveNoHints100pct(A, 3 ether, troveDebtRequest, 25e16);
 
         // fast-forward past such that trove is Stale
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
         // Confirm Trove is stale
         assertTrue(troveManager.troveIsStale(ATroveId));
 
@@ -1345,7 +1345,7 @@ contract InterestRateAggregate is DevTestSetup {
         uint256 ATroveId = openTroveNoHints100pct(A, 3 ether, troveDebtRequest, 25e16);
 
         // fast-forward time such that trove is Stale
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
         // Confirm Trove is stale
         assertTrue(troveManager.troveIsStale(ATroveId));
 
@@ -1365,7 +1365,7 @@ contract InterestRateAggregate is DevTestSetup {
         uint256 ATroveId = openTroveNoHints100pct(A, 3 ether, troveDebtRequest, 25e16);
 
         // fast-forward time such that trove is Stale
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
         // Confirm Trove is stale
         assertTrue(troveManager.troveIsStale(ATroveId));
 
@@ -1391,7 +1391,7 @@ contract InterestRateAggregate is DevTestSetup {
         uint256 ATroveId = openTroveNoHints100pct(A, 3 ether, troveDebtRequest, 25e16);
 
         // fast-forward time such that trove is Stale
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
         // Confirm Trove is stale
         assertTrue(troveManager.troveIsStale(ATroveId));
 
@@ -1416,7 +1416,7 @@ contract InterestRateAggregate is DevTestSetup {
         uint256 oldRecordedWeightedDebt = troveManager.getTroveWeightedRecordedDebt(ATroveId);
 
         // fast-forward time such that trove is Stale
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
         // Confirm Trove is stale
         assertTrue(troveManager.troveIsStale(ATroveId));
 

--- a/contracts/src/test/interestRateBasic.t.sol
+++ b/contracts/src/test/interestRateBasic.t.sol
@@ -626,7 +626,7 @@ contract InterestRateBasic is DevTestSetup {
         uint256 ATroveId = openTroveNoHints100pct(A, 3 ether, troveDebtRequest, interestRate);
 
         // Fast-forward time such that trove is Stale
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
         // Confirm Trove is stale
         assertTrue(troveManager.troveIsStale(ATroveId));
 
@@ -646,7 +646,7 @@ contract InterestRateBasic is DevTestSetup {
         uint256 ATroveId = openTroveNoHints100pct(A, 3 ether, troveDebtRequest, interestRate);
 
         // Fast-forward time such that trove is Stale
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
         // Confirm Trove is stale
         assertTrue(troveManager.troveIsStale(ATroveId));
 
@@ -666,7 +666,7 @@ contract InterestRateBasic is DevTestSetup {
         uint256 ATroveId = openTroveNoHints100pct(A, 3 ether, troveDebtRequest, interestRate);
 
         // Fast-forward time such that trove is Stale
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
         // Confirm Trove is stale
         assertTrue(troveManager.troveIsStale(ATroveId));
 
@@ -688,7 +688,7 @@ contract InterestRateBasic is DevTestSetup {
         uint256 ATroveId = openTroveNoHints100pct(A, 3 ether, troveDebtRequest, interestRate);
 
         // Fast-forward time such that trove is Stale
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
         // Confirm Trove is stale
         assertTrue(troveManager.troveIsStale(ATroveId));
 
@@ -717,8 +717,7 @@ contract InterestRateBasic is DevTestSetup {
         vm.stopPrank();
 
         // Fast-forward time, but less than the staleness threshold
-        // TODO: replace "90 days" with troveManager.STALE_TROVE_DURATION() after conflicts are resolved
-        vm.warp(block.timestamp + 90 days - 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION - 1);
 
         // B tries to apply A's interest. Expect revert
         vm.startPrank(B);

--- a/contracts/src/test/redemptions.t.sol
+++ b/contracts/src/test/redemptions.t.sol
@@ -707,7 +707,7 @@ contract Redemptions is DevTestSetup {
         _redeemAndCreateZombieTrovesAAndB(troveIDs);
 
         // fast-forward time such that trove is Stale
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
         // Confirm Trove is stale
         assertTrue(troveManager.troveIsStale(troveIDs.A));
 

--- a/contracts/src/test/stabilityPool.t.sol
+++ b/contracts/src/test/stabilityPool.t.sol
@@ -134,7 +134,7 @@ contract SPTest is DevTestSetup {
     function testProvideToSPWithClaim_WithOnlyCurrentBOLDGainsSendsTotalBOLDGainToDepositor() public {
         ABCDEF memory troveIDs = _setupForSPDepositAdjustments();
 
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
 
         // A trove gets poked, interst minted and yield paid to SP
         applyTroveInterestPermissionless(B, troveIDs.A);
@@ -153,7 +153,7 @@ contract SPTest is DevTestSetup {
     function testProvideToSPWithClaim_WithCurrentBOLDGainsZerosCurrentBOLDGains() public {
         ABCDEF memory troveIDs = _setupForSPDepositAdjustments();
 
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
 
         // A trove gets poked, interst minted and yield paid to SP
         applyTroveInterestPermissionless(B, troveIDs.A);
@@ -268,7 +268,7 @@ contract SPTest is DevTestSetup {
     function testProvideToSPNoClaimAddsBOLDGainsToDeposit() public {
         ABCDEF memory troveIDs = _setupForSPDepositAdjustments();
 
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
 
         // A trove gets poked, interst minted and yield paid to SP
         applyTroveInterestPermissionless(B, troveIDs.A);
@@ -287,7 +287,7 @@ contract SPTest is DevTestSetup {
     function testProvideToSPNoClaimZerosCurrentBoldGains() public {
         ABCDEF memory troveIDs = _setupForSPDepositAdjustments();
 
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
 
         // A trove gets poked, interst minted and yield paid to SP
         applyTroveInterestPermissionless(B, troveIDs.A);
@@ -304,7 +304,7 @@ contract SPTest is DevTestSetup {
     function testProvideToSPNoClaimReducesDepositorBoldBalanceByOnlyTheTopUp() public {
         ABCDEF memory troveIDs = _setupForSPDepositAdjustments();
 
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
 
         // A trove gets poked, interst minted and yield paid to SP
         applyTroveInterestPermissionless(B, troveIDs.A);
@@ -424,7 +424,7 @@ contract SPTest is DevTestSetup {
     function testWithdrawFromSPWithClaim_WithCurrentBOLDGainsSendsBOLDGainToDepositor() public {
         ABCDEF memory troveIDs = _setupForSPDepositAdjustments();
 
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
 
         // A trove gets poked, interst minted and yield paid to SP
         applyTroveInterestPermissionless(B, troveIDs.A);
@@ -444,7 +444,7 @@ contract SPTest is DevTestSetup {
     function testWithdrawFromSPWithClaim_WithCurrentBOLDGainsZerosCurrentBoldGains() public {
         ABCDEF memory troveIDs = _setupForSPDepositAdjustments();
 
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
 
         // A trove gets poked, interst minted and yield paid to SP
         applyTroveInterestPermissionless(B, troveIDs.A);
@@ -561,7 +561,7 @@ contract SPTest is DevTestSetup {
     function testWithdrawFromSPNoClaimAddsBOLDGainsToDeposit() public {
         ABCDEF memory troveIDs = _setupForSPDepositAdjustments();
 
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
 
         // A trove gets poked, interst minted and yield paid to SP
         applyTroveInterestPermissionless(B, troveIDs.A);
@@ -580,7 +580,7 @@ contract SPTest is DevTestSetup {
     function testWithdrawFromSPNoClaimZerosCurrentBoldGains() public {
         ABCDEF memory troveIDs = _setupForSPDepositAdjustments();
 
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
 
         // A trove gets poked, interst minted and yield paid to SP
         applyTroveInterestPermissionless(B, troveIDs.A);
@@ -597,7 +597,7 @@ contract SPTest is DevTestSetup {
     function testWithdrawFromSPNoClaimReducesDepositorBoldBalanceByOnlyTheTopUp() public {
         ABCDEF memory troveIDs = _setupForSPDepositAdjustments();
 
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
 
         // A trove gets poked, interst minted and yield paid to SP
         applyTroveInterestPermissionless(B, troveIDs.A);
@@ -818,7 +818,7 @@ contract SPTest is DevTestSetup {
     function testBoldRewardSumIncreasesWhenInterestAppliedPermissionlessly() public {
         ABCDEF memory troveIDs = _setupForSPDepositAdjustments();
 
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
 
         uint256 pendingAggInterest = activePool.calcPendingAggInterest();
         assertGt(pendingAggInterest, 0);
@@ -1044,7 +1044,7 @@ contract SPTest is DevTestSetup {
     function testBoldRewardsOwedIncreasesWhenInterestAppliedPermissionlessly() public {
         ABCDEF memory troveIDs = _setupForSPDepositAdjustments();
 
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
 
         uint256 pendingAggInterest = activePool.calcPendingAggInterest();
         assertGt(pendingAggInterest, 0);
@@ -1166,7 +1166,7 @@ contract SPTest is DevTestSetup {
         assertApproximatelyEqual(stabilityPool.getCompoundedBoldDeposit(A), stabilityPool.getTotalBoldDeposits(), 1e4);
         assertGt(stabilityPool.getTotalBoldDeposits(), 0);
 
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
 
         uint256 pendingAggInterest = activePool.calcPendingAggInterest();
         assertGt(pendingAggInterest, 0);
@@ -1181,7 +1181,7 @@ contract SPTest is DevTestSetup {
     function testGetDepositorBoldGain_2SPDepositor1RewardEvent_EarnFairShareOfSPYield() public {
         ABCDEF memory troveIDs = _setupForSPDepositAdjustments();
 
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
 
         uint256 pendingAggInterest = activePool.calcPendingAggInterest();
         assertGt(pendingAggInterest, 0);
@@ -1211,7 +1211,7 @@ contract SPTest is DevTestSetup {
         assertApproximatelyEqual(stabilityPool.getCompoundedBoldDeposit(A), stabilityPool.getTotalBoldDeposits(), 1e4);
         assertGt(stabilityPool.getTotalBoldDeposits(), 0);
 
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
 
         uint256 pendingAggInterest_1 = activePool.calcPendingAggInterest();
         assertGt(pendingAggInterest_1, 0);
@@ -1222,7 +1222,7 @@ contract SPTest is DevTestSetup {
         uint256 yieldGainsOwed_1 = stabilityPool.getYieldGainsOwed();
         assertGt(yieldGainsOwed_1, 0);
 
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
 
         uint256 pendingAggInterest_2 = activePool.calcPendingAggInterest();
         assertGt(pendingAggInterest_2, 0);
@@ -1239,7 +1239,7 @@ contract SPTest is DevTestSetup {
     function testGetDepositorBoldGain_2SPDepositor2RewardEvent_EarnFairShareOfSPYield() public {
         ABCDEF memory troveIDs = _setupForSPDepositAdjustments();
 
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
 
         uint256 pendingAggInterest_1 = activePool.calcPendingAggInterest();
         assertGt(pendingAggInterest_1, 0);
@@ -1257,7 +1257,7 @@ contract SPTest is DevTestSetup {
         applyTroveInterestPermissionless(B, troveIDs.A);
 
         // fast-forward time again and accrue interest
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
 
         uint256 pendingAggInterest_2 = activePool.calcPendingAggInterest();
         assertGt(pendingAggInterest_2, 0);
@@ -1286,7 +1286,7 @@ contract SPTest is DevTestSetup {
     function testGetDepositorBoldGain_2SPDepositor1Liq1FreshDeposit_EarnFairShareOfSPYield() public {
         ABCDEF memory troveIDs = _setupForSPDepositAdjustments();
 
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
 
         uint256 pendingAggInterest_1 = activePool.calcPendingAggInterest();
         assertGt(pendingAggInterest_1, 0);
@@ -1318,7 +1318,7 @@ contract SPTest is DevTestSetup {
         assertLt(totalSPDeposits_2, totalSPDeposits_1);
 
         // fast-forward time again and accrue interest
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
 
         uint256 pendingAggInterest_2 = activePool.calcPendingAggInterest();
         assertGt(pendingAggInterest_2, 0);
@@ -1391,7 +1391,7 @@ contract SPTest is DevTestSetup {
         assertLt(totalSPDeposits_1, totalSPDeposits_0);
 
         // fast-forward time again and accrue interest
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
 
         uint256 pendingAggInterest_1 = activePool.calcPendingAggInterest();
         assertGt(pendingAggInterest_1, 0);
@@ -1471,7 +1471,7 @@ contract SPTest is DevTestSetup {
         makeSPDepositAndClaim(D, deposit_D);
 
         // fast-forward time again and accrue interest
-        vm.warp(block.timestamp + 90 days + 1);
+        vm.warp(block.timestamp + STALE_TROVE_DURATION + 1);
 
         uint256 pendingAggInterest_1 = activePool.calcPendingAggInterest();
         assertGt(pendingAggInterest_1, 0);
@@ -1596,7 +1596,7 @@ contract SPTest is DevTestSetup {
         makeSPDepositAndClaim(D, deposit_D);
 
         // fast-forward time again and accrue interest
-        vm.warp(block.timestamp + 180 days);
+        vm.warp(block.timestamp + 2 * STALE_TROVE_DURATION);
 
         pendingAggInterest[2] = activePool.calcPendingAggInterest();
         assertGt(pendingAggInterest[2], 0);


### PR DESCRIPTION
**TODO:**
- [x] change PR base to main after #187 is merged