### PR TITLE
App: more demo data on Leverage + Borrow screens

### DIFF
--- a/frontend/app/src/app/layout.tsx
+++ b/frontend/app/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { AppLayout } from "@/src/comps/AppLayout/AppLayout";
 import { Config } from "@/src/comps/Config/Config";
 import { ConfigModal } from "@/src/comps/ConfigModal/ConfigModal";
 import { Ethereum } from "@/src/comps/Ethereum/Ethereum";
+import { Prices } from "@/src/prices";
 import { UiKit } from "@liquity2/uikit";
 import { GeistSans } from "geist/font/sans";
 
@@ -28,13 +29,15 @@ export default function Layout({
         <UiKit>
           <Config>
             <Ethereum>
-              <ConfigModal>
-                <AboutModal>
-                  <AppLayout>
-                    {children}
-                  </AppLayout>
-                </AboutModal>
-              </ConfigModal>
+              <Prices>
+                <ConfigModal>
+                  <AboutModal>
+                    <AppLayout>
+                      {children}
+                    </AppLayout>
+                  </AboutModal>
+                </ConfigModal>
+              </Prices>
             </Ethereum>
           </Config>
         </UiKit>

--- a/frontend/app/src/constants.ts
+++ b/frontend/app/src/constants.ts
@@ -1,0 +1,5 @@
+export const COLLATERAL_RATIO = 1.1;
+
+export const LEVERAGE_FACTOR_MIN = 1.1;
+export const LEVERAGE_FACTOR_MAX = 6;
+export const LEVERAGE_FACTOR_DEFAULT = 1.5;

--- a/frontend/app/src/demo-data.ts
+++ b/frontend/app/src/demo-data.ts
@@ -1,4 +1,4 @@
-import type { Position, PositionLoan } from "@/src/types";
+import type { Position, PositionLoan, RiskLevel } from "@/src/types";
 
 import * as dn from "dnum";
 
@@ -7,6 +7,20 @@ export const ETH_PRICE = dn.from(3_839.293872, 18);
 export const BOLD_PRICE = dn.from(1.0031, 18);
 
 export const STAKED_LQTY_TOTAL = [43_920_716_739_092_664_364_409_174n, 18] as const;
+
+// ltv risk levels
+export const LTV_RISK: Record<RiskLevel, number> = {
+  low: 0,
+  medium: 0.5,
+  high: 0.7,
+};
+
+// redemption risk levels
+export const REDEMPTION_RISK: Record<RiskLevel, number> = {
+  high: 0,
+  medium: 3.5,
+  low: 5.0,
+};
 
 export const ACCOUNT_STAKED_LQTY = {
   deposit: [100n * 10n ** 18n, 18] as const,

--- a/frontend/app/src/form-utils.ts
+++ b/frontend/app/src/form-utils.ts
@@ -2,7 +2,7 @@ import type { Dnum } from "dnum";
 
 import { ADDRESS_ZERO, isAddress } from "@/src/eth-utils";
 import * as dn from "dnum";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 const inputValueRegex = /^[0-9]*\.?[0-9]*?$/;
 export function isInputFloat(value: string) {
@@ -112,15 +112,65 @@ export function useForm<Form extends Record<string, FormValue<unknown>>>(
   } as const;
 }
 
-export function useInputFieldValue(format: (value: Dnum) => string) {
-  const [value, setValue] = useState("");
-  const [focused, setFocused] = useState(false);
-  const parsed = parseInputFloat(value);
+export function useInputFieldValue(
+  format: (value: Dnum) => string,
+  {
+    defaultValue = "",
+    onChange,
+    onFocusChange,
+  }: {
+    defaultValue?: string;
+    onChange?: ({
+      parsed,
+      value,
+    }: {
+      parsed: Dnum | null;
+      value: string;
+    }) => void;
+    onFocusChange?: (data: {
+      focus: boolean;
+      parsed: Dnum | null;
+      value: string;
+    }) => void;
+  } = {},
+) {
+  const [{ value, focused, parsed }, set] = useState<{
+    value: string;
+    focused: boolean;
+    parsed: Dnum | null;
+  }>({
+    value: defaultValue,
+    focused: false,
+    parsed: parseInputFloat(defaultValue),
+  });
+
+  const ref = useRef<HTMLInputElement>(null);
+
+  const setValue = (value: string) => {
+    const parsed = parseInputFloat(value);
+    set((s) => ({ ...s, parsed, value }));
+    onChange?.({ parsed, value });
+  };
+
+  const setFocused = (focused: boolean) => {
+    set((s) => ({ ...s, focused }));
+  };
+
   return {
+    focus: () => {
+      ref.current?.focus();
+    },
     inputFieldProps: {
-      onBlur: () => setFocused(false),
-      onChange: (value: string) => setValue(value),
-      onFocus: () => setFocused(true),
+      ref,
+      onBlur: () => {
+        setFocused(false);
+        onFocusChange?.({ focus: false, parsed, value });
+      },
+      onFocus: () => {
+        setFocused(true);
+        onFocusChange?.({ focus: true, parsed, value });
+      },
+      onChange: setValue,
       value: focused || !parsed || !value.trim() ? value : format(parsed),
     },
     parsed,

--- a/frontend/app/src/math-utils.ts
+++ b/frontend/app/src/math-utils.ts
@@ -1,0 +1,11 @@
+export function lerp(value1: number, value2: number, amt: number) {
+  return ((value2 - value1) * amt) + value1;
+}
+
+export function map(value: number, istart: number, istop: number, ostart: number, ostop: number) {
+  return ostart + (ostop - ostart) * ((value - istart) / (istop - istart));
+}
+
+export function norm(aNumber: number, low: number, high: number) {
+  return (aNumber - low) / (high - low);
+}

--- a/frontend/app/src/prices.tsx
+++ b/frontend/app/src/prices.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import type { Dnum } from "dnum";
+import type { ReactNode } from "react";
+
+import { BOLD_PRICE, ETH_PRICE, LQTY_PRICE } from "@/src/demo-data";
+import * as dn from "dnum";
+import { createContext, useContext, useEffect, useState } from "react";
+
+type PriceToken = "ETH" | "LQTY" | "BOLD";
+
+const PriceContext = createContext<Record<PriceToken, Dnum>>({
+  ETH: ETH_PRICE,
+  LQTY: LQTY_PRICE,
+  BOLD: BOLD_PRICE,
+});
+
+export function Prices({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [prices, setPrices] = useState({
+    ETH: ETH_PRICE,
+    LQTY: LQTY_PRICE,
+    BOLD: BOLD_PRICE,
+  });
+
+  // simulate a 0.5% deviation from the demo prices every 10 seconds
+  useEffect(() => {
+    const timer = setInterval(() => {
+      const variation = dn.from((Math.random() - 0.5) * 0.005, 18);
+      setPrices({
+        ETH: dn.add(ETH_PRICE, dn.mul(ETH_PRICE, variation)),
+        LQTY: dn.add(LQTY_PRICE, dn.mul(LQTY_PRICE, variation)),
+        BOLD: dn.add(BOLD_PRICE, dn.mul(BOLD_PRICE, variation)),
+      });
+    }, 10_000);
+
+    return () => clearInterval(timer);
+  }, []);
+
+  return (
+    <PriceContext.Provider value={prices}>
+      {children}
+    </PriceContext.Provider>
+  );
+}
+
+export function usePrice(token: PriceToken) {
+  return useContext(PriceContext)[token];
+}

--- a/frontend/app/src/screens/LeverageScreen/LeverageScreen.tsx
+++ b/frontend/app/src/screens/LeverageScreen/LeverageScreen.tsx
@@ -1,12 +1,17 @@
 "use client";
 
+import type { RiskLevel } from "@/src/types";
 import type { Dnum } from "dnum";
 import type { ReactNode } from "react";
 
 import { Field } from "@/src/comps/Field/Field";
 import { Screen } from "@/src/comps/Screen/Screen";
+import { COLLATERAL_RATIO, LEVERAGE_FACTOR_DEFAULT, LEVERAGE_FACTOR_MAX, LEVERAGE_FACTOR_MIN } from "@/src/constants";
 import content from "@/src/content";
+import { ACCOUNT_BALANCES, LTV_RISK, REDEMPTION_RISK } from "@/src/demo-data";
 import { useInputFieldValue } from "@/src/form-utils";
+import { lerp, norm } from "@/src/math-utils";
+import { usePrice } from "@/src/prices";
 import { css } from "@/styled-system/css";
 import {
   Button,
@@ -22,8 +27,9 @@ import {
 } from "@liquity2/uikit";
 import * as dn from "dnum";
 import { useParams, useRouter } from "next/navigation";
-import { useState } from "react";
-import { match } from "ts-pattern";
+import { useEffect, useState } from "react";
+import { match, P } from "ts-pattern";
+import { useAccount } from "wagmi";
 
 const collateralSymbols = COLLATERALS.map(({ symbol }) => symbol);
 
@@ -33,43 +39,87 @@ function isCollateralSymbol(symbol: string): symbol is typeof collateralSymbols[
 }
 
 export function LeverageScreen() {
+  const account = useAccount();
   const router = useRouter();
+  const ethPrice = usePrice("ETH");
 
   // useParams() can return an array, but not with the current
   // routing setup so we can safely assume it’s a string
   const collateral = String(useParams().collateral ?? "eth").toUpperCase();
-  const collateralIndex = isCollateralSymbol(collateral) ? collateralSymbols.indexOf(collateral) : 0;
+  if (!isCollateralSymbol(collateral)) {
+    throw new Error(`Invalid collateral symbol: ${collateral}`);
+  }
+  const collateralIndex = collateralSymbols.indexOf(collateral);
 
   const deposit = useInputFieldValue((value) => `${dn.format(value)} ${collateral}`);
   const interestRate = useInputFieldValue((value) => `${dn.format(value)}%`);
-  const ethLiqPrice = useInputFieldValue((value) => `$ ${dn.format(value)}`);
 
-  const [leverage, setLeverage] = useState(0);
-  const maxLeverage = 5; // 6.0x
+  const [liqPriceFocused, setLiqPriceFocused] = useState(false);
 
-  const liquidationRisk: null | {
-    ethPrice: Dnum;
-    level: "low" | "medium" | "high";
-    ltv: string;
-  } = deposit.parsed && dn.gt(deposit.parsed, 0)
-    ? {
-      ethPrice: dn.from(1200),
-      level: match(leverage)
-        .when((l) => l <= 1, () => "low" as const)
-        .when((l) => l <= 3, () => "medium" as const)
-        .otherwise(() => "high" as const),
-      ltv: "33.00%",
+  const ethLiqPrice = useInputFieldValue((value) => `$ ${dn.format(value)}`, {
+    defaultValue: dn.toString(leveragedLiquidationPrice(ethPrice, LEVERAGE_FACTOR_DEFAULT), 2),
+    onChange: ({ parsed: price }) => {
+      if (price) {
+        updateLeverageFactorFromLiquidationPrice(price);
+      }
+    },
+    onFocusChange: ({ focus }) => {
+      setLiqPriceFocused(focus);
+
+      // recalculate exact liquidation price based on the selected leverage factor
+      if (!focus) {
+        ethLiqPrice.setValue(dn.toString(leveragedLiquidationPrice(ethPrice, leverageFactor), 2));
+      }
+    },
+  });
+
+  const [leverageFactor, setLeverageFactor] = useState(LEVERAGE_FACTOR_DEFAULT);
+
+  const depositUsd = deposit.parsed && dn.mul(deposit.parsed, ethPrice);
+  const leveragedDeposit = deposit.parsed ? dn.mul(deposit.parsed, leverageFactor) : null;
+  const totalDebtUsd = depositUsd && dn.mul(dn.sub(leverageFactor, dn.from(1, 18)), depositUsd);
+
+  const ltv = ltvFromLeverageFactor(leverageFactor);
+
+  // update liquidation price when ETH price changes
+  useEffect(() => {
+    if (!liqPriceFocused) {
+      ethLiqPrice.setValue(
+        dn.toString(leveragedLiquidationPrice(ethPrice, leverageFactor), 2),
+      );
     }
-    : null;
+  }, [ethPrice, leverageFactor, liqPriceFocused]);
 
-  const redemptionRiskLevel = interestRate.parsed
-    && dn.gt(interestRate.parsed, 0)
-    && (
-      match(interestRate.parsed)
-        .when((r) => dn.lt(r, 3.6), () => "high" as const)
-        .when((r) => dn.lt(r, 5.1), () => "medium" as const)
-        .otherwise(() => "low" as const)
+  const liquidationRisk: null | RiskLevel = match(ltv)
+    .with(P.nullish, () => null)
+    .when((ltv) => dn.gt(ltv, LTV_RISK.high), () => "high" as const)
+    .when((ltv) => dn.gt(ltv, LTV_RISK.medium), () => "medium" as const)
+    .otherwise(() => "low" as const);
+
+  const redemptionRisk: null | RiskLevel = match(interestRate.parsed)
+    .with(P.nullish, () => null)
+    .when((r) => dn.gt(r, REDEMPTION_RISK.low), () => "low" as const)
+    .when((r) => dn.gt(r, REDEMPTION_RISK.medium), () => "medium" as const)
+    .otherwise(() => "high" as const);
+
+  const updateLeverageFactor = (factor: number) => {
+    setLeverageFactor(factor);
+    ethLiqPrice.setValue(
+      dn.toString(leveragedLiquidationPrice(ethPrice, factor), 2),
     );
+  };
+
+  const updateLeverageFactorFromLiquidationPrice = (liquidationPrice: Dnum) => {
+    const liquidationPriceMin = leveragedLiquidationPrice(ethPrice, LEVERAGE_FACTOR_MIN);
+    const liquidationPriceMax = leveragedLiquidationPrice(ethPrice, LEVERAGE_FACTOR_MAX);
+    const leverageFactor = leverageFactorFromLiquidationPrice(ethPrice, liquidationPrice);
+    setLeverageFactor(
+      match(liquidationPrice)
+        .when((l) => dn.lt(l, liquidationPriceMin), () => LEVERAGE_FACTOR_MIN)
+        .when((l) => dn.gt(l, liquidationPriceMax), () => LEVERAGE_FACTOR_MAX)
+        .otherwise(() => leverageFactor),
+    );
+  };
 
   return (
     <Screen
@@ -105,11 +155,15 @@ export function LeverageScreen() {
                   items={COLLATERALS.map(({ symbol, name }) => ({
                     icon: <TokenIcon symbol={symbol} />,
                     label: name,
-                    value: "0.00",
+                    value: account.isConnected ? dn.format(ACCOUNT_BALANCES[symbol]) : "−",
                   }))}
                   menuPlacement="end"
                   menuWidth={300}
                   onSelect={(index) => {
+                    setTimeout(() => {
+                      deposit.setValue("");
+                      deposit.focus();
+                    }, 0);
                     router.push(
                       `/leverage/${COLLATERALS[index].symbol.toLowerCase()}`,
                       { scroll: false },
@@ -120,13 +174,15 @@ export function LeverageScreen() {
               }
               label={content.leverageScreen.depositField.label}
               placeholder="0.00"
-              secondaryStart="$0.00"
-              secondaryEnd={
+              secondaryStart={depositUsd && `$${dn.format(depositUsd, 2)}`}
+              secondaryEnd={account.isConnected && (
                 <TextButton
-                  label={`Max. 10.00 ${collateral}`}
-                  onClick={() => deposit.setValue("10.00")}
+                  label={`Max. ${dn.format(ACCOUNT_BALANCES[collateral])} ${collateral}`}
+                  onClick={() => {
+                    deposit.setValue(dn.toString(ACCOUNT_BALANCES[collateral]));
+                  }}
                 />
-              }
+              )}
               {...deposit.inputFieldProps}
             />
           }
@@ -137,9 +193,26 @@ export function LeverageScreen() {
                   color: "contentAlt",
                 })}
               >
-                ETH stats
+                Leveraged
               </span>
-              <span>{0}</span>
+              <span
+                className={css({
+                  fontVariantNumeric: "tabular-nums",
+                })}
+              >
+                {leveragedDeposit && dn.gt(leveragedDeposit, 0)
+                  ? `${
+                    dn.format(leveragedDeposit, {
+                      digits: 2,
+                      trailingZeros: true,
+                    })
+                  } ETH`
+                  : "−"}
+              </span>
+              <InfoTooltip heading="Leveraged deposit">
+                A redemption is an event where the borrower’s collateral is exchanged for a corresponding amount of Bold
+                stablecoins. At the time of the exchange a borrower does not lose any money.
+              </InfoTooltip>
             </HFlex>
           }
           footerEnd={
@@ -159,7 +232,7 @@ export function LeverageScreen() {
         />
 
         <Field
-          // “ETH Liquidation price”
+          // ETH Liquidation price
           field={
             <InputField
               action={
@@ -174,9 +247,13 @@ export function LeverageScreen() {
                   <Slider
                     gradientMode={true}
                     onChange={(value) => {
-                      setLeverage(Math.round(value * maxLeverage * 10) / 10);
+                      updateLeverageFactor(
+                        Math.round(
+                          lerp(LEVERAGE_FACTOR_MIN, LEVERAGE_FACTOR_MAX, value) * 10,
+                        ) / 10,
+                      );
                     }}
-                    value={leverage / maxLeverage}
+                    value={norm(leverageFactor, LEVERAGE_FACTOR_MIN, LEVERAGE_FACTOR_MAX)}
                   />
                 </div>
               }
@@ -186,11 +263,15 @@ export function LeverageScreen() {
                   Leverage{" "}
                   <span
                     style={{
-                      color: leverage > 3 ? "#F36740" : "#2F3037",
+                      color: (
+                          liquidationRisk === "high"
+                        )
+                        ? "#F36740"
+                        : "#2F3037",
                       fontVariantNumeric: "tabular-nums",
                     }}
                   >
-                    {dn.format([BigInt(Math.round((leverage + 1) * 10)), 1], {
+                    {dn.format([BigInt(Math.round(leverageFactor * 10)), 1], {
                       digits: 1,
                       trailingZeros: true,
                     })}x
@@ -198,22 +279,39 @@ export function LeverageScreen() {
                 </span>
               }
               placeholder="0.00"
-              secondaryStart="Total debt 0 BOLD"
+              secondaryStart={
+                <>
+                  Total debt {totalDebtUsd && dn.gt(totalDebtUsd, 0)
+                    ? (
+                      <span
+                        className={css({
+                          fontVariantNumeric: "tabular-nums",
+                        })}
+                      >
+                        ${dn.format(totalDebtUsd, {
+                          digits: 2,
+                          trailingZeros: true,
+                        })}
+                      </span>
+                    )
+                    : "−"}
+                </>
+              }
               secondaryEnd={
                 <HFlex gap={6}>
                   <PillButton
                     label="1.5x"
-                    onClick={() => setLeverage(0.5)}
+                    onClick={() => updateLeverageFactor(1.5)}
                     warnLevel="low"
                   />
                   <PillButton
                     label="2.5x"
-                    onClick={() => setLeverage(1.5)}
+                    onClick={() => updateLeverageFactor(2.5)}
                     warnLevel="medium"
                   />
                   <PillButton
                     label="5.0x"
-                    onClick={() => setLeverage(4.0)}
+                    onClick={() => updateLeverageFactor(5.0)}
                     warnLevel="high"
                   />
                   <InfoTooltip heading="Leverage level">
@@ -228,20 +326,31 @@ export function LeverageScreen() {
           footerStart={liquidationRisk && (
             <>
               <Field.FooterInfoWarnLevel
-                label={`${
-                  match(liquidationRisk.level)
-                    .with("low", () => "Low")
-                    .with("medium", () => "Medium")
-                    .with("high", () => "High")
-                    .exhaustive()
-                } liq. risk`}
-                level={liquidationRisk.level}
+                label={match(liquidationRisk)
+                  .with("low", () => "Low liq. risk")
+                  .with("medium", () => "Medium liq. risk")
+                  .with("high", () => "High liq. risk")
+                  .exhaustive()}
+                level={liquidationRisk}
               />
               <Field.FooterInfo
                 label="LTV"
                 value={
                   <HFlex gap={4}>
-                    {liquidationRisk.ltv}
+                    {ltv
+                      ? (
+                        <span
+                          className={css({
+                            fontVariantNumeric: "tabular-nums",
+                          })}
+                        >
+                          {dn.format(dn.mul(ltv, 100), {
+                            digits: 2,
+                            trailingZeros: true,
+                          })}%
+                        </span>
+                      )
+                      : "−"}
                     <InfoTooltip heading="LTV">
                       A redemption is an event where the borrower’s collateral is exchanged for a corresponding amount
                       of Bold stablecoins. At the time of the exchange a borrower does not lose any money.
@@ -253,10 +362,19 @@ export function LeverageScreen() {
           )}
           footerEnd={liquidationRisk && (
             <Field.FooterInfo
-              label="Liq. ETH Price"
+              label="ETH Price"
               value={
                 <HFlex gap={4}>
-                  ${dn.format(liquidationRisk.ethPrice, 2)}
+                  <span
+                    className={css({
+                      fontVariantNumeric: "tabular-nums",
+                    })}
+                  >
+                    ${dn.format(ethPrice, {
+                      digits: 2,
+                      trailingZeros: true,
+                    })}
+                  </span>
                   <InfoTooltip heading="LTV">
                     A redemption is an event where the borrower’s collateral is exchanged for a corresponding amount of
                     Bold stablecoins. At the time of the exchange a borrower does not lose any money.
@@ -309,21 +427,16 @@ export function LeverageScreen() {
               {...interestRate.inputFieldProps}
             />
           }
-          footerStart={
-            // e.g. “Medium redemption risk”
-            redemptionRiskLevel && (
-              <Field.FooterInfoWarnLevel
-                label={`${
-                  match(redemptionRiskLevel)
-                    .with("low", () => "Low")
-                    .with("medium", () => "Medium")
-                    .with("high", () => "High")
-                    .exhaustive()
-                } redemption risk`}
-                level={redemptionRiskLevel}
-              />
-            )
-          }
+          footerStart={redemptionRisk && (
+            <Field.FooterInfoWarnLevel
+              label={match(redemptionRisk)
+                .with("low", () => "Low redemption risk")
+                .with("medium", () => "Medium redemption risk")
+                .with("high", () => "High redemption risk")
+                .exhaustive()}
+              level={redemptionRisk}
+            />
+          )}
         />
         <div
           style={{
@@ -382,4 +495,35 @@ function StaticAction({
       </div>
     </div>
   );
+}
+
+// e.g. $4000 per ETH @ 1.5x, returns $3248.63 liq. price
+function leveragedLiquidationPrice(
+  ethPrice: Dnum,
+  leverage: number,
+) {
+  return dn.div(
+    dn.sub(dn.mul(leverage, ethPrice), ethPrice),
+    dn.sub(leverage, dn.div(dn.from(1, 18), COLLATERAL_RATIO)),
+  );
+}
+
+// e.g. $4000 per ETH, $3248.63 liq. price returns 1.5x
+function leverageFactorFromLiquidationPrice(
+  ethPrice: Dnum,
+  liquidationPrice: Dnum,
+) {
+  return Math.round(
+    dn.toNumber(dn.div(
+      dn.sub(
+        dn.mul(liquidationPrice, dn.div(dn.from(1, 18), COLLATERAL_RATIO)),
+        ethPrice,
+      ),
+      dn.sub(liquidationPrice, ethPrice),
+    )) * 10,
+  ) / 10;
+}
+
+function ltvFromLeverageFactor(leverageFactor: number) {
+  return dn.div(dn.sub(leverageFactor, dn.from(1, 18)), leverageFactor);
 }

--- a/frontend/app/src/types.ts
+++ b/frontend/app/src/types.ts
@@ -2,6 +2,8 @@ import type { Token } from "@liquity2/uikit";
 import type { Dnum } from "dnum";
 import type { ReactNode } from "react";
 
+export type RiskLevel = "low" | "medium" | "high";
+
 export type TroveId = bigint;
 
 // Utility type to get type-safe entries of an object,

--- a/frontend/uikit/src/InputField/InputField.tsx
+++ b/frontend/uikit/src/InputField/InputField.tsx
@@ -1,20 +1,9 @@
 import type { ReactNode } from "react";
 
-import { useId } from "react";
+import { forwardRef, useId } from "react";
 import { css, cx } from "../../styled-system/css";
 
-export function InputField({
-  action,
-  actionLabel,
-  label,
-  onBlur,
-  onChange,
-  onFocus,
-  placeholder,
-  secondaryEnd,
-  secondaryStart,
-  value,
-}: {
+type InputFieldProps = {
   action?: ReactNode;
   actionLabel?: ReactNode;
   label?: string;
@@ -25,7 +14,20 @@ export function InputField({
   secondaryEnd?: ReactNode;
   secondaryStart?: ReactNode;
   value?: string;
-}) {
+};
+
+export const InputField = forwardRef<HTMLInputElement, InputFieldProps>(function InputField({
+  action,
+  actionLabel,
+  label,
+  onBlur,
+  onChange,
+  onFocus,
+  placeholder,
+  secondaryEnd,
+  secondaryStart,
+  value,
+}, ref) {
   const id = useId();
   return (
     <div
@@ -56,6 +58,7 @@ export function InputField({
         {actionLabel && <div>{actionLabel}</div>}
       </div>
       <input
+        ref={ref}
         id={id}
         type="text"
         placeholder={placeholder}
@@ -117,6 +120,10 @@ export function InputField({
           justifyContent: "space-between",
           fontSize: 16,
           color: "contentAlt",
+          pointerEvents: "none",
+          "& > div": {
+            pointerEvents: "auto",
+          },
         })}
       >
         <div>
@@ -128,4 +135,4 @@ export function InputField({
       </div>
     </div>
   );
-}
+});


### PR DESCRIPTION
Leverage screen:

- Calculate the different leverage values
- Do not rely on the deposit for the LTV and liq. risk
- Simulate price changes
- Round the leverage factor
- Round the liquidation price when the focus leaves the field
- Update the liquidation price when the price changes (not during edit)
- Focus input when the collateral changes
- More interaction & UI fixes + tweaks

Borrow screen:

- Integrate the account connection status to the screen data
- Various changes to align the code with the Leverage screen