### PR TITLE
InputField API changes

### DIFF
--- a/frontend/app/src/screens/BorrowScreen/BorrowScreen.tsx
+++ b/frontend/app/src/screens/BorrowScreen/BorrowScreen.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import type { ReactNode } from "react";
-
 import { Field } from "@/src/comps/Field/Field";
 import { Forecast } from "@/src/comps/Forecast/Forecast";
 import { Screen } from "@/src/comps/Screen/Screen";
@@ -123,7 +121,7 @@ export function BorrowScreen() {
           // “You deposit”
           field={
             <InputField
-              action={
+              contextual={
                 <Dropdown
                   items={COLLATERALS.map(({ symbol, name }) => ({
                     icon: <TokenIcon symbol={symbol} />,
@@ -144,24 +142,23 @@ export function BorrowScreen() {
               }
               label={content.borrowScreen.depositField.label}
               placeholder="0.00"
-              secondaryStart={`$${
-                deposit.parsed
-                  ? dn.format(
-                    dn.mul(ethPriceUsd, deposit.parsed),
-                    2,
-                  )
-                  : "0.00"
-              }`}
-              secondaryEnd={account.isConnected && (
-                <TextButton
-                  label={`Max ${dn.format(ACCOUNT_BALANCES[collateral])} ${collateral}`}
-                  onClick={() => {
-                    deposit.setValue(
-                      dn.format(ACCOUNT_BALANCES[collateral]).replace(",", ""),
-                    );
-                  }}
-                />
-              )}
+              secondary={{
+                start: `$${
+                  deposit.parsed
+                    ? dn.format(dn.mul(ethPriceUsd, deposit.parsed), 2)
+                    : "0.00"
+                }`,
+                end: account.isConnected && (
+                  <TextButton
+                    label={`Max ${dn.format(ACCOUNT_BALANCES[collateral])} ${collateral}`}
+                    onClick={() => {
+                      deposit.setValue(
+                        dn.format(ACCOUNT_BALANCES[collateral]).replace(",", ""),
+                      );
+                    }}
+                  />
+                ),
+              }}
               {...deposit.inputFieldProps}
             />
           }
@@ -180,52 +177,47 @@ export function BorrowScreen() {
           // “You borrow”
           field={
             <InputField
-              action={
-                <StaticAction
+              contextual={
+                <InputField.Badge
                   icon={<TokenIcon symbol="BOLD" />}
                   label="BOLD"
                 />
               }
               label={content.borrowScreen.borrowField.label}
               placeholder="0.00"
-              secondaryStart={`$${
-                debt.parsed
-                  ? dn.gt(
-                      dn.mul(boldPriceUsd, debt.parsed),
-                      1_000_000_000_000,
-                    )
-                    ? "−"
-                    : dn.format(
-                      dn.mul(boldPriceUsd, debt.parsed),
-                      {
-                        digits: 2,
-                        trailingZeros: true,
-                        compact: dn.gt(debt.parsed, 1_000_000_000),
-                      },
-                    )
-                  : "0.00"
-              }`}
-              secondaryEnd={debtSuggestions && (
-                <HFlex gap={6}>
-                  {debtSuggestions.map((s) => (
-                    s.debt && s.risk && (
-                      <PillButton
-                        key={dn.toString(s.debt)}
-                        label={`$${dn.format(s.debt, { compact: true, digits: 0 })}`}
-                        onClick={() => {
-                          if (s.debt) {
-                            debt.setValue(dn.toString(s.debt, 0));
-                          }
-                        }}
-                        warnLevel={s.risk}
-                      />
-                    )
-                  ))}
-                  {debtSuggestions.length > 0 && (
-                    <InfoTooltip {...infoTooltipProps(content.borrowScreen.infoTooltips.interestRateSuggestions)} />
-                  )}
-                </HFlex>
-              )}
+              secondary={{
+                start: `$${
+                  debt.parsed
+                    ? dn.gt(dn.mul(boldPriceUsd, debt.parsed), 1_000_000_000_000)
+                      ? "−"
+                      : dn.format(
+                        dn.mul(boldPriceUsd, debt.parsed),
+                        { digits: 2, trailingZeros: true, compact: dn.gt(debt.parsed, 1_000_000_000) },
+                      )
+                    : "0.00"
+                }`,
+                end: debtSuggestions && (
+                  <HFlex gap={6}>
+                    {debtSuggestions.map((s) => (
+                      s.debt && s.risk && (
+                        <PillButton
+                          key={dn.toString(s.debt)}
+                          label={`$${dn.format(s.debt, { compact: true, digits: 0 })}`}
+                          onClick={() => {
+                            if (s.debt) {
+                              debt.setValue(dn.toString(s.debt, 0));
+                            }
+                          }}
+                          warnLevel={s.risk}
+                        />
+                      )
+                    ))}
+                    {debtSuggestions.length > 0 && (
+                      <InfoTooltip {...infoTooltipProps(content.borrowScreen.infoTooltips.interestRateSuggestions)} />
+                    )}
+                  </HFlex>
+                ),
+              }}
               {...debt.inputFieldProps}
             />
           }
@@ -256,39 +248,41 @@ export function BorrowScreen() {
             // “Interest rate”
             field={
               <InputField
-                action={<StaticAction label="% per year" />}
+                contextual={<InputField.Badge label="% per year" />}
                 label={content.borrowScreen.interestRateField.label}
                 placeholder="0.00"
-                secondaryStart={
-                  <HFlex gap={4}>
-                    <div>
-                      {boldInterestPerYear
-                        ? dn.format(boldInterestPerYear, { digits: 2, trailingZeros: false })
-                        : "−"} BOLD / year
-                    </div>
-                    <InfoTooltip {...infoTooltipProps(content.borrowScreen.infoTooltips.interestRateBoldPerYear)} />
-                  </HFlex>
-                }
-                secondaryEnd={
-                  <HFlex gap={6}>
-                    <PillButton
-                      label="6.5%"
-                      onClick={() => interestRate.setValue("6.5")}
-                      warnLevel="low"
-                    />
-                    <PillButton
-                      label="5.0%"
-                      onClick={() => interestRate.setValue("5.0")}
-                      warnLevel="medium"
-                    />
-                    <PillButton
-                      label="3.5%"
-                      onClick={() => interestRate.setValue("3.5")}
-                      warnLevel="high"
-                    />
-                    <InfoTooltip {...infoTooltipProps(content.borrowScreen.infoTooltips.interestRateSuggestions)} />
-                  </HFlex>
-                }
+                secondary={{
+                  start: (
+                    <HFlex gap={4}>
+                      <div>
+                        {boldInterestPerYear
+                          ? dn.format(boldInterestPerYear, { digits: 2, trailingZeros: false })
+                          : "−"} BOLD / year
+                      </div>
+                      <InfoTooltip {...infoTooltipProps(content.borrowScreen.infoTooltips.interestRateBoldPerYear)} />
+                    </HFlex>
+                  ),
+                  end: (
+                    <HFlex gap={6}>
+                      <PillButton
+                        label="6.5%"
+                        onClick={() => interestRate.setValue("6.5")}
+                        warnLevel="low"
+                      />
+                      <PillButton
+                        label="5.0%"
+                        onClick={() => interestRate.setValue("5.0")}
+                        warnLevel="medium"
+                      />
+                      <PillButton
+                        label="3.5%"
+                        onClick={() => interestRate.setValue("3.5")}
+                        warnLevel="high"
+                      />
+                      <InfoTooltip {...infoTooltipProps(content.borrowScreen.infoTooltips.interestRateSuggestions)} />
+                    </HFlex>
+                  ),
+                }}
                 {...interestRate.inputFieldProps}
               />
             }
@@ -371,39 +365,5 @@ export function BorrowScreen() {
         </div>
       </div>
     </Screen>
-  );
-}
-
-function StaticAction({
-  label,
-  icon,
-}: {
-  label: ReactNode;
-  icon?: ReactNode;
-}) {
-  return (
-    <div
-      style={{
-        display: "flex",
-        alignItems: "center",
-        gap: 8,
-        height: 40,
-        padding: "0 16px",
-        paddingLeft: icon ? 8 : 16,
-        background: "#FFF",
-        borderRadius: 20,
-        userSelect: "none",
-      }}
-    >
-      {icon}
-      <div
-        style={{
-          fontSize: 24,
-          fontWeight: 500,
-        }}
-      >
-        {label}
-      </div>
-    </div>
   );
 }

--- a/frontend/app/src/screens/EarnPoolScreen/DepositPanel.tsx
+++ b/frontend/app/src/screens/EarnPoolScreen/DepositPanel.tsx
@@ -56,7 +56,7 @@ export function DepositPanel({
       <Field
         field={
           <InputField
-            action={
+            contextual={
               <div
                 style={{
                   display: "flex",
@@ -87,25 +87,27 @@ export function DepositPanel({
             onBlur={() => setFocused(false)}
             value={value_}
             placeholder="0.00"
-            secondaryStart={
-              <HFlex gap={4}>
-                <div>
-                  {content.earnScreen.depositPanel.shareLabel}
-                </div>
-                <div>
-                  {updatedPoolShare
-                    ? dn.format(dn.mul(updatedPoolShare, 100), 2)
-                    : "0"}%
-                </div>
-                <InfoTooltip {...infoTooltipProps(content.earnScreen.infoTooltips.depositPoolShare)} />
-              </HFlex>
-            }
-            secondaryEnd={accountBoldBalance && (
-              <TextButton
-                label={`Max ${dn.format(accountBoldBalance)} BOLD`}
-                onClick={() => setValue(dn.toString(accountBoldBalance))}
-              />
-            )}
+            secondary={{
+              start: (
+                <HFlex gap={4}>
+                  <div>
+                    {content.earnScreen.depositPanel.shareLabel}
+                  </div>
+                  <div>
+                    {updatedPoolShare
+                      ? dn.format(dn.mul(updatedPoolShare, 100), 2)
+                      : "0"}%
+                  </div>
+                  <InfoTooltip {...infoTooltipProps(content.earnScreen.infoTooltips.depositPoolShare)} />
+                </HFlex>
+              ),
+              end: accountBoldBalance && (
+                <TextButton
+                  label={`Max ${dn.format(accountBoldBalance)} BOLD`}
+                  onClick={() => setValue(dn.toString(accountBoldBalance))}
+                />
+              ),
+            }}
           />
         }
       />

--- a/frontend/app/src/screens/EarnPoolScreen/WithdrawPanel.tsx
+++ b/frontend/app/src/screens/EarnPoolScreen/WithdrawPanel.tsx
@@ -55,7 +55,7 @@ export function WithdrawPanel({
       <Field
         field={
           <InputField
-            action={
+            contextual={
               <div
                 style={{
                   display: "flex",
@@ -86,27 +86,27 @@ export function WithdrawPanel({
             onBlur={() => setFocused(false)}
             value={value_}
             placeholder="0.00"
-            secondaryStart={
-              <HFlex gap={4}>
-                <div>
-                  {content.earnScreen.depositPanel.shareLabel}
-                </div>
-                <div>
-                  {updatedPoolShare
-                    ? dn.format(dn.mul(updatedPoolShare, 100), 2)
-                    : "0"}%
-                </div>
-                <InfoTooltip {...infoTooltipProps(content.earnScreen.infoTooltips.depositPoolShare)} />
-              </HFlex>
-            }
-            secondaryEnd={position?.deposit && dn.gt(position?.deposit, 0) && (
-              <TextButton
-                label={`Max ${dn.format(position.deposit)} BOLD`}
-                onClick={() => {
-                  setValue(dn.toString(position.deposit));
-                }}
-              />
-            )}
+            secondary={{
+              start: (
+                <HFlex gap={4}>
+                  <div>{content.earnScreen.depositPanel.shareLabel}</div>
+                  <div>
+                    {updatedPoolShare
+                      ? dn.format(dn.mul(updatedPoolShare, 100), 2)
+                      : "0"}%
+                  </div>
+                  <InfoTooltip {...infoTooltipProps(content.earnScreen.infoTooltips.depositPoolShare)} />
+                </HFlex>
+              ),
+              end: (position?.deposit && dn.gt(position?.deposit, 0) && (
+                <TextButton
+                  label={`Max ${dn.format(position.deposit)} BOLD`}
+                  onClick={() => {
+                    setValue(dn.toString(position.deposit));
+                  }}
+                />
+              )),
+            }}
           />
         }
       />

--- a/frontend/app/src/screens/LeverageScreen/LeverageScreen.tsx
+++ b/frontend/app/src/screens/LeverageScreen/LeverageScreen.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import type { Dnum } from "dnum";
-import type { ReactNode } from "react";
 
 import { Field } from "@/src/comps/Field/Field";
 import { Forecast } from "@/src/comps/Forecast/Forecast";
@@ -227,7 +226,7 @@ export function LeverageScreen() {
           // “You deposit”
           field={
             <InputField
-              action={
+              contextual={
                 <Dropdown
                   items={COLLATERALS.map(({ symbol, name }) => ({
                     icon: <TokenIcon symbol={symbol} />,
@@ -251,20 +250,22 @@ export function LeverageScreen() {
               }
               label={content.leverageScreen.depositField.label}
               placeholder="0.00"
-              secondaryStart={depositUsd && `$${
-                dn.format(depositUsd, {
-                  digits: 2,
-                  trailingZeros: true,
-                })
-              }`}
-              secondaryEnd={account.isConnected && (
-                <TextButton
-                  label={`Max ${dn.format(ACCOUNT_BALANCES[collateral])} ${collateral}`}
-                  onClick={() => {
-                    deposit.setValue(dn.toString(ACCOUNT_BALANCES[collateral]));
-                  }}
-                />
-              )}
+              secondary={{
+                start: depositUsd && `$${
+                  dn.format(depositUsd, {
+                    digits: 2,
+                    trailingZeros: true,
+                  })
+                }`,
+                end: account.isConnected && (
+                  <TextButton
+                    label={`Max ${dn.format(ACCOUNT_BALANCES[collateral])} ${collateral}`}
+                    onClick={() => {
+                      deposit.setValue(dn.toString(ACCOUNT_BALANCES[collateral]));
+                    }}
+                  />
+                ),
+              }}
               {...deposit.inputFieldProps}
             />
           }
@@ -281,7 +282,7 @@ export function LeverageScreen() {
           // ETH Liquidation price
           field={
             <InputField
-              action={
+              contextual={
                 <div
                   style={{
                     display: "flex",
@@ -318,62 +319,66 @@ export function LeverageScreen() {
                   />
                 </div>
               }
-              label={content.leverageScreen.liquidationPriceField.label}
-              actionLabel={
-                <span>
-                  Leverage{" "}
-                  <span
-                    title={dn.format([BigInt(Math.round(leverageFactor * 10)), 1])}
-                    style={{
-                      color: liquidationRisk === "high"
-                        ? "#F36740"
-                        : "#2F3037",
-                      fontVariantNumeric: "tabular-nums",
-                    }}
-                  >
-                    {dn.format([BigInt(Math.round(leverageFactor * 10)), 1], {
-                      digits: 1,
-                      trailingZeros: true,
-                    })}x
+              label={{
+                end: (
+                  <span>
+                    Leverage{" "}
+                    <span
+                      title={dn.format([BigInt(Math.round(leverageFactor * 10)), 1])}
+                      style={{
+                        color: liquidationRisk === "high"
+                          ? "#F36740"
+                          : "#2F3037",
+                        fontVariantNumeric: "tabular-nums",
+                      }}
+                    >
+                      {dn.format([BigInt(Math.round(leverageFactor * 10)), 1], {
+                        digits: 1,
+                        trailingZeros: true,
+                      })}x
+                    </span>
                   </span>
-                </span>
-              }
+                ),
+                start: content.leverageScreen.liquidationPriceField.label,
+              }}
               placeholder="0.00"
-              secondaryStart={
-                <div>
-                  Total debt {totalDebtBold && dn.gt(totalDebtBold, 0)
-                    ? (
-                      <>
-                        <span
-                          className={css({
-                            fontVariantNumeric: "tabular-nums",
-                          })}
-                        >
-                          {dn.format(totalDebtBold, { digits: 2, trailingZeros: true })}
-                        </span>
-                        {" BOLD"}
-                      </>
-                    )
-                    : "−"}
-                </div>
-              }
-              secondaryEnd={
-                <HFlex gap={6}>
-                  {leverageFactorSuggestions.map((factor) => (
-                    <PillButton
-                      key={factor}
-                      label={`${factor.toFixed(1)}x`}
-                      onClick={() => updateLeverageFactor(factor)}
-                      warnLevel={getLiquidationRiskFromLeverageFactor(
-                        factor,
-                        mediumRiskLeverageFactor,
-                        highRiskLeverageFactor,
-                      )}
-                    />
-                  ))}
-                  <InfoTooltip {...infoTooltipProps(content.leverageScreen.infoTooltips.leverageLevel)} />
-                </HFlex>
-              }
+              secondary={{
+                start: (
+                  <div>
+                    Total debt {totalDebtBold && dn.gt(totalDebtBold, 0)
+                      ? (
+                        <>
+                          <span
+                            className={css({
+                              fontVariantNumeric: "tabular-nums",
+                            })}
+                          >
+                            {dn.format(totalDebtBold, { digits: 2, trailingZeros: true })}
+                          </span>
+                          {" BOLD"}
+                        </>
+                      )
+                      : "−"}
+                  </div>
+                ),
+                end: (
+                  <HFlex gap={6}>
+                    {leverageFactorSuggestions.map((factor) => (
+                      <PillButton
+                        key={factor}
+                        label={`${factor.toFixed(1)}x`}
+                        onClick={() => updateLeverageFactor(factor)}
+                        warnLevel={getLiquidationRiskFromLeverageFactor(
+                          factor,
+                          mediumRiskLeverageFactor,
+                          highRiskLeverageFactor,
+                        )}
+                      />
+                    ))}
+                    <InfoTooltip {...infoTooltipProps(content.leverageScreen.infoTooltips.leverageLevel)} />
+                  </HFlex>
+                ),
+              }}
               {...ethLiqPrice.inputFieldProps}
             />
           }
@@ -421,42 +426,44 @@ export function LeverageScreen() {
             // “Interest rate”
             field={
               <InputField
-                action={<StaticAction label="% per year" />}
+                contextual={<InputField.Badge label="% per year" />}
                 label={content.leverageScreen.interestRateField.label}
                 placeholder="0.00"
-                secondaryStart={
-                  <HFlex gap={4}>
-                    <div>
-                      {interestRate.parsed && totalDebtBold
-                        ? dn.format(dn.mul(dn.div(interestRate.parsed, 100), totalDebtBold), {
-                          digits: 2,
-                          trailingZeros: true,
-                        })
-                        : "−"} BOLD / year
-                    </div>
-                    <InfoTooltip {...infoTooltipProps(content.borrowScreen.infoTooltips.interestRateBoldPerYear)} />
-                  </HFlex>
-                }
-                secondaryEnd={
-                  <HFlex gap={6}>
-                    <PillButton
-                      label="6.5%"
-                      onClick={() => interestRate.setValue("6.5")}
-                      warnLevel="low"
-                    />
-                    <PillButton
-                      label="5.0%"
-                      onClick={() => interestRate.setValue("5.0")}
-                      warnLevel="medium"
-                    />
-                    <PillButton
-                      label="3.5%"
-                      onClick={() => interestRate.setValue("3.5")}
-                      warnLevel="high"
-                    />
-                    <InfoTooltip {...infoTooltipProps(content.borrowScreen.infoTooltips.interestRateSuggestions)} />
-                  </HFlex>
-                }
+                secondary={{
+                  start: (
+                    <HFlex gap={4}>
+                      <div>
+                        {interestRate.parsed && totalDebtBold
+                          ? dn.format(dn.mul(dn.div(interestRate.parsed, 100), totalDebtBold), {
+                            digits: 2,
+                            trailingZeros: true,
+                          })
+                          : "−"} BOLD / year
+                      </div>
+                      <InfoTooltip {...infoTooltipProps(content.borrowScreen.infoTooltips.interestRateBoldPerYear)} />
+                    </HFlex>
+                  ),
+                  end: (
+                    <HFlex gap={6}>
+                      <PillButton
+                        label="6.5%"
+                        onClick={() => interestRate.setValue("6.5")}
+                        warnLevel="low"
+                      />
+                      <PillButton
+                        label="5.0%"
+                        onClick={() => interestRate.setValue("5.0")}
+                        warnLevel="medium"
+                      />
+                      <PillButton
+                        label="3.5%"
+                        onClick={() => interestRate.setValue("3.5")}
+                        warnLevel="high"
+                      />
+                      <InfoTooltip {...infoTooltipProps(content.borrowScreen.infoTooltips.interestRateSuggestions)} />
+                    </HFlex>
+                  ),
+                }}
                 {...interestRate.inputFieldProps}
               />
             }
@@ -537,39 +544,5 @@ export function LeverageScreen() {
         </div>
       </div>
     </Screen>
-  );
-}
-
-function StaticAction({
-  label,
-  icon,
-}: {
-  label: ReactNode;
-  icon?: ReactNode;
-}) {
-  return (
-    <div
-      style={{
-        display: "flex",
-        alignItems: "center",
-        gap: 8,
-        height: 40,
-        padding: "0 16px",
-        paddingLeft: icon ? 8 : 16,
-        background: "#FFF",
-        borderRadius: 20,
-        userSelect: "none",
-      }}
-    >
-      {icon}
-      <div
-        style={{
-          fontSize: 24,
-          fontWeight: 500,
-        }}
-      >
-        {label}
-      </div>
-    </div>
   );
 }

--- a/frontend/app/src/screens/LoanScreen/LoanScreen.tsx
+++ b/frontend/app/src/screens/LoanScreen/LoanScreen.tsx
@@ -173,7 +173,7 @@ function UpdatePositionPanel({
         <Field
           field={
             <InputField
-              action={
+              contextual={
                 <InputTokenBadge
                   icon={<TokenIcon symbol={collateral.symbol} />}
                   label={collateral.name}
@@ -190,17 +190,19 @@ function UpdatePositionPanel({
               }}
               label="Deposit"
               placeholder="0.00"
-              secondaryStart={loanDetails.depositUsd
-                ? "$" + dn.format(loanDetails.depositUsd, 2)
-                : "$0.00"}
-              secondaryEnd={
-                <TextButton
-                  label={`Max ${dn.format(ethMax, 2)} ${collateral.symbol}`}
-                  onClick={() => {
-                    deposit.setValue(dn.toString(ethMax));
-                  }}
-                />
-              }
+              secondary={{
+                start: loanDetails.depositUsd
+                  ? "$" + dn.format(loanDetails.depositUsd, 2)
+                  : "$0.00",
+                end: (
+                  <TextButton
+                    label={`Max ${dn.format(ethMax, 2)} ${collateral.symbol}`}
+                    onClick={() => {
+                      deposit.setValue(dn.toString(ethMax));
+                    }}
+                  />
+                ),
+              }}
               {...deposit.inputFieldProps}
             />
           }
@@ -215,7 +217,7 @@ function UpdatePositionPanel({
         <Field
           field={
             <InputField
-              action={
+              contextual={
                 <InputTokenBadge
                   icon={<TokenIcon symbol="BOLD" />}
                   label="BOLD"
@@ -232,28 +234,30 @@ function UpdatePositionPanel({
               }}
               label="Debt"
               placeholder="0.00"
-              secondaryStart={debt.parsed ? `$${dn.format(dn.mul(debt.parsed, boldPriceUsd), 2)}` : "$0.00"}
-              secondaryEnd={debtSuggestions && (
-                <HFlex gap={6}>
-                  {debtSuggestions.map((s) => (
-                    s.debt && s.risk && (
-                      <PillButton
-                        key={dn.toString(s.debt)}
-                        label={`$${dn.format(s.debt, { compact: true, digits: 0 })}`}
-                        onClick={() => {
-                          if (s.debt) {
-                            debt.setValue(dn.toString(s.debt, 0));
-                          }
-                        }}
-                        warnLevel={s.risk}
-                      />
-                    )
-                  ))}
-                  {debtSuggestions.length > 0 && (
-                    <InfoTooltip {...infoTooltipProps(content.borrowScreen.infoTooltips.interestRateSuggestions)} />
-                  )}
-                </HFlex>
-              )}
+              secondary={{
+                start: debt.parsed ? `$${dn.format(dn.mul(debt.parsed, boldPriceUsd), 2)}` : "$0.00",
+                end: debtSuggestions && (
+                  <HFlex gap={6}>
+                    {debtSuggestions.map((s) => (
+                      s.debt && s.risk && (
+                        <PillButton
+                          key={dn.toString(s.debt)}
+                          label={`$${dn.format(s.debt, { compact: true, digits: 0 })}`}
+                          onClick={() => {
+                            if (s.debt) {
+                              debt.setValue(dn.toString(s.debt, 0));
+                            }
+                          }}
+                          warnLevel={s.risk}
+                        />
+                      )
+                    ))}
+                    {debtSuggestions.length > 0 && (
+                      <InfoTooltip {...infoTooltipProps(content.borrowScreen.infoTooltips.interestRateSuggestions)} />
+                    )}
+                  </HFlex>
+                ),
+              }}
               {...debt.inputFieldProps}
             />
           }
@@ -282,7 +286,7 @@ function UpdatePositionPanel({
           // “Interest rate”
           field={
             <InputField
-              action={<InputTokenBadge label="% per year" />}
+              contextual={<InputTokenBadge label="% per year" />}
               difference={showInterestRateDifference && `${
                 dn.format(interestRateDifference, {
                   digits: 2,
@@ -294,36 +298,38 @@ function UpdatePositionPanel({
               }}
               label="Interest rate"
               placeholder="0.00"
-              secondaryStart={
-                <HFlex gap={4}>
-                  <div>
-                    {boldInterestPerYear
-                      ? dn.format(boldInterestPerYear, { digits: 2, trailingZeros: false })
-                      : "−"} BOLD / year
-                  </div>
-                  <InfoTooltip {...infoTooltipProps(content.borrowScreen.infoTooltips.interestRateBoldPerYear)} />
-                </HFlex>
-              }
-              secondaryEnd={
-                <HFlex gap={6}>
-                  <PillButton
-                    label="6.5%"
-                    onClick={() => interestRate.setValue("6.5")}
-                    warnLevel="low"
-                  />
-                  <PillButton
-                    label="5.0%"
-                    onClick={() => interestRate.setValue("5.0")}
-                    warnLevel="medium"
-                  />
-                  <PillButton
-                    label="3.5%"
-                    onClick={() => interestRate.setValue("3.5")}
-                    warnLevel="high"
-                  />
-                  <InfoTooltip {...infoTooltipProps(content.borrowScreen.infoTooltips.interestRateSuggestions)} />
-                </HFlex>
-              }
+              secondary={{
+                start: (
+                  <HFlex gap={4}>
+                    <div>
+                      {boldInterestPerYear
+                        ? dn.format(boldInterestPerYear, { digits: 2, trailingZeros: false })
+                        : "−"} BOLD / year
+                    </div>
+                    <InfoTooltip {...infoTooltipProps(content.borrowScreen.infoTooltips.interestRateBoldPerYear)} />
+                  </HFlex>
+                ),
+                end: (
+                  <HFlex gap={6}>
+                    <PillButton
+                      label="6.5%"
+                      onClick={() => interestRate.setValue("6.5")}
+                      warnLevel="low"
+                    />
+                    <PillButton
+                      label="5.0%"
+                      onClick={() => interestRate.setValue("5.0")}
+                      warnLevel="medium"
+                    />
+                    <PillButton
+                      label="3.5%"
+                      onClick={() => interestRate.setValue("3.5")}
+                      warnLevel="high"
+                    />
+                    <InfoTooltip {...infoTooltipProps(content.borrowScreen.infoTooltips.interestRateSuggestions)} />
+                  </HFlex>
+                ),
+              }}
               {...interestRate.inputFieldProps}
             />
           }

--- a/frontend/app/src/screens/StakeScreen/StakeScreen.tsx
+++ b/frontend/app/src/screens/StakeScreen/StakeScreen.tsx
@@ -111,25 +111,27 @@ export function StakeScreen() {
               <Field
                 field={
                   <InputField
-                    action={
-                      <StaticAction
+                    contextual={
+                      <InputField.Badge
                         icon={<TokenIcon symbol="LQTY" />}
                         label="LQTY"
                       />
                     }
                     label="You deposit"
                     placeholder="0.00"
-                    secondaryStart={deposit.parsed && `$${dn.format(dn.mul(deposit.parsed, lqtyPrice), 2)}`}
-                    secondaryEnd={
-                      <TextButton
-                        label={`Max. ${dn.format(ACCOUNT_BALANCES.LQTY, 2)} LQTY`}
-                        onClick={() => {
-                          deposit.setValue(
-                            dn.toString(ACCOUNT_BALANCES.LQTY),
-                          );
-                        }}
-                      />
-                    }
+                    secondary={{
+                      start: deposit.parsed && `$${dn.format(dn.mul(deposit.parsed, lqtyPrice), 2)}`,
+                      end: (
+                        <TextButton
+                          label={`Max. ${dn.format(ACCOUNT_BALANCES.LQTY, 2)} LQTY`}
+                          onClick={() => {
+                            deposit.setValue(
+                              dn.toString(ACCOUNT_BALANCES.LQTY),
+                            );
+                          }}
+                        />
+                      ),
+                    }}
                     {...deposit.inputFieldProps}
                   />
                 }
@@ -188,25 +190,27 @@ export function StakeScreen() {
               <Field
                 field={
                   <InputField
-                    action={
-                      <StaticAction
+                    contextual={
+                      <InputField.Badge
                         icon={<TokenIcon symbol="LQTY" />}
                         label="LQTY"
                       />
                     }
                     label="You withdraw"
                     placeholder="0.00"
-                    secondaryStart={withdraw.parsed && `$${dn.format(dn.mul(withdraw.parsed, lqtyPrice), 2)}`}
-                    secondaryEnd={
-                      <TextButton
-                        label={`Max. ${dn.format(ACCOUNT_STAKED_LQTY.deposit, 2)} LQTY`}
-                        onClick={() => {
-                          withdraw.setValue(
-                            dn.toString(ACCOUNT_STAKED_LQTY.deposit),
-                          );
-                        }}
-                      />
-                    }
+                    secondary={{
+                      start: withdraw.parsed && `$${dn.format(dn.mul(withdraw.parsed, lqtyPrice), 2)}`,
+                      end: (
+                        <TextButton
+                          label={`Max. ${dn.format(ACCOUNT_STAKED_LQTY.deposit, 2)} LQTY`}
+                          onClick={() => {
+                            withdraw.setValue(
+                              dn.toString(ACCOUNT_STAKED_LQTY.deposit),
+                            );
+                          }}
+                        />
+                      ),
+                    }}
                     {...withdraw.inputFieldProps}
                   />
                 }
@@ -344,40 +348,6 @@ export function StakeScreen() {
         </VFlex>
       </VFlex>
     </Screen>
-  );
-}
-
-function StaticAction({
-  label,
-  icon,
-}: {
-  label: ReactNode;
-  icon?: ReactNode;
-}) {
-  return (
-    <div
-      style={{
-        display: "flex",
-        alignItems: "center",
-        gap: 8,
-        height: 40,
-        padding: "0 16px",
-        paddingLeft: icon ? 8 : 16,
-        background: "#FFF",
-        borderRadius: 20,
-        userSelect: "none",
-      }}
-    >
-      {icon}
-      <div
-        style={{
-          fontSize: 24,
-          fontWeight: 500,
-        }}
-      >
-        {label}
-      </div>
-    </div>
   );
 }
 

--- a/frontend/uikit-gallery/src/InputField/shared.tsx
+++ b/frontend/uikit-gallery/src/InputField/shared.tsx
@@ -50,7 +50,7 @@ export function InputFieldFixture({
 
   const [leverage, setLeverage] = useState(0); // from 0 (1x) to 5.3 (6.3x)
 
-  const actionLabel = match(fixture)
+  const labelEnd = match(fixture)
     .with("slider", () => (
       <span>
         Leverage{" "}
@@ -220,16 +220,20 @@ export function InputFieldFixture({
       }}
     >
       <InputField
-        action={action}
-        actionLabel={actionLabel}
-        label={label}
+        contextual={action}
+        label={{
+          start: label,
+          end: labelEnd,
+        }}
         onFocus={() => setFocused(true)}
         onChange={setValue}
         onBlur={() => setFocused(false)}
         value={value_}
         placeholder={placeholder}
-        secondaryStart={secondaryStart}
-        secondaryEnd={secondaryEnd}
+        secondary={{
+          start: secondaryStart,
+          end: secondaryEnd,
+        }}
       />
     </div>
   );

--- a/frontend/uikit/src/InputField/InputField.tsx
+++ b/frontend/uikit/src/InputField/InputField.tsx
@@ -7,17 +7,21 @@ import { IconCross } from "../icons";
 import { useElementSize } from "../react-utils";
 
 type InputFieldProps = {
-  action?: ReactNode;
-  actionLabel?: ReactNode;
+  contextual?: ReactNode;
   difference?: ReactNode;
-  label?: string;
+  label?:
+    | ReactNode
+    | { end: ReactNode; start?: ReactNode }
+    | { end?: ReactNode; start: ReactNode };
   onBlur?: () => void;
   onChange?: (value: string) => void;
   onDifferenceClick?: () => void;
   onFocus?: () => void;
   placeholder?: string;
-  secondaryEnd?: ReactNode;
-  secondaryStart?: ReactNode;
+  secondary?:
+    | ReactNode
+    | { end: ReactNode; start?: ReactNode }
+    | { end?: ReactNode; start: ReactNode };
   value?: string;
 };
 
@@ -27,9 +31,8 @@ const diffSpringConfig = {
   friction: 120,
 };
 
-export const InputField = forwardRef<HTMLInputElement, InputFieldProps>(function InputField({
-  action,
-  actionLabel,
+const InputField = forwardRef<HTMLInputElement, InputFieldProps>(function InputField({
+  contextual,
   difference,
   label,
   onBlur,
@@ -37,10 +40,21 @@ export const InputField = forwardRef<HTMLInputElement, InputFieldProps>(function
   onDifferenceClick,
   onFocus,
   placeholder,
-  secondaryEnd,
-  secondaryStart,
+  secondary,
   value,
 }, ref) {
+  const label_ = label
+      && typeof label === "object"
+      && ("start" in label || "end" in label)
+    ? label
+    : { start: label };
+
+  const secondary_ = secondary
+      && typeof secondary === "object"
+      && ("start" in secondary || "end" in secondary)
+    ? secondary
+    : { start: secondary };
+
   const id = useId();
 
   const valueMeasurement = useRef<HTMLDivElement>(null);
@@ -119,8 +133,8 @@ export const InputField = forwardRef<HTMLInputElement, InputFieldProps>(function
           color: "contentAlt",
         })}
       >
-        {label ? <label htmlFor={id}>{label}</label> : <div />}
-        {actionLabel && <div>{actionLabel}</div>}
+        {label_.start ? <label htmlFor={id}>{label_.start}</label> : <div />}
+        {label_.end && <div>{label_.end}</div>}
       </div>
       <div
         ref={valueMeasurement}
@@ -216,14 +230,14 @@ export const InputField = forwardRef<HTMLInputElement, InputFieldProps>(function
           },
         })}
       />
-      {action && (
+      {contextual && (
         <div
           className={css({
             position: "absolute",
             inset: "48px 16px auto auto",
           })}
         >
-          {action}
+          {contextual}
         </div>
       )}
       <div
@@ -241,30 +255,76 @@ export const InputField = forwardRef<HTMLInputElement, InputFieldProps>(function
           },
         })}
       >
-        <div
-          className={css({
-            flexGrow: 0,
-            flexShrink: 1,
-            display: "flex",
-            whiteSpace: "nowrap",
-            textOverflow: "ellipsis",
-            maxWidth: "50%",
-          })}
-        >
-          {secondaryStart}
-        </div>
-        <div
-          className={css({
-            flexGrow: 0,
-            flexShrink: 1,
-            display: "flex",
-            whiteSpace: "nowrap",
-            textOverflow: "ellipsis",
-          })}
-        >
-          {secondaryEnd}
-        </div>
+        {secondary_.start
+          ? (
+            <div
+              className={css({
+                flexGrow: 0,
+                flexShrink: 1,
+                display: "flex",
+                whiteSpace: "nowrap",
+                textOverflow: "ellipsis",
+                maxWidth: "50%",
+              })}
+            >
+              {secondary_.start}
+            </div>
+          )
+          : <div />}
+        {secondary_.end && (
+          <div
+            className={css({
+              flexGrow: 0,
+              flexShrink: 1,
+              display: "flex",
+              whiteSpace: "nowrap",
+              textOverflow: "ellipsis",
+            })}
+          >
+            {secondary_.end}
+          </div>
+        )}
       </div>
     </div>
   );
 });
+
+export function InputFieldBadge({
+  label,
+  icon,
+}: {
+  label: ReactNode;
+  icon?: ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        height: 40,
+        padding: "0 16px",
+        paddingLeft: icon ? 8 : 16,
+        background: "#FFF",
+        borderRadius: 20,
+        userSelect: "none",
+      }}
+    >
+      {icon}
+      <div
+        style={{
+          fontSize: 24,
+          fontWeight: 500,
+        }}
+      >
+        {label}
+      </div>
+    </div>
+  );
+}
+
+const InputFieldCompound = Object.assign(InputField, {
+  Badge: InputFieldBadge,
+});
+
+export { InputFieldCompound as InputField };


### PR DESCRIPTION
- `action` is now `contextual`.
- `label` and `actionLabel` have been replaced by a single `label` prop, accepting an object with `start` and/or `end`.
- `secondaryStart` and `secondaryEnd` have been replaced by a single `secondary` prop, accepting an object with `start` and/or `end`.
- InputField now provides the `InputField.Badge` component for convenience.