### PR TITLE
chore: rename INITIAL_REDEMPTION_RATE -> INITIAL_BASE_RATE

### DIFF
--- a/contracts/src/CollateralRegistry.sol
+++ b/contracts/src/CollateralRegistry.sol
@@ -89,10 +89,9 @@ contract CollateralRegistry is LiquityBase, ICollateralRegistry {
         token9 = numTokens > 9 ? _tokens[9] : IERC20(address(0));
         troveManager9 = numTokens > 9 ? _troveManagers[9] : ITroveManager(address(0));
 
-        // Update the baseRate state variable
-        // To prevent redemptions unless Bold depegs below 0.95 and allow the system to take off
-        baseRate = INITIAL_REDEMPTION_RATE;
-        emit BaseRateUpdated(INITIAL_REDEMPTION_RATE);
+        // Initialize the baseRate state variable
+        baseRate = INITIAL_BASE_RATE;
+        emit BaseRateUpdated(INITIAL_BASE_RATE);
     }
 
     struct RedemptionTotals {

--- a/contracts/src/Dependencies/Constants.sol
+++ b/contracts/src/Dependencies/Constants.sol
@@ -35,7 +35,7 @@ uint256 constant REDEMPTION_MINUTE_DECAY_FACTOR = 999037758833783000;
 uint256 constant REDEMPTION_BETA = 2;
 
 // To prevent redemptions unless Bold depegs below 0.95 and allow the system to take off
-uint256 constant INITIAL_REDEMPTION_RATE = 5 * _1pct; // 5%
+uint256 constant INITIAL_BASE_RATE = 5 * _1pct - REDEMPTION_FEE_FLOOR; // 5% initial redemption rate
 
 // Discount to be used once the shutdown thas been triggered
 uint256 constant URGENT_REDEMPTION_BONUS = 1e16; // 1%

--- a/contracts/src/test/troveManager.t.sol
+++ b/contracts/src/test/troveManager.t.sol
@@ -55,12 +55,12 @@ contract TroveManagerTest is DevTestSetup {
         assertLt(collB2, collB1, "B coll mismatch");
     }
 
-    function testInitialRedemptionBaseRate() public {
-        assertEq(collateralRegistry.baseRate(), 5e16);
+    function testInitialRedemptionBaseRate() public view {
+        assertEq(collateralRegistry.baseRate(), INITIAL_BASE_RATE);
     }
 
     function testRedemptionBaseRateAfter2Weeks() public {
-        assertEq(collateralRegistry.baseRate(), 5e16);
+        assertEq(collateralRegistry.baseRate(), INITIAL_BASE_RATE);
 
         // Two weeks go by
         vm.warp(block.timestamp + 14 days);


### PR DESCRIPTION
The name was misleading. Also, calculate INITIAL_BASE_RATE such that it results in 5% (TBD) initial redemption rate, as intended.