### PR TITLE
Testnet ETH price

### DIFF
--- a/contracts/src/test/TestContracts/PriceFeedTestnet.sol
+++ b/contracts/src/test/TestContracts/PriceFeedTestnet.sol
@@ -12,7 +12,6 @@ contract PriceFeedTestnet is IPriceFeedTestnet {
     event LastGoodPriceUpdated(uint256 _lastGoodPrice);
 
     uint256 private _price = 200 * 1e18;
-    uint256 public lastGoodPrice = 200 * 1e18;
 
     // --- Functions ---
 


### PR DESCRIPTION
- ~Add `lastGoodPrice` to the `PriceFeedTestnet` contract.~ (was implemented in `main`)
- Use it to fetch the latest price from the app.