### PR TITLE
InputField: support mini tabs

### DIFF
--- a/frontend/uikit-gallery/src/InputField/3. Interest.fixture.tsx
+++ b/frontend/uikit-gallery/src/InputField/3. Interest.fixture.tsx
@@ -81,6 +81,7 @@ export default function InputFieldFixture() {
               alignItems: "center",
               justifyContent: "center",
               width: 300,
+              marginRight: -16,
             }}
           >
             <Slider

--- a/frontend/uikit-gallery/src/InputField/5. Tabs.fixture.tsx
+++ b/frontend/uikit-gallery/src/InputField/5. Tabs.fixture.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import { InputField, Tabs, TextButton, TokenIcon } from "@liquity2/uikit";
+import * as dn from "dnum";
+import { useState } from "react";
+import { useFixtureInput } from "react-cosmos/client";
+
+function isInputValueFloat(value: string) {
+  value = value.trim();
+  return value && /^[0-9]*\.?[0-9]*?$/.test(value);
+}
+function parseInputFloat(value: string) {
+  value = value.trim();
+  if (!isInputValueFloat(value)) {
+    return null;
+  }
+  value = value
+    .replace(/\.$/, "")
+    .replace(/^\./, "0.");
+  return dn.from(value === "" ? 0 : value, 18);
+}
+
+export default function InputFieldFixture() {
+  const [value, setValue] = useFixtureInput("value", "");
+  const parsedValue = parseInputFloat(value);
+
+  const [tab, setTab] = useState(0);
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "center",
+        width: 640,
+        padding: 16,
+      }}
+    >
+      <InputField
+        contextual={
+          <InputTokenBadge
+            icon={<TokenIcon symbol="ETH" />}
+            label="ETH"
+          />
+        }
+        label={{
+          start: "Increase your collateral",
+          end: (
+            <Tabs
+              compact
+              items={[
+                { label: "Deposit", panelId: "panel-deposit", tabId: "tab-deposit" },
+                { label: "Withdraw", panelId: "panel-withdraw", tabId: "tab-withdraw" },
+              ]}
+              onSelect={setTab}
+              selected={tab}
+            />
+          ),
+        }}
+        labelHeight={32}
+        onChange={setValue}
+        value={value}
+        valueUnfocused={parsedValue
+          ? (
+            <span
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 12,
+              }}
+            >
+              <span
+                style={{
+                  fontVariantNumeric: "tabular-nums",
+                }}
+              >
+                {dn.format(parsedValue, { digits: 1, trailingZeros: true })}
+              </span>
+              <span
+                style={{
+                  color: "#878AA4",
+                  fontSize: 24,
+                }}
+              >
+                % per year
+              </span>
+            </span>
+          )
+          : null}
+        placeholder="0.00"
+        secondary={{
+          start: "$0.00",
+          end: (
+            <TextButton
+              label={`Max 4.67 ETH`}
+              onClick={() => {
+                // deposit.setValue(dn.toString(ethMax));
+              }}
+            />
+          ),
+        }}
+      />
+    </div>
+  );
+}
+
+function InputTokenBadge({
+  label,
+  icon,
+}: {
+  label: ReactNode;
+  icon?: ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        height: 40,
+        padding: 0,
+        fontSize: 24,
+        fontWeight: 500,
+        borderRadius: 20,
+        userSelect: "none",
+      }}
+    >
+      {icon}
+      <div>
+        {label}
+      </div>
+    </div>
+  );
+}

--- a/frontend/uikit-gallery/src/InputField/shared.tsx
+++ b/frontend/uikit-gallery/src/InputField/shared.tsx
@@ -86,6 +86,7 @@ export function InputFieldFixture({
           alignItems: "center",
           justifyContent: "center",
           width: 300,
+          marginRight: -16,
         }}
       >
         <Slider

--- a/frontend/uikit/src/InputField/InputField.tsx
+++ b/frontend/uikit/src/InputField/InputField.tsx
@@ -7,48 +7,48 @@ import { css, cx } from "../../styled-system/css";
 import { IconCross } from "../icons";
 import { useElementSize } from "../react-utils";
 
-type InputFieldProps = {
-  contextual?: ReactNode;
-  difference?: ReactNode;
-  label?:
-    | ReactNode
-    | { end: ReactNode; start?: ReactNode }
-    | { end?: ReactNode; start: ReactNode };
-  onBlur?: () => void;
-  onChange?: (value: string) => void;
-  onDifferenceClick?: () => void;
-  onFocus?: () => void;
-  paddingBottom?: number;
-  placeholder?: string;
-  secondary?:
-    | ReactNode
-    | { end: ReactNode; start?: ReactNode }
-    | { end?: ReactNode; start: ReactNode };
-  value?: string;
-  valueUnfocused?: ReactNode;
-};
-
 const diffSpringConfig = {
   mass: 1,
   tension: 3000,
   friction: 120,
 };
 
-const INPUT_HEIGHT = 120;
-const CONTEXTUAL_HEIGHT = 40;
-const CONTEXTUAL_TOP = (INPUT_HEIGHT - CONTEXTUAL_HEIGHT) / 2;
-
-const InputField = forwardRef<HTMLInputElement, InputFieldProps>(function InputField({
+const InputField = forwardRef<HTMLInputElement, {
+  contextual?: ReactNode;
+  difference?: ReactNode;
+  label?:
+    | ReactNode
+    | { end: ReactNode; start?: ReactNode }
+    | { end?: ReactNode; start: ReactNode };
+  labelHeight?: number;
+  labelSpacing?: number;
+  onBlur?: () => void;
+  onChange?: (value: string) => void;
+  onDifferenceClick?: () => void;
+  onFocus?: () => void;
+  placeholder?: string;
+  secondary?:
+    | ReactNode
+    | { end: ReactNode; start?: ReactNode }
+    | { end?: ReactNode; start: ReactNode };
+  secondaryHeight?: number;
+  secondarySpacing?: number;
+  value?: string;
+  valueUnfocused?: ReactNode;
+}>(function InputField({
   contextual,
   difference,
   label,
+  labelHeight = 12,
+  labelSpacing = 12,
   onBlur,
   onChange,
   onDifferenceClick,
   onFocus,
-  paddingBottom = 12,
   placeholder,
   secondary,
+  secondaryHeight = 12,
+  secondarySpacing = 20,
   value,
   valueUnfocused,
 }, ref) {
@@ -131,19 +131,22 @@ const InputField = forwardRef<HTMLInputElement, InputFieldProps>(function InputF
         background: "fieldSurface",
         border: "1px solid token(colors.fieldBorder)",
         borderRadius: 8,
+        padding: 16,
       })}
     >
       <div
         className={css({
-          position: "absolute",
-          inset: "0 0 auto 0",
           display: "flex",
           justifyContent: "space-between",
           alignItems: "center",
-          padding: "12px 16px 0",
           fontSize: 16,
+          fontWeight: 500,
           color: "contentAlt",
         })}
+        style={{
+          height: labelHeight + labelSpacing,
+          paddingBottom: labelSpacing,
+        }}
       >
         {label_.start ? <label htmlFor={id}>{label_.start}</label> : <div />}
         {label_.end && <div>{label_.end}</div>}
@@ -197,93 +200,93 @@ const InputField = forwardRef<HTMLInputElement, InputFieldProps>(function InputF
           <IconCross size={12} />
         </a.button>
       )}
-      <input
-        ref={ref}
-        id={id}
-        onBlur={() => {
-          setFocused(false);
-          onBlur?.();
-        }}
-        onChange={(event) => {
-          onChange?.(event.target.value);
-        }}
-        onFocus={() => {
-          setFocused(true);
-          onFocus?.();
-        }}
-        placeholder={showValueUnfocused ? "" : placeholder}
-        type="text"
-        value={showValueUnfocused ? "" : value}
-        className={cx(
-          "peer",
-          css({
-            display: "block",
-            height: INPUT_HEIGHT - 2, // account for the 1px border
-            padding: "0 16px",
-            fontSize: 28,
-            fontWeight: 500,
-            letterSpacing: -1,
-            color: "content",
-            background: "transparent",
-            border: 0,
-            _placeholder: {
-              color: "dimmed",
-            },
-            _focusVisible: {
-              outline: 0,
-            },
-          }),
-        )}
-      />
-      {showValueUnfocused && (
-        <div
-          className={css({
-            position: "absolute",
-            inset: "0 0 auto 16px",
-            display: "flex",
-            alignItems: "center",
-            height: INPUT_HEIGHT - 2, // account for the 1px border
-            fontSize: 28,
-            fontWeight: 500,
-            letterSpacing: -1,
-            color: "content",
-            pointerEvents: "none",
-          })}
-        >
-          {valueUnfocused}
-        </div>
-      )}
       <div
         className={css({
-          display: "none",
-          position: "absolute",
-          inset: -1,
-          border: "2px solid token(colors.fieldBorderFocused)",
-          borderRadius: 8,
-          pointerEvents: "none",
-          _peerFocusVisible: {
-            display: "block",
-          },
+          position: "relative",
+          zIndex: 1,
+          display: "flex",
+          height: 40,
         })}
-      />
-      {contextual && (
-        <div
-          className={css({
-            position: "absolute",
-            inset: `${CONTEXTUAL_TOP}px 16px auto auto`,
-          })}
-        >
-          {contextual}
-        </div>
-      )}
+      >
+        <input
+          ref={ref}
+          id={id}
+          onBlur={() => {
+            setFocused(false);
+            onBlur?.();
+          }}
+          onChange={(event) => {
+            onChange?.(event.target.value);
+          }}
+          onFocus={() => {
+            setFocused(true);
+            onFocus?.();
+          }}
+          placeholder={showValueUnfocused ? "" : placeholder}
+          type="text"
+          value={showValueUnfocused ? "" : value}
+          className={cx(
+            "peer",
+            css({
+              display: "block",
+              padding: 0,
+              width: "100%",
+              height: "100%",
+              fontSize: 28,
+              fontWeight: 500,
+              letterSpacing: -1,
+              color: "content",
+              background: "transparent",
+              border: 0,
+              _placeholder: {
+                color: "dimmed",
+              },
+              _focusVisible: {
+                outline: 0,
+              },
+            }),
+          )}
+        />
+        {showValueUnfocused && (
+          <div
+            className={css({
+              position: "absolute",
+              inset: 0,
+              display: "flex",
+              alignItems: "center",
+              height: "100%",
+              fontSize: 28,
+              fontWeight: 500,
+              letterSpacing: -1,
+              color: "content",
+              pointerEvents: "none",
+            })}
+          >
+            {valueUnfocused}
+          </div>
+        )}
+        {contextual && (
+          <div
+            className={css({
+              position: "absolute",
+              zIndex: 2,
+              inset: `50% 0 auto auto`,
+              transform: "translateY(-50%)",
+            })}
+          >
+            {contextual}
+          </div>
+        )}
+      </div>
       {(secondary_.start || secondary_.end) && (
         <div
           className={css({
             display: "flex",
             justifyContent: "space-between",
-            marginTop: -20,
+            alignItems: "center",
             gap: 16,
             fontSize: 16,
+            fontWeight: 500,
             color: "contentAlt",
             pointerEvents: "none",
             "& > div": {
@@ -291,7 +294,8 @@ const InputField = forwardRef<HTMLInputElement, InputFieldProps>(function InputF
             },
           })}
           style={{
-            padding: `0 16px ${paddingBottom}px`,
+            height: secondaryHeight + secondarySpacing,
+            paddingTop: secondarySpacing,
           }}
         >
           {secondary_.start
@@ -325,6 +329,19 @@ const InputField = forwardRef<HTMLInputElement, InputFieldProps>(function InputF
           )}
         </div>
       )}
+      <div
+        className={css({
+          display: "none",
+          position: "absolute",
+          inset: -1,
+          border: "2px solid token(colors.fieldBorderFocused)",
+          borderRadius: 8,
+          pointerEvents: "none",
+        })}
+        style={{
+          display: focused ? "block" : "none",
+        }}
+      />
     </div>
   );
 });

--- a/frontend/uikit/src/Tabs/Tabs.tsx
+++ b/frontend/uikit/src/Tabs/Tabs.tsx
@@ -24,10 +24,12 @@ export type TabItem = {
 // [2] https://www.w3.org/WAI/ARIA/apg/patterns/tabs/examples/tabs-automatic/
 
 export function Tabs({
+  compact,
   items,
   onSelect,
   selected,
 }: {
+  compact?: boolean;
   items: TabItem[];
   onSelect: (index: number) => void;
   selected: number;
@@ -80,6 +82,43 @@ export function Tabs({
     size, // update on container size change too
   ]);
 
+  const styles = compact
+    ? {
+      container: {
+        height: 32,
+        "--background": token("colors.controlSurface"),
+        "--border": `1px solid ${token("colors.border")}`,
+        borderRadius: 16,
+      },
+      activeTab: {
+        border: 0,
+        "--background": token("colors.accent"),
+        borderRadius: 12,
+      },
+      activeTabContent: {
+        // color: token("colors.accentContent"),
+        color: token(`colors.${selected ? "selected" : "interactive"}`),
+      },
+      tabsGap: 0,
+    }
+    : {
+      container: {
+        height: 44,
+        "--background": token("colors.fieldSurface"),
+        "--border": "0",
+        borderRadius: 8,
+      },
+      activeTab: {
+        border: "1px solid token(colors.border)",
+        "--background": token("colors.controlSurface"),
+        borderRadius: 8,
+      },
+      activeTabContent: {
+        color: token(`colors.${selected ? "selected" : "interactive"}`),
+      },
+      tabsGap: 8,
+    };
+
   return (
     <div
       ref={container}
@@ -88,11 +127,11 @@ export function Tabs({
         overflow: "hidden",
         display: "flex",
         width: "100%",
-        height: 44,
         padding: 4,
-        background: "fieldSurface",
-        borderRadius: 12,
+        background: "var(--background)",
+        border: "var(--border)",
       })}
+      style={styles.container}
     >
       <div
         className={css({
@@ -113,17 +152,18 @@ export function Tabs({
             zIndex: 2,
             display: "grid",
             gridTemplateRows: "1fr",
-            gap: 8,
             width: "100%",
             height: "100%",
           })}
           style={{
             gridTemplateColumns: `repeat(${items.length}, 1fr)`,
+            gap: styles.tabsGap,
           }}
         >
           {items.map((item, index) => (
             <Tab
               key={index}
+              compact={compact}
               onSelect={() => onSelect(index)}
               selected={index === selected}
               tabItem={item}
@@ -131,20 +171,21 @@ export function Tabs({
           ))}
         </div>
         <a.div
-          style={{
-            transform: barSpring.transform,
-            width: barSpring.width,
-          }}
           className={css({
             position: "absolute",
             zIndex: 1,
             inset: "0 auto 0 0",
             width: 0,
-            background: "controlSurface",
+            background: "var(--background)",
             border: "1px solid token(colors.border)",
             transformOrigin: "0 0",
             borderRadius: 8,
           })}
+          style={{
+            transform: barSpring.transform,
+            width: barSpring.width,
+            ...styles.activeTab,
+          }}
         />
       </div>
     </div>
@@ -152,14 +193,27 @@ export function Tabs({
 }
 
 function Tab({
+  compact,
   onSelect,
   selected,
   tabItem: { label, tabId, panelId },
 }: {
+  compact?: boolean;
   onSelect: () => void;
   selected: boolean;
   tabItem: TabItem;
 }) {
+  const styles = compact
+    ? {
+      activeTabContent: {
+        color: selected ? token("colors.accentContent") : token("colors.interactive"),
+      },
+    }
+    : {
+      activeTabContent: {
+        color: selected ? token("colors.selected") : token("colors.interactive"),
+      },
+    };
   return (
     <button
       aria-controls={panelId}
@@ -174,24 +228,21 @@ function Tab({
         alignItems: "center",
         justifyContent: "center",
         height: "100%",
-        padding: "0 16px",
         fontSize: 16,
         color: "interactive",
         cursor: "pointer",
         whiteSpace: "nowrap",
         textOverflow: "ellipsis",
         overflow: "hidden",
-        _active: {
-          translate: "0 1px",
-        },
         _focusVisible: {
           outline: "2px solid token(colors.focused)",
-          outlineOffset: -2,
           borderRadius: 8,
         },
       })}
       style={{
-        color: token(`colors.${selected ? "selected" : "interactive"}`),
+        color: styles.activeTabContent.color,
+        padding: compact ? "0 12px" : "0 16px",
+        outlineOffset: compact ? 1 : -2,
       }}
     >
       {label}


### PR DESCRIPTION
Changes:

- InputField: reimplement the layout to get closer to the different Figma variants.
- Tabs: add a compact mode.
- Add gallery examples.

![image](https://github.com/user-attachments/assets/cb82f47e-380c-46c7-b421-bd69e88f5431)
