### PR TITLE
fix: wrong coll & agg. accrual after `applyPendingDebt()`

### DIFF
--- a/contracts/src/BorrowerOperations.sol
+++ b/contracts/src/BorrowerOperations.sol
@@ -765,10 +765,11 @@ contract BorrowerOperations is LiquityBase, AddRemoveManagers, IBorrowerOperatio
             batch = troveManagerCached.getLatestBatchData(batchManager);
             change.batchAccruedManagementFee = batch.accruedManagementFee;
             change.oldWeightedRecordedDebt = batch.weightedRecordedDebt;
-            change.newWeightedRecordedDebt = batch.entireDebtWithoutRedistribution * batch.annualInterestRate;
+            change.newWeightedRecordedDebt =
+                (batch.entireDebtWithoutRedistribution + trove.redistBoldDebtGain) * batch.annualInterestRate;
             change.oldWeightedRecordedBatchManagementFee = batch.weightedRecordedBatchManagementFee;
             change.newWeightedRecordedBatchManagementFee =
-                batch.entireDebtWithoutRedistribution * batch.annualManagementFee;
+                (batch.entireDebtWithoutRedistribution + trove.redistBoldDebtGain) * batch.annualManagementFee;
         }
 
         troveManagerCached.onApplyTroveInterest(

--- a/contracts/src/TroveManager.sol
+++ b/contracts/src/TroveManager.sol
@@ -1505,6 +1505,8 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
     ) external {
         _requireCallerIsBorrowerOperations();
 
+        Troves[_troveId].coll = _newTroveColl;
+
         if (_batchAddress != address(0)) {
             _updateBatchShares(_troveId, _batchAddress, _troveChange, _newBatchColl, _newBatchDebt);
 
@@ -1518,7 +1520,6 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
                 batches[_batchAddress].totalDebtShares
             );
         } else {
-            Troves[_troveId].coll = _newTroveColl;
             Troves[_troveId].debt = _newTroveDebt;
             Troves[_troveId].lastDebtUpdateTime = uint64(block.timestamp);
         }


### PR DESCRIPTION
It seems we forgot to move the coll update for batched Troves into `onApplyTroveInterest()` after removing it from `_updateBatchShares()`. Also, we were ignoring applied redistributed debt when updating agg. weighted sums.

Fixes #301.