### PR TITLE
fix: Always set managers on opening troves through zappers

### DIFF
--- a/contracts/src/Zappers/GasCompZapper.sol
+++ b/contracts/src/Zappers/GasCompZapper.sol
@@ -37,6 +37,9 @@ contract GasCompZapper is AddRemoveManagers {
         uint256 lowerHint;
         uint256 annualInterestRate;
         uint256 maxUpfrontFee;
+        address addManager;
+        address removeManager;
+        address receiver;
     }
 
     struct OpenTroveVars {
@@ -81,6 +84,10 @@ contract GasCompZapper is AddRemoveManagers {
         );
 
         boldToken.transfer(msg.sender, _params.boldAmount);
+
+        // Set add/remove managers
+        _setAddManager(vars.troveId, _params.addManager);
+        _setRemoveManagerAndReceiver(vars.troveId, _params.removeManager, _params.receiver);
 
         return vars.troveId;
     }

--- a/contracts/src/Zappers/WETHZapper.sol
+++ b/contracts/src/Zappers/WETHZapper.sol
@@ -30,6 +30,9 @@ contract WETHZapper is AddRemoveManagers {
         uint256 lowerHint;
         uint256 annualInterestRate;
         uint256 maxUpfrontFee;
+        address addManager;
+        address removeManager;
+        address receiver;
     }
 
     struct OpenTroveVars {
@@ -68,6 +71,10 @@ contract WETHZapper is AddRemoveManagers {
         );
 
         boldToken.transfer(msg.sender, _params.boldAmount);
+
+        // Set add/remove managers
+        _setAddManager(vars.troveId, _params.addManager);
+        _setRemoveManagerAndReceiver(vars.troveId, _params.removeManager, _params.receiver);
 
         return vars.troveId;
     }

--- a/contracts/src/test/zapperGasComp.t.sol
+++ b/contracts/src/test/zapperGasComp.t.sol
@@ -77,7 +77,10 @@ contract ZapperGasCompTest is DevTestSetup {
             upperHint: 0,
             lowerHint: 0,
             annualInterestRate: 5e16,
-            maxUpfrontFee: 1000e18
+            maxUpfrontFee: 1000e18,
+            addManager: address(0),
+            removeManager: address(0),
+            receiver: address(0)
         });
         vm.startPrank(A);
         uint256 troveId = gasCompZapper.openTroveWithRawETH{value: ETH_GAS_COMPENSATION}(params);
@@ -105,7 +108,10 @@ contract ZapperGasCompTest is DevTestSetup {
             upperHint: 0,
             lowerHint: 0,
             annualInterestRate: 5e16,
-            maxUpfrontFee: 1000e18
+            maxUpfrontFee: 1000e18,
+            addManager: address(0),
+            removeManager: address(0),
+            receiver: address(0)
         });
         vm.startPrank(A);
         uint256 troveId = gasCompZapper.openTroveWithRawETH{value: ETH_GAS_COMPENSATION}(params);
@@ -135,7 +141,10 @@ contract ZapperGasCompTest is DevTestSetup {
             upperHint: 0,
             lowerHint: 0,
             annualInterestRate: 5e16,
-            maxUpfrontFee: 1000e18
+            maxUpfrontFee: 1000e18,
+            addManager: address(0),
+            removeManager: address(0),
+            receiver: address(0)
         });
         vm.startPrank(A);
         uint256 troveId = gasCompZapper.openTroveWithRawETH{value: ETH_GAS_COMPENSATION}(params);
@@ -165,7 +174,10 @@ contract ZapperGasCompTest is DevTestSetup {
             upperHint: 0,
             lowerHint: 0,
             annualInterestRate: MIN_ANNUAL_INTEREST_RATE,
-            maxUpfrontFee: 1000e18
+            maxUpfrontFee: 1000e18,
+            addManager: address(0),
+            removeManager: address(0),
+            receiver: address(0)
         });
         vm.startPrank(A);
         uint256 troveId = gasCompZapper.openTroveWithRawETH{value: ETH_GAS_COMPENSATION}(params);
@@ -211,7 +223,10 @@ contract ZapperGasCompTest is DevTestSetup {
             upperHint: 0,
             lowerHint: 0,
             annualInterestRate: MIN_ANNUAL_INTEREST_RATE,
-            maxUpfrontFee: 1000e18
+            maxUpfrontFee: 1000e18,
+            addManager: address(0),
+            removeManager: address(0),
+            receiver: address(0)
         });
         vm.startPrank(A);
         uint256 troveId = gasCompZapper.openTroveWithRawETH{value: ETH_GAS_COMPENSATION}(params);
@@ -257,7 +272,10 @@ contract ZapperGasCompTest is DevTestSetup {
             upperHint: 0,
             lowerHint: 0,
             annualInterestRate: MIN_ANNUAL_INTEREST_RATE,
-            maxUpfrontFee: 1000e18
+            maxUpfrontFee: 1000e18,
+            addManager: address(0),
+            removeManager: address(0),
+            receiver: address(0)
         });
         vm.startPrank(A);
         uint256 troveId = gasCompZapper.openTroveWithRawETH{value: ETH_GAS_COMPENSATION}(params);
@@ -303,7 +321,10 @@ contract ZapperGasCompTest is DevTestSetup {
             upperHint: 0,
             lowerHint: 0,
             annualInterestRate: MIN_ANNUAL_INTEREST_RATE,
-            maxUpfrontFee: 1000e18
+            maxUpfrontFee: 1000e18,
+            addManager: address(0),
+            removeManager: address(0),
+            receiver: address(0)
         });
         vm.startPrank(A);
         uint256 troveId = gasCompZapper.openTroveWithRawETH{value: ETH_GAS_COMPENSATION}(params);
@@ -354,7 +375,10 @@ contract ZapperGasCompTest is DevTestSetup {
             upperHint: 0,
             lowerHint: 0,
             annualInterestRate: MIN_ANNUAL_INTEREST_RATE,
-            maxUpfrontFee: 1000e18
+            maxUpfrontFee: 1000e18,
+            addManager: address(0),
+            removeManager: address(0),
+            receiver: address(0)
         });
         vm.startPrank(A);
         uint256 troveId = gasCompZapper.openTroveWithRawETH{value: ETH_GAS_COMPENSATION}(params);

--- a/contracts/src/test/zapperWETH.t.sol
+++ b/contracts/src/test/zapperWETH.t.sol
@@ -68,7 +68,10 @@ contract ZapperWETHTest is DevTestSetup {
             upperHint: 0,
             lowerHint: 0,
             annualInterestRate: 5e16,
-            maxUpfrontFee: 1000e18
+            maxUpfrontFee: 1000e18,
+            addManager: address(0),
+            removeManager: address(0),
+            receiver: address(0)
         });
         vm.startPrank(A);
         uint256 troveId = wethZapper.openTroveWithRawETH{value: ethAmount + ETH_GAS_COMPENSATION}(params);
@@ -94,7 +97,10 @@ contract ZapperWETHTest is DevTestSetup {
             upperHint: 0,
             lowerHint: 0,
             annualInterestRate: 5e16,
-            maxUpfrontFee: 1000e18
+            maxUpfrontFee: 1000e18,
+            addManager: address(0),
+            removeManager: address(0),
+            receiver: address(0)
         });
         vm.startPrank(A);
         uint256 troveId = wethZapper.openTroveWithRawETH{value: ethAmount1 + ETH_GAS_COMPENSATION}(params);
@@ -123,7 +129,10 @@ contract ZapperWETHTest is DevTestSetup {
             upperHint: 0,
             lowerHint: 0,
             annualInterestRate: 5e16,
-            maxUpfrontFee: 1000e18
+            maxUpfrontFee: 1000e18,
+            addManager: address(0),
+            removeManager: address(0),
+            receiver: address(0)
         });
         vm.startPrank(A);
         uint256 troveId = wethZapper.openTroveWithRawETH{value: ethAmount1 + ETH_GAS_COMPENSATION}(params);
@@ -152,7 +161,10 @@ contract ZapperWETHTest is DevTestSetup {
             upperHint: 0,
             lowerHint: 0,
             annualInterestRate: MIN_ANNUAL_INTEREST_RATE,
-            maxUpfrontFee: 1000e18
+            maxUpfrontFee: 1000e18,
+            addManager: address(0),
+            removeManager: address(0),
+            receiver: address(0)
         });
         vm.startPrank(A);
         uint256 troveId = wethZapper.openTroveWithRawETH{value: ethAmount + ETH_GAS_COMPENSATION}(params);
@@ -197,7 +209,10 @@ contract ZapperWETHTest is DevTestSetup {
             upperHint: 0,
             lowerHint: 0,
             annualInterestRate: MIN_ANNUAL_INTEREST_RATE,
-            maxUpfrontFee: 1000e18
+            maxUpfrontFee: 1000e18,
+            addManager: address(0),
+            removeManager: address(0),
+            receiver: address(0)
         });
         vm.startPrank(A);
         uint256 troveId = wethZapper.openTroveWithRawETH{value: ethAmount + ETH_GAS_COMPENSATION}(params);
@@ -242,7 +257,10 @@ contract ZapperWETHTest is DevTestSetup {
             upperHint: 0,
             lowerHint: 0,
             annualInterestRate: MIN_ANNUAL_INTEREST_RATE,
-            maxUpfrontFee: 1000e18
+            maxUpfrontFee: 1000e18,
+            addManager: address(0),
+            removeManager: address(0),
+            receiver: address(0)
         });
         vm.startPrank(A);
         uint256 troveId = wethZapper.openTroveWithRawETH{value: ethAmount1 + ETH_GAS_COMPENSATION}(params);
@@ -287,7 +305,10 @@ contract ZapperWETHTest is DevTestSetup {
             upperHint: 0,
             lowerHint: 0,
             annualInterestRate: MIN_ANNUAL_INTEREST_RATE,
-            maxUpfrontFee: 1000e18
+            maxUpfrontFee: 1000e18,
+            addManager: address(0),
+            removeManager: address(0),
+            receiver: address(0)
         });
         vm.startPrank(A);
         uint256 troveId = wethZapper.openTroveWithRawETH{value: ethAmount1 + ETH_GAS_COMPENSATION}(params);
@@ -334,7 +355,10 @@ contract ZapperWETHTest is DevTestSetup {
             upperHint: 0,
             lowerHint: 0,
             annualInterestRate: MIN_ANNUAL_INTEREST_RATE,
-            maxUpfrontFee: 1000e18
+            maxUpfrontFee: 1000e18,
+            addManager: address(0),
+            removeManager: address(0),
+            receiver: address(0)
         });
         vm.startPrank(A);
         uint256 troveId = wethZapper.openTroveWithRawETH{value: ethAmount + ETH_GAS_COMPENSATION}(params);


### PR DESCRIPTION
As we are no wiping them out in the zapper (as opposed to the core system) when the trove is closed, we make sure they are reset when opening a trove to avoid the frontrunning issue. See: https://github.com/liquity/bold/issues/282