### PR TITLE
fix: underflow when closing Trove that has pending batch management fees

### DIFF
--- a/contracts/src/ActivePool.sol
+++ b/contracts/src/ActivePool.sol
@@ -222,6 +222,11 @@ contract ActivePool is IActivePool {
     {
         _requireCallerIsBOorTroveM();
 
+        // Batch management fees
+        if (_batchAddress != address(0)) {
+            _mintBatchManagementFeeAndAccountForChange(boldToken, _troveChange, _batchAddress);
+        }
+
         // Do the arithmetic in 2 steps here to avoid overflow from the decrease
         uint256 newAggRecordedDebt = aggRecordedDebt; // 1 SLOAD
         newAggRecordedDebt += _mintAggInterest(boldToken, _troveChange.upfrontFee); // adds minted agg. interest + upfront fee
@@ -238,11 +243,6 @@ contract ActivePool is IActivePool {
         newAggWeightedDebtSum += _troveChange.newWeightedRecordedDebt;
         newAggWeightedDebtSum -= _troveChange.oldWeightedRecordedDebt;
         aggWeightedDebtSum = newAggWeightedDebtSum; // 1 SSTORE
-
-        // Batch management fees
-        if (_batchAddress != address(0)) {
-            _mintBatchManagementFeeAndAccountForChange(boldToken, _troveChange, _batchAddress);
-        }
     }
 
     function mintAggInterest() external override {


### PR DESCRIPTION
The issue occured when all the remaining Troves had debt from nothing but pending redistributions. This can happen if there's a liquidation by redistribution following a redemption that turns many Troves into zero-debt zombies.

Fixes #361.