### PR TITLE
App: add delegate selection on the interest rate field

### DIFF
--- a/frontend/app/src/comps/InterestRateField/InterestRateField.tsx
+++ b/frontend/app/src/comps/InterestRateField/InterestRateField.tsx
@@ -1,0 +1,526 @@
+import type { Dnum } from "dnum";
+import type { ReactNode } from "react";
+
+import { INTEREST_RATE_DEFAULT, INTEREST_RATE_INCREMENT, INTEREST_RATE_MAX, INTEREST_RATE_MIN } from "@/src/constants";
+import content from "@/src/content";
+import { DELEGATES, getDebtBeforeRateBucketIndex, INTEREST_CHART } from "@/src/demo-mode";
+import { useInputFieldValue } from "@/src/form-utils";
+import { fmtnum, formatRedemptionRisk } from "@/src/formatting";
+import { getRedemptionRisk } from "@/src/liquity-math";
+import { infoTooltipProps, riskLevelToStatusMode } from "@/src/uikit-utils";
+import { css } from "@/styled-system/css";
+import {
+  Button,
+  Dropdown,
+  HFlex,
+  IconCopy,
+  IconExternal,
+  InfoTooltip,
+  InputField,
+  lerp,
+  Modal,
+  norm,
+  Slider,
+  StatusDot,
+  TextButton,
+} from "@liquity2/uikit";
+import * as dn from "dnum";
+import { useState } from "react";
+
+const MODES = [
+  {
+    label: "Manually",
+    value: "manual",
+    secondary: "Set the interest rate as you see fit",
+  },
+  {
+    label: "By Strategy",
+    value: "strategy",
+    secondary: "It’s an automated strategy developed by ICP that helps avoid redemption and reduce costs",
+  },
+  {
+    label: "By Delegation",
+    value: "delegation",
+    secondary: `
+      Delegates manage your interest rate, optimizing costs and preventing redemption.
+      They charge a fee for this.
+    `,
+  },
+] as const;
+
+export function InterestRateField({
+  debt,
+  interestRate,
+  onChange,
+}: {
+  debt: Dnum | null;
+  interestRate: Dnum | null;
+  onChange: (interestRate: Dnum) => void;
+}) {
+  const [delegate, setDelegate] = useState<typeof DELEGATES[number]["id"] | null>(null);
+  const [showDelegatePicker, setShowDelegatePicker] = useState(false);
+
+  const fieldValue = useInputFieldValue((value) => `${fmtnum(value)}%`, {
+    defaultValue: interestRate
+      ? dn.toString(dn.mul(interestRate, 100))
+      : String(INTEREST_RATE_DEFAULT),
+    onChange: ({ parsed }) => {
+      if (parsed) {
+        onChange(dn.div(parsed, 100));
+      }
+    },
+  });
+
+  const boldInterestPerYear = interestRate && debt && dn.mul(interestRate, debt);
+
+  const boldRedeemableInFront = getDebtBeforeRateBucketIndex(
+    interestRate
+      ? Math.round((dn.toNumber(interestRate) * 100 - INTEREST_RATE_MIN) / INTEREST_RATE_INCREMENT)
+      : 0,
+  );
+
+  const [selectedMode, setSelectedMode] = useState<number>(0);
+
+  return (
+    <>
+      <InputField
+        labelHeight={32}
+        labelSpacing={24}
+        contextual={delegate === null
+          ? (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                width: 300,
+              }}
+            >
+              <Slider
+                gradient={[1 / 3, 2 / 3]}
+                chart={INTEREST_CHART}
+                onChange={(value) => {
+                  fieldValue.setValue(String(
+                    Math.round(
+                      lerp(
+                        INTEREST_RATE_MIN,
+                        INTEREST_RATE_MAX,
+                        value,
+                      ) * 10,
+                    ) / 10,
+                  ));
+                }}
+                value={norm(
+                  interestRate ? dn.toNumber(dn.mul(interestRate, 100)) : 0,
+                  INTEREST_RATE_MIN,
+                  INTEREST_RATE_MAX,
+                )}
+              />
+            </div>
+          )
+          : (
+            <Button
+              size="small"
+              mode="primary"
+              label={DELEGATES.find(({ id }) => id === delegate)?.name}
+              onClick={() => {
+                setShowDelegatePicker(true);
+              }}
+            />
+          )}
+        label={{
+          start: "Set interest rate",
+          end: (
+            <div>
+              <Dropdown
+                items={MODES}
+                menuWidth={300}
+                onSelect={(mode) => {
+                  if (mode === 2) {
+                    setShowDelegatePicker(true);
+                    return;
+                  }
+                  if (mode === 1) {
+                    // strategy selection
+                    return;
+                  }
+
+                  setSelectedMode(mode);
+                  setDelegate(null);
+                }}
+                selected={selectedMode}
+                size="small"
+              />
+            </div>
+          ),
+        }}
+        placeholder="0.00"
+        secondary={{
+          start: (
+            <HFlex gap={4}>
+              <div>
+                {boldInterestPerYear
+                  ? fmtnum(boldInterestPerYear, 2)
+                  : "−"} BOLD / year
+              </div>
+              <InfoTooltip {...infoTooltipProps(content.borrowScreen.infoTooltips.interestRateBoldPerYear)} />
+            </HFlex>
+          ),
+          end: (
+            <span>
+              <span>{"Before you "}</span>
+              <span
+                className={css({
+                  color: "content",
+                })}
+              >
+                <span
+                  className={css({
+                    fontVariantNumeric: "tabular-nums",
+                  })}
+                >
+                  {fmtnum(boldRedeemableInFront, "compact")}
+                </span>
+                <span>{" BOLD to redeem"}</span>
+              </span>
+            </span>
+          ),
+        }}
+        {...fieldValue.inputFieldProps}
+        value={fieldValue.value}
+        valueUnfocused={(!fieldValue.isEmpty && fieldValue.parsed && interestRate)
+          ? (
+            <span
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+              }}
+            >
+              {delegate !== null && <MiniChart size="medium" />}
+              <span
+                style={{
+                  fontVariantNumeric: "tabular-nums",
+                }}
+              >
+                {fmtnum(interestRate, "1z", 100)}
+              </span>
+              <span
+                style={{
+                  color: "#878AA4",
+                  fontSize: 24,
+                }}
+              >
+                % per year
+              </span>
+            </span>
+          )
+          : null}
+      />
+      <Modal
+        onClose={() => {
+          setShowDelegatePicker(false);
+        }}
+        title={`${DELEGATES.length} delegates`}
+        visible={showDelegatePicker}
+      >
+        <DelegatesModalContent
+          onSelectDelegate={(id) => {
+            const delegate = DELEGATES.find((delegate) => delegate.id === id);
+            setDelegate(delegate ? id : null);
+            setSelectedMode(delegate ? 2 : 0);
+            if (delegate) {
+              onChange(delegate.interestRate);
+            }
+            setShowDelegatePicker(false);
+          }}
+        />
+      </Modal>
+    </>
+  );
+}
+
+function DelegatesModalContent({
+  onSelectDelegate,
+}: {
+  onSelectDelegate: (id: typeof DELEGATES[number]["id"]) => void;
+}) {
+  const [displayedDelegates, setDisplayedDelegates] = useState(5);
+  return (
+    <>
+      <div
+        className={css({
+          fontSize: 16,
+          color: "contentAlt",
+        })}
+      >
+        Delegates manage your interest rate, optimizing costs and preventing redemption. They charge a fee for this.
+      </div>
+      <div
+        className={css({
+          display: "flex",
+          flexDirection: "column",
+          gap: 8,
+          paddingTop: 32,
+          paddingBottom: 24,
+        })}
+      >
+        {DELEGATES.slice(0, displayedDelegates).map((delegate) => {
+          const delegationRisk = getRedemptionRisk(delegate.interestRate);
+          return (
+            <ShadowBox key={delegate.id}>
+              <section
+                key={delegate.name}
+                className={css({
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  padding: "8px 16px",
+                })}
+              >
+                <div
+                  className={css({
+                    display: "flex",
+                    flexDirection: "column",
+                    width: "100%",
+                    paddingBottom: 12,
+                    borderBottom: "1px solid token(colors.borderSoft)",
+                  })}
+                >
+                  <div
+                    className={css({
+                      display: "flex",
+                      justifyContent: "space-between",
+                      alignItems: "center",
+                      width: "100%",
+                      fontSize: 20,
+                      fontWeight: 500,
+                    })}
+                  >
+                    <h1>
+                      {delegate.name}
+                    </h1>
+                    <div
+                      className={css({
+                        display: "flex",
+                        gap: 6,
+                        alignItems: "center",
+                      })}
+                    >
+                      <MiniChart />
+                      {fmtnum(delegate.interestRate, "1z", 100)}%
+                    </div>
+                  </div>
+                  <div
+                    className={css({
+                      display: "flex",
+                      justifyContent: "space-between",
+                      width: "100%",
+                      fontSize: 14,
+                      color: "content",
+                    })}
+                  >
+                    <div
+                      className={css({
+                        display: "flex",
+                        gap: 8,
+                        alignItems: "center",
+                      })}
+                    >
+                      <div>{delegate.followers} followers</div>
+                      <Bullet />
+                      <div>
+                        {fmtnum(delegate.boldAmount, "compact")} BOLD
+                      </div>
+                    </div>
+                    <div
+                      className={css({
+                        display: "flex",
+                        gap: 8,
+                        alignItems: "center",
+                      })}
+                    >
+                      <StatusDot mode={riskLevelToStatusMode(delegationRisk)} />
+                      {formatRedemptionRisk(delegationRisk)}
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className={css({
+                    display: "flex",
+                    flexDirection: "column",
+                    width: "100%",
+                    paddingTop: 12,
+                    fontSize: 14,
+                    paddingBottom: 12,
+                    borderBottom: "1px solid token(colors.borderSoft)",
+                  })}
+                >
+                  <div
+                    className={css({
+                      paddingBottom: 8,
+                      color: "contentAlt",
+                    })}
+                  >
+                    Last {delegate.lastDays} days
+                  </div>
+                  <div
+                    className={css({
+                      display: "flex",
+                      justifyContent: "space-between",
+                      width: "100%",
+                      fontSize: 14,
+                      color: "content",
+                    })}
+                  >
+                    <div>Redemptions</div>
+                    <div>
+                      {fmtnum(delegate.redemptions, "compact")} BOLD
+                    </div>
+                  </div>
+                  <div
+                    className={css({
+                      display: "flex",
+                      justifyContent: "space-between",
+                      width: "100%",
+                      fontSize: 14,
+                      color: "content",
+                    })}
+                  >
+                    <div>Interest rate change</div>
+                    <div>
+                      {fmtnum(delegate.interestRateChange[0], 2, 100)}…{fmtnum(delegate.interestRateChange[1], 2, 100)}%
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className={css({
+                    display: "flex",
+                    justifyContent: "space-between",
+                    width: "100%",
+                    paddingTop: 16,
+                    paddingBottom: 8,
+                    fontSize: 14,
+                  })}
+                >
+                  <div
+                    className={css({
+                      display: "flex",
+                      gap: 8,
+                    })}
+                  >
+                    <TextButton
+                      label={
+                        <>
+                          Copy address
+                          <IconCopy size={16} />
+                        </>
+                      }
+                      className={css({
+                        fontSize: 14,
+                      })}
+                    />
+                    <TextButton
+                      label={
+                        <>
+                          Dune
+                          <IconExternal size={16} />
+                        </>
+                      }
+                      className={css({
+                        fontSize: 14,
+                      })}
+                    />
+                  </div>
+                  <div>
+                    <Button
+                      label="Choose delegate"
+                      mode="primary"
+                      size="small"
+                      onClick={() => {
+                        onSelectDelegate(delegate.id);
+                      }}
+                    />
+                  </div>
+                </div>
+              </section>
+            </ShadowBox>
+          );
+        })}
+        {displayedDelegates < DELEGATES.length && (
+          <ShadowBox>
+            <TextButton
+              label="Load more"
+              onClick={() => setDisplayedDelegates(displayedDelegates + 5)}
+              className={css({
+                width: "100%",
+                padding: "24px 0",
+                justifyContent: "center",
+              })}
+            />
+          </ShadowBox>
+        )}
+      </div>
+    </>
+  );
+}
+
+function MiniChart({ size = "small" }: { size?: "small" | "medium" }) {
+  return (
+    size === "medium"
+      ? (
+        <svg width="45" height="18" fill="none">
+          <path
+            stroke="#9EA2B8"
+            stroke-linecap="round"
+            stroke-width="1.5"
+            d="m1 10.607 1.66 2.61a2 2 0 0 0 1.688.926H7.31c.29 0 .576.063.84.185l4.684 2.168a2 2 0 0 0 2.142-.296l2.995-2.568a2 2 0 0 0 .662-1.137l1.787-9.191a2 2 0 0 1 .318-.756l.096-.138a2 2 0 0 1 3.303.02l1.421 2.107a2 2 0 0 1 .278.616l1.295 4.996a2 2 0 0 0 .431.815l1.691 1.932c.163.187.29.402.375.635l.731 2.015a2 2 0 0 0 3.029.955l.079-.056a2 2 0 0 0 .744-.99l2.539-7.42 2.477-5.005a2 2 0 0 1 2.924-.762L44 3.536"
+          />
+        </svg>
+      )
+      : (
+        <svg width="28" height="16" fill="none">
+          <path
+            stroke="#9EA2B8"
+            stroke-linecap="round"
+            stroke-width="1.5"
+            d="m2 8.893.618 1.009a2 2 0 0 0 1.706.955h.83a2 2 0 0 1 .867.198l1.731.832a2 2 0 0 0 2.197-.309l.901-.802a2 2 0 0 0 .636-1.126l.902-4.819c.028-.148.085-.288.169-.414v0a1.119 1.119 0 0 1 1.87.011l.64.986c.113.175.197.368.248.571l.613 2.458a2 2 0 0 0 .411.804l.686.814c.145.172.257.37.332.582l.339.97a1.09 1.09 0 0 0 1.671.522v0a1.09 1.09 0 0 0 .394-.54l1.361-4.13.847-1.778a2 2 0 0 1 2.966-.77l.065.047"
+          />
+        </svg>
+      )
+  );
+}
+
+function Bullet() {
+  return (
+    <div
+      className={css({
+        width: 4,
+        height: 4,
+        background: "currentcolor",
+        borderRadius: "50%",
+      })}
+    />
+  );
+}
+
+function ShadowBox({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className={css({
+        background: "background",
+        borderWidth: "1px 1px 0",
+        borderStyle: "solid",
+        borderColor: "gray:50",
+        boxShadow: `
+        0 2px 2px rgba(0, 0, 0, 0.1),
+        0 4px 10px rgba(18, 27, 68, 0.05),
+        inset 0 -1px 4px rgba(0, 0, 0, 0.05)
+      `,
+        borderRadius: 8,
+      })}
+    >
+      {children}
+    </div>
+  );
+}

--- a/frontend/app/src/comps/LeverageField/LeverageField.tsx
+++ b/frontend/app/src/comps/LeverageField/LeverageField.tsx
@@ -34,11 +34,11 @@ export function LeverageField({
 }: ReturnType<typeof useLeverageField> & {
   disabled?: boolean;
 }) {
-  const negativeDeposit = !deposit || dn.lt(deposit, 0);
+  const isDepositNegative = !deposit || dn.lt(deposit, 0);
   return (
     <InputField
       secondarySpacing={16}
-      disabled={negativeDeposit}
+      disabled={isDepositNegative}
       contextual={
         <div
           style={{
@@ -69,7 +69,7 @@ export function LeverageField({
       label={{
         end: (
           <div>
-            Total debt {!debt || negativeDeposit ? "−" : (
+            Total debt {!debt || isDepositNegative ? "−" : (
               <>
                 <span
                   className={css({
@@ -118,7 +118,7 @@ export function LeverageField({
         ),
       }}
       {...liquidationPriceField.inputFieldProps}
-      valueUnfocused={negativeDeposit
+      valueUnfocused={isDepositNegative
         ? (
           <span
             className={css({
@@ -180,7 +180,11 @@ export function useLeverageField({
     ? dn.mul(depositPreLeverage, leverageFactor)
     : null;
 
-  const debt = depositPreLeverage && calculateDebt(depositPreLeverage, leverageFactor, collPrice);
+  const debt = depositPreLeverage && calculateDebt(
+    depositPreLeverage,
+    leverageFactor,
+    collPrice,
+  );
 
   const getLeverageFactorFromLiquidationPriceClamped = (liquidationPrice: Dnum) => {
     const leverageFactor = getLeverageFactorFromLiquidationPrice(

--- a/frontend/app/src/comps/Position/Position.tsx
+++ b/frontend/app/src/comps/Position/Position.tsx
@@ -219,7 +219,7 @@ export function Position({
           )}
         <GridItem label="Liq. price">
           <Value negative={ltv && dn.gt(ltv, maxLtv)}>
-            {fmtnum(loanDetails.liquidationPrice)}
+            ${fmtnum(loanDetails.liquidationPrice)}
           </Value>
         </GridItem>
         <GridItem label="Interest rate">

--- a/frontend/app/src/constants.ts
+++ b/frontend/app/src/constants.ts
@@ -24,6 +24,7 @@ export const LQTY_SUPPLY = dn.from(100_000_000, 18);
 
 export const INTEREST_RATE_MIN = 1;
 export const INTEREST_RATE_MAX = 8;
+export const INTEREST_RATE_DEFAULT = 4;
 export const INTEREST_RATE_INCREMENT = 0.1;
 
 // LTV factor suggestions, as ratios of the leverage factor range

--- a/frontend/app/src/demo-mode/demo-data.ts
+++ b/frontend/app/src/demo-mode/demo-data.ts
@@ -107,13 +107,23 @@ export const EARN_POOLS: Record<
 const BUCKET_SIZE_MAX = 20_000_000;
 const RATE_STEPS = Math.round((INTEREST_RATE_MAX - INTEREST_RATE_MIN) / INTEREST_RATE_INCREMENT) + 1;
 export const INTEREST_RATE_BUCKETS = Array.from({ length: RATE_STEPS }, (_, i) => {
-  const rate = Math.round((INTEREST_RATE_MIN + i * INTEREST_RATE_INCREMENT) * 10) / 10;
+  const rate = Math.round(
+    (INTEREST_RATE_MIN + i * INTEREST_RATE_INCREMENT) * 10,
+  ) / 10;
   const baseFactor = 1 - Math.pow((i / (RATE_STEPS - 1) - 0.5) * 2, 2);
-  return [rate, dn.from(Math.pow(baseFactor * Math.random(), 2) * BUCKET_SIZE_MAX, 18)];
+  return [
+    rate,
+    dn.from(Math.pow(baseFactor * Math.random(), 2) * BUCKET_SIZE_MAX, 18),
+  ];
 }) as Array<[number, dn.Dnum]>;
 
 export const INTEREST_CHART = INTEREST_RATE_BUCKETS.map(([_, size]) => (
-  Math.max(0.1, dn.toNumber(size) / Math.max(...INTEREST_RATE_BUCKETS.map(([_, size]) => dn.toNumber(size))))
+  Math.max(
+    0.1,
+    dn.toNumber(size) / Math.max(
+      ...INTEREST_RATE_BUCKETS.map(([_, size]) => dn.toNumber(size)),
+    ),
+  )
 ));
 
 export function getDebtBeforeRateBucketIndex(index: number) {
@@ -129,3 +139,229 @@ export function getDebtBeforeRateBucketIndex(index: number) {
   }
   return debt;
 }
+
+export const DELEGATES = [
+  {
+    id: "0x01",
+    name: "DeFi Saver",
+    interestRate: dn.from(0.065, 18),
+    followers: 1202,
+    boldAmount: dn.from(25_130_000, 18),
+    lastDays: 180,
+    redemptions: dn.from(900_000, 18),
+    interestRateChange: [
+      dn.from(0.028, 18),
+      dn.from(0.0812, 18),
+    ],
+  },
+  {
+    id: "0x02",
+    name: "Yield Harbor",
+    interestRate: dn.from(0.041, 18),
+    followers: 700,
+    boldAmount: dn.from(15_730_000, 18),
+    lastDays: 180,
+    redemptions: dn.from(2_600_000, 18),
+    liquidations: 0,
+    interestRateChange: [
+      dn.from(0.032, 18),
+      dn.from(0.069, 18),
+    ],
+  },
+  {
+    id: "0x03",
+    name: "Crypto Nexus",
+    interestRate: dn.from(0.031, 18),
+    followers: 500,
+    boldAmount: dn.from(12_000_000, 18),
+    lastDays: 180,
+    redemptions: dn.from(1_200_000, 18),
+    liquidations: 0,
+    interestRateChange: [
+      dn.from(0.025, 18),
+      dn.from(0.078, 18),
+    ],
+  },
+  {
+    id: "0x04",
+    name: "Block Ventures",
+    interestRate: dn.from(0.021, 18),
+    followers: 200,
+    boldAmount: dn.from(7_000_000, 18),
+    lastDays: 180,
+    redemptions: dn.from(1_280_000, 18),
+    liquidations: 0,
+    interestRateChange: [
+      dn.from(0.018, 18),
+      dn.from(0.065, 18),
+    ],
+  },
+  {
+    id: "0x05",
+    name: "Chain Gains",
+    interestRate: dn.from(0.011, 18),
+    followers: 100,
+    boldAmount: dn.from(3_000_000, 18),
+    lastDays: 47,
+    redemptions: dn.from(1_100_000, 18),
+    liquidations: 0,
+    interestRateChange: [
+      dn.from(0.009, 18),
+      dn.from(0.058, 18),
+    ],
+  },
+  {
+    id: "0x06",
+    name: "TokenTrust",
+    interestRate: dn.from(0.001, 18),
+    followers: 50,
+    boldAmount: dn.from(1_000_000, 18),
+    lastDays: 180,
+    redemptions: dn.from(334_000, 18),
+    liquidations: 0,
+    interestRateChange: [
+      dn.from(0.001, 18),
+      dn.from(0.043, 18),
+    ],
+  },
+  {
+    id: "0x07",
+    name: "Yield Maximizer",
+    interestRate: dn.from(0.072, 18),
+    followers: 1500,
+    boldAmount: dn.from(30_000_000, 18),
+    lastDays: 180,
+    redemptions: dn.from(750_000, 18),
+    liquidations: 0,
+    interestRateChange: [
+      dn.from(0.035, 18),
+      dn.from(0.089, 18),
+    ],
+  },
+  {
+    id: "0x08",
+    name: "Stable Growth",
+    interestRate: dn.from(0.055, 18),
+    followers: 980,
+    boldAmount: dn.from(22_500_000, 18),
+    lastDays: 180,
+    redemptions: dn.from(1_100_000, 18),
+    liquidations: 0,
+    interestRateChange: [
+      dn.from(0.041, 18),
+      dn.from(0.072, 18),
+    ],
+  },
+  {
+    id: "0x09",
+    name: "Risk Taker",
+    interestRate: dn.from(0.089, 18),
+    followers: 750,
+    boldAmount: dn.from(18_000_000, 18),
+    lastDays: 180,
+    redemptions: dn.from(2_200_000, 18),
+    liquidations: 1,
+    interestRateChange: [
+      dn.from(0.038, 18),
+      dn.from(0.102, 18),
+    ],
+  },
+  {
+    id: "0x0a",
+    name: "Conservative Gains",
+    interestRate: dn.from(0.038, 18),
+    followers: 620,
+    boldAmount: dn.from(14_800_000, 18),
+    lastDays: 180,
+    redemptions: dn.from(500_000, 18),
+    liquidations: 0,
+    interestRateChange: [
+      dn.from(0.029, 18),
+      dn.from(0.061, 18),
+    ],
+  },
+  {
+    id: "0x0b",
+    name: "Crypto Innovator",
+    interestRate: dn.from(0.062, 18),
+    followers: 890,
+    boldAmount: dn.from(20_500_000, 18),
+    lastDays: 180,
+    redemptions: dn.from(1_500_000, 18),
+    liquidations: 0,
+    interestRateChange: [
+      dn.from(0.033, 18),
+      dn.from(0.085, 18),
+    ],
+  },
+  {
+    id: "0x0c",
+    name: "DeFi Pioneer",
+    interestRate: dn.from(0.075, 18),
+    followers: 1100,
+    boldAmount: dn.from(26_000_000, 18),
+    lastDays: 180,
+    redemptions: dn.from(1_800_000, 18),
+    liquidations: 0,
+    interestRateChange: [
+      dn.from(0.037, 18),
+      dn.from(0.091, 18),
+    ],
+  },
+  {
+    id: "0x0d",
+    name: "Steady Returns",
+    interestRate: dn.from(0.049, 18),
+    followers: 780,
+    boldAmount: dn.from(17_500_000, 18),
+    lastDays: 180,
+    redemptions: dn.from(600_000, 18),
+    liquidations: 0,
+    interestRateChange: [
+      dn.from(0.036, 18),
+      dn.from(0.067, 18),
+    ],
+  },
+  {
+    id: "0x0e",
+    name: "Blockchain Believer",
+    interestRate: dn.from(0.058, 18),
+    followers: 850,
+    boldAmount: dn.from(19_800_000, 18),
+    lastDays: 180,
+    redemptions: dn.from(1_300_000, 18),
+    liquidations: 0,
+    interestRateChange: [
+      dn.from(0.031, 18),
+      dn.from(0.076, 18),
+    ],
+  },
+  {
+    id: "0x0f",
+    name: "Crypto Sage",
+    interestRate: dn.from(0.069, 18),
+    followers: 1300,
+    boldAmount: dn.from(28_500_000, 18),
+    lastDays: 180,
+    redemptions: dn.from(950_000, 18),
+    liquidations: 0,
+    interestRateChange: [
+      dn.from(0.034, 18),
+      dn.from(0.088, 18),
+    ],
+  },
+  {
+    id: "0x10",
+    name: "Bold Strategist",
+    interestRate: dn.from(0.082, 18),
+    followers: 970,
+    boldAmount: dn.from(23_000_000, 18),
+    lastDays: 180,
+    redemptions: dn.from(2_500_000, 18),
+    liquidations: 1,
+    interestRateChange: [
+      dn.from(0.039, 18),
+      dn.from(0.098, 18),
+    ],
+  },
+] as const;

--- a/frontend/app/src/formatting.ts
+++ b/frontend/app/src/formatting.ts
@@ -7,6 +7,7 @@ import { match, P } from "ts-pattern";
 const dnFormatOptions = {
   "1z": { digits: 1, trailingZeros: true },
   "2z": { digits: 2, trailingZeros: true },
+  "compact": { compact: true, digits: 2 },
   "full": undefined, // dnum defaults
 } as const;
 
@@ -19,6 +20,7 @@ export function fmtnum(
   optionsOrFormatName:
     | keyof typeof dnFormatOptions
     | Parameters<typeof dn.format>[1] = "2z",
+  scale = 1,
 ) {
   if (value === null) {
     return "";
@@ -28,6 +30,9 @@ export function fmtnum(
   }
   if (isDnFormatName(optionsOrFormatName)) {
     optionsOrFormatName = dnFormatOptions[optionsOrFormatName];
+  }
+  if (scale > 1) {
+    value = dn.mul(value, scale);
   }
   return dn.format(value, optionsOrFormatName);
 }

--- a/frontend/app/src/screens/LeverageScreen/LeverageScreen.tsx
+++ b/frontend/app/src/screens/LeverageScreen/LeverageScreen.tsx
@@ -2,12 +2,13 @@
 
 import { ConnectWarningBox } from "@/src/comps/ConnectWarningBox/ConnectWarningBox";
 import { Field } from "@/src/comps/Field/Field";
+import { InterestRateField } from "@/src/comps/InterestRateField/InterestRateField";
 import { LeverageField, useLeverageField } from "@/src/comps/LeverageField/LeverageField";
 import { RedemptionInfo } from "@/src/comps/RedemptionInfo/RedemptionInfo";
 import { Screen } from "@/src/comps/Screen/Screen";
-import { INTEREST_RATE_INCREMENT, INTEREST_RATE_MAX, INTEREST_RATE_MIN } from "@/src/constants";
+import { INTEREST_RATE_DEFAULT } from "@/src/constants";
 import content from "@/src/content";
-import { ACCOUNT_BALANCES, getDebtBeforeRateBucketIndex, INTEREST_CHART } from "@/src/demo-mode";
+import { ACCOUNT_BALANCES } from "@/src/demo-mode";
 import { useInputFieldValue } from "@/src/form-utils";
 import { getRedemptionRisk } from "@/src/liquity-math";
 import { useAccount } from "@/src/services/Ethereum";
@@ -22,16 +23,13 @@ import {
   IconSuggestion,
   InfoTooltip,
   InputField,
-  lerp,
-  norm,
-  Slider,
   TextButton,
   TokenIcon,
   VFlex,
 } from "@liquity2/uikit";
 import * as dn from "dnum";
 import { useParams, useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 const collateralSymbols = COLLATERALS.map(({ symbol }) => symbol);
 
@@ -53,56 +51,28 @@ export function LeverageScreen() {
   const collateralIndex = collateralSymbols.indexOf(collSymbol);
   const collateral = COLLATERALS[collateralIndex];
 
-  const boldPriceUsd = usePrice("BOLD") ?? dn.from(0, 18);
   const collPrice = usePrice(collateral.symbol) ?? dn.from(0, 18);
-
   const depositPreLeverage = useInputFieldValue((value) => `${dn.format(value)} ${collateral.name}`);
-  const interestRate = useInputFieldValue((value) => `${dn.format(value)}%`);
-
-  const ethPriceBold = dn.mul(collPrice, boldPriceUsd);
-
-  const depositUsd = depositPreLeverage.parsed && dn.mul(depositPreLeverage.parsed, collPrice);
-  const depositBold = depositPreLeverage.parsed && dn.mul(depositPreLeverage.parsed, ethPriceBold);
+  const [interestRate, setInterestRate] = useState(dn.div(dn.from(INTEREST_RATE_DEFAULT, 18), 100));
 
   const leverageField = useLeverageField({
     depositPreLeverage: depositPreLeverage.parsed,
     collPrice,
     collToken: COLLATERALS[collateralIndex],
   });
-
-  const totalDebtBold = depositBold && dn.mul(
-    dn.sub(leverageField.leverageFactor, dn.from(1, 18)),
-    depositBold,
-  );
-
-  const redemptionRisk = getRedemptionRisk(
-    interestRate.parsed && dn.div(interestRate.parsed, 100),
-  );
-
-  // reset leverage when collateral changes
   useEffect(() => {
+    // reset leverage when collateral changes
     leverageField.updateLeverageFactor(leverageField.leverageFactorSuggestions[0]);
   }, [collateral.symbol, leverageField.leverageFactorSuggestions]);
 
-  const boldInterestPerYear = interestRate.parsed
-    && totalDebtBold
-    && dn.gt(depositBold, 0)
-    && dn.div(totalDebtBold, depositBold);
-
-  const boldRedeemableInFront = dn.format(
-    getDebtBeforeRateBucketIndex(
-      interestRate.parsed
-        ? Math.round((dn.toNumber(interestRate.parsed) - INTEREST_RATE_MIN) / INTEREST_RATE_INCREMENT)
-        : 0,
-    ),
-    { compact: true },
-  );
+  const redemptionRisk = getRedemptionRisk(interestRate);
+  const depositUsd = depositPreLeverage.parsed && dn.mul(depositPreLeverage.parsed, collPrice);
 
   const allowSubmit = account.isConnected
     && depositPreLeverage.parsed
     && dn.gt(depositPreLeverage.parsed, 0)
-    && interestRate.parsed
-    && dn.gt(interestRate.parsed, 0);
+    && interestRate
+    && dn.gt(interestRate, 0);
 
   return (
     <Screen
@@ -225,93 +195,10 @@ export function LeverageScreen() {
           <Field
             // “Interest rate”
             field={
-              <InputField
-                contextual={
-                  <div
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "center",
-                      width: 300,
-                    }}
-                  >
-                    <Slider
-                      gradient={[1 / 3, 2 / 3]}
-                      chart={INTEREST_CHART}
-                      onChange={(value) => {
-                        interestRate.setValue(
-                          String(Math.round(lerp(INTEREST_RATE_MIN, INTEREST_RATE_MAX, value) * 10) / 10),
-                        );
-                      }}
-                      value={norm(
-                        interestRate.parsed ? dn.toNumber(interestRate.parsed) : 0,
-                        INTEREST_RATE_MIN,
-                        INTEREST_RATE_MAX,
-                      )}
-                    />
-                  </div>
-                }
-                label={content.borrowScreen.interestRateField.label}
-                placeholder="0.00"
-                secondary={{
-                  start: (
-                    <HFlex gap={4}>
-                      <div>
-                        {boldInterestPerYear
-                          ? dn.format(boldInterestPerYear, { digits: 2, trailingZeros: false })
-                          : "−"} BOLD / year
-                      </div>
-                      <InfoTooltip {...infoTooltipProps(content.borrowScreen.infoTooltips.interestRateBoldPerYear)} />
-                    </HFlex>
-                  ),
-                  end: (
-                    <span>
-                      <span>{"Before you "}</span>
-                      <span
-                        className={css({
-                          color: "content",
-                        })}
-                      >
-                        <span
-                          style={{
-                            fontVariantNumeric: "tabular-nums",
-                          }}
-                        >
-                          {boldRedeemableInFront}
-                        </span>
-                        <span>{" BOLD to redeem"}</span>
-                      </span>
-                    </span>
-                  ),
-                }}
-                {...interestRate.inputFieldProps}
-                valueUnfocused={(!interestRate.isEmpty && interestRate.parsed)
-                  ? (
-                    <span
-                      style={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 12,
-                      }}
-                    >
-                      <span
-                        style={{
-                          fontVariantNumeric: "tabular-nums",
-                        }}
-                      >
-                        {dn.format(interestRate.parsed, { digits: 1, trailingZeros: true })}
-                      </span>
-                      <span
-                        style={{
-                          color: "#878AA4",
-                          fontSize: 24,
-                        }}
-                      >
-                        % per year
-                      </span>
-                    </span>
-                  )
-                  : null}
+              <InterestRateField
+                debt={leverageField.debt}
+                interestRate={interestRate ?? dn.from(0, 18)}
+                onChange={setInterestRate}
               />
             }
             footer={[

--- a/frontend/app/src/screens/LoanScreen/PanelUpdateRate.tsx
+++ b/frontend/app/src/screens/LoanScreen/PanelUpdateRate.tsx
@@ -3,30 +3,19 @@ import type { PositionLoan } from "@/src/types";
 import { ConnectWarningBox } from "@/src/comps/ConnectWarningBox/ConnectWarningBox";
 import { Field } from "@/src/comps/Field/Field";
 import { InfoBox } from "@/src/comps/InfoBox/InfoBox";
+import { InterestRateField } from "@/src/comps/InterestRateField/InterestRateField";
 import { ValueUpdate } from "@/src/comps/ValueUpdate/ValueUpdate";
-import { INTEREST_RATE_INCREMENT, INTEREST_RATE_MAX, INTEREST_RATE_MIN } from "@/src/constants";
-import content from "@/src/content";
-import { getDebtBeforeRateBucketIndex, INTEREST_CHART } from "@/src/demo-mode";
 import { useInputFieldValue } from "@/src/form-utils";
 import { fmtnum, formatRisk } from "@/src/formatting";
 import { getLoanDetails } from "@/src/liquity-math";
 import { useAccount } from "@/src/services/Ethereum";
 import { usePrice } from "@/src/services/Prices";
-import { infoTooltipProps, riskLevelToStatusMode } from "@/src/uikit-utils";
+import { riskLevelToStatusMode } from "@/src/uikit-utils";
 import { css } from "@/styled-system/css";
-import {
-  Button,
-  HFlex,
-  InfoTooltip,
-  InputField,
-  lerp,
-  norm,
-  Slider,
-  StatusDot,
-  TOKENS_BY_SYMBOL,
-} from "@liquity2/uikit";
+import { Button, HFlex, InfoTooltip, StatusDot, TOKENS_BY_SYMBOL } from "@liquity2/uikit";
 import * as dn from "dnum";
 import { useRouter } from "next/navigation";
+import { useState } from "react";
 
 export function PanelUpdateRate({ loan }: { loan: PositionLoan }) {
   const router = useRouter();
@@ -41,9 +30,8 @@ export function PanelUpdateRate({ loan }: { loan: PositionLoan }) {
   const debt = useInputFieldValue((value) => `${dn.format(value)} BOLD`, {
     defaultValue: dn.toString(loan.borrowed),
   });
-  const interestRate = useInputFieldValue((value) => `${dn.format(value)} %`, {
-    defaultValue: dn.toString(dn.mul(loan.interestRate, 100)),
-  });
+
+  const [interestRate, setInterestRate] = useState(loan.interestRate);
 
   const loanDetails = getLoanDetails(
     loan.deposit,
@@ -56,124 +44,32 @@ export function PanelUpdateRate({ loan }: { loan: PositionLoan }) {
   const newLoanDetails = getLoanDetails(
     deposit.isEmpty ? null : deposit.parsed,
     debt.isEmpty ? null : debt.parsed,
-    interestRate.parsed && dn.div(interestRate.parsed, 100),
+    interestRate,
     collateral.collateralRatio,
     collPrice,
   );
 
-  const boldInterestPerYear = interestRate.parsed
+  const boldInterestPerYear = interestRate
     && debt.parsed
-    && dn.mul(debt.parsed, dn.div(interestRate.parsed, 100));
-
-  const boldRedeemableInFront = dn.format(
-    getDebtBeforeRateBucketIndex(
-      interestRate.parsed
-        ? Math.round((dn.toNumber(interestRate.parsed) - INTEREST_RATE_MIN) / INTEREST_RATE_INCREMENT)
-        : 0,
-    ),
-    { compact: true },
-  );
+    && dn.mul(debt.parsed, interestRate);
 
   const allowSubmit = account.isConnected
     && deposit.parsed
     && dn.gt(deposit.parsed, 0)
     && debt.parsed
     && dn.gt(debt.parsed, 0)
-    && interestRate.parsed
-    && dn.gt(interestRate.parsed, 0);
+    && interestRate
+    && dn.gt(interestRate, 0);
 
   return (
     <>
       <Field
         // “Interest rate”
         field={
-          <InputField
-            contextual={
-              <div
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  width: 300,
-                }}
-              >
-                <Slider
-                  gradient={[1 / 3, 2 / 3]}
-                  chart={INTEREST_CHART}
-                  onChange={(value) => {
-                    interestRate.setValue(
-                      String(Math.round(lerp(INTEREST_RATE_MIN, INTEREST_RATE_MAX, value) * 10) / 10),
-                    );
-                  }}
-                  value={norm(
-                    interestRate.parsed ? dn.toNumber(interestRate.parsed) : 0,
-                    INTEREST_RATE_MIN,
-                    INTEREST_RATE_MAX,
-                  )}
-                />
-              </div>
-            }
-            label={content.borrowScreen.interestRateField.label}
-            placeholder="0.00"
-            secondary={{
-              start: (
-                <HFlex gap={4}>
-                  <div>
-                    {boldInterestPerYear
-                      ? fmtnum(boldInterestPerYear, 2)
-                      : "−"} BOLD / year
-                  </div>
-                  <InfoTooltip {...infoTooltipProps(content.borrowScreen.infoTooltips.interestRateBoldPerYear)} />
-                </HFlex>
-              ),
-              end: (
-                <span>
-                  <span>{"Before you "}</span>
-                  <span
-                    className={css({
-                      color: "content",
-                    })}
-                  >
-                    <span
-                      style={{
-                        fontVariantNumeric: "tabular-nums",
-                      }}
-                    >
-                      {boldRedeemableInFront}
-                    </span>
-                    <span>{" BOLD to redeem"}</span>
-                  </span>
-                </span>
-              ),
-            }}
-            {...interestRate.inputFieldProps}
-            valueUnfocused={(!interestRate.isEmpty && interestRate.parsed)
-              ? (
-                <span
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 12,
-                  }}
-                >
-                  <span
-                    style={{
-                      fontVariantNumeric: "tabular-nums",
-                    }}
-                  >
-                    {fmtnum(interestRate.parsed, "1z")}
-                  </span>
-                  <span
-                    style={{
-                      color: "#878AA4",
-                      fontSize: 24,
-                    }}
-                  >
-                    % per year
-                  </span>
-                </span>
-              )
-              : null}
+          <InterestRateField
+            debt={debt.parsed}
+            interestRate={interestRate}
+            onChange={setInterestRate}
           />
         }
       />

--- a/frontend/uikit/src/Theme/Theme.tsx
+++ b/frontend/uikit/src/Theme/Theme.tsx
@@ -109,6 +109,7 @@ export const lightTheme = {
     background: "white",
     backgroundActive: "gray:50",
     border: "gray:200",
+    borderSoft: "gray:100",
     content: "gray:950",
     contentAlt: "gray:600",
     contentAlt2: "gray:500",


### PR DESCRIPTION
- Add `InterestRateField` (used by `LoanScreen` and `LeverageScreen`).
- The interest rate now defaults to 4 (see `constants.ts`).
- `fmtnum()` now supports a `scale` parameter that can be used to format percentages.