### PR TITLE
feat: simulation support in deploy-cli

### DIFF
--- a/.github/workflows/testnet-deployment.yml
+++ b/.github/workflows/testnet-deployment.yml
@@ -59,8 +59,8 @@ jobs:
 
       - name: Run deployment tool
         working-directory: ./contracts
-        run: ./deploy liquity-testnet --verify
-        timeout-minutes: 5
+        run: ./deploy liquity-testnet --debug --verify
+        timeout-minutes: 10
         env:
           DEPLOYER: ${{ secrets.DEPLOYER }}
 

--- a/contracts/.gitignore
+++ b/contracts/.gitignore
@@ -28,3 +28,4 @@ coverage.json
 mochaOutput.json
 testMatrix.json
 /deployment-context-latest.json
+/deployment-manifest.json

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -4,7 +4,10 @@ out = "out"
 libs = ["lib"]
 evm_version = 'shanghai'
 ignored_error_codes = [5574] # contract-size
-fs_permissions = [{access = "read", path   = "./utils/assets/"}]
+fs_permissions = [
+    { access = "read", path = "./utils/assets/" },
+    { access = "write", path = "./deployment-manifest.json" }
+]
 
 [invariant]
 call_override = false

--- a/contracts/utils/deploy-cli.ts
+++ b/contracts/utils/deploy-cli.ts
@@ -22,11 +22,12 @@ Options:
                                            Requires a Ledger if an address is used.
   --ledger-path <LEDGER_PATH>              HD path to use with the Ledger (only used
                                            when DEPLOYER is an address).
-  --etherscan-api-key <ETHERSCAN_API_KEY>  Etherscan API key to verify the contracts
-                                           (required when verifying with Etherscan).
-  --help, -h                               Show this help message.
   --dry-run                                Don't broadcast transaction, only
                                            simulate execution.
+  --etherscan-api-key <ETHERSCAN_API_KEY>  Etherscan API key to verify the contracts
+                                           (required when verifying with Etherscan).
+  --gas-price <GAS_PRICE>                  Max fee per gas to use in transactions.
+  --help, -h                               Show this help message.
   --open-demo-troves                       Open demo troves after deployment (local
                                            only).
   --rpc-url <RPC_URL>                      RPC URL to use.

--- a/contracts/utils/deploy-cli.ts
+++ b/contracts/utils/deploy-cli.ts
@@ -25,9 +25,13 @@ Options:
   --etherscan-api-key <ETHERSCAN_API_KEY>  Etherscan API key to verify the contracts
                                            (required when verifying with Etherscan).
   --help, -h                               Show this help message.
+  --dry-run                                Don't broadcast transaction, only
+                                           simulate execution.
   --open-demo-troves                       Open demo troves after deployment (local
                                            only).
   --rpc-url <RPC_URL>                      RPC URL to use.
+  --slow                                   Only send a transaction after the previous
+                                           one has been confirmed.
   --verify                                 Verify contracts after deployment.
   --verifier <VERIFIER>                    Verification provider to use.
                                            Possible values: etherscan, sourcify.
@@ -57,6 +61,8 @@ const argv = minimist(process.argv.slice(2), {
     "help",
     "open-demo-troves",
     "verify",
+    "dry-run",
+    "slow",
   ],
   string: [
     "chain-id",
@@ -122,8 +128,15 @@ export async function main() {
     String(options.chainId),
     "--rpc-url",
     options.rpcUrl,
-    "--broadcast",
   ];
+
+  if (!options.dryRun) {
+    forgeArgs.push("--broadcast");
+  }
+
+  if (options.slow) {
+    forgeArgs.push("--slow");
+  }
 
   // verify
   if (options.verify) {
@@ -189,31 +202,41 @@ Deploying Liquity contracts with the following settings:
   // deploy
   await $`forge ${forgeArgs}`;
 
-  const deployedContracts = await getDeployedContracts(
-    `broadcast/DeployLiquity2.s.sol/${options.chainId}/run-latest.json`,
-  );
-
-  const collateralContracts = await getAllCollateralsContracts(deployedContracts, options);
+  const deploymentManifestJson = fs.readFileSync("deployment-manifest.json", "utf-8");
+  const deploymentManifest = JSON.parse(deploymentManifestJson);
 
   // XXX hotfix: we were leaking Github secrets in "deployer"
   // TODO: check if "deployer" is a private key, and calculate its address and use it instead?
   const { deployer, ...safeOptions } = options;
 
-  const protocolContracts = Object.fromEntries(
-    filterProtocolContracts(deployedContracts),
-  );
+  const protocolContracts = {
+    WETHTester: deploymentManifest.branches[0].collToken as string,
+    BoldToken: deploymentManifest.boldToken as string,
+    CollateralRegistry: deploymentManifest.collateralRegistry as string,
+    HintHelpers: deploymentManifest.hintHelpers as string,
+    MultiTroveGetter: deploymentManifest.multiTroveGetter as string,
+  };
+
+  const collateralContracts = (deploymentManifest.branches as any[]).map((branch) => ({
+    activePool: branch.activePool as string,
+    borrowerOperations: branch.borrowerOperations as string,
+    sortedTroves: branch.sortedTroves as string,
+    stabilityPool: branch.stabilityPool as string,
+    token: branch.collToken as string,
+    troveManager: branch.troveManager as string,
+  }));
 
   // write env file
   await fs.writeJson("deployment-context-latest.json", {
     options: safeOptions,
-    deployedContracts,
     collateralContracts,
     protocolContracts,
   });
 
   // format deployed contracts
   const longestContractName = Math.max(
-    ...deployedContracts.map(([name]) => name.length),
+    ...Object.keys(protocolContracts).map((name) => name.length),
+    ...collateralContracts.flatMap((contracts) => Object.keys(contracts).map((name) => name.length)),
   );
 
   const formatContracts = (contracts: Array<string[]>) =>
@@ -221,7 +244,7 @@ Deploying Liquity contracts with the following settings:
 
   echo("Protocol contracts:");
   echo("");
-  echo(formatContracts(filterProtocolContracts(deployedContracts)));
+  echo(formatContracts(Object.entries(protocolContracts)));
   echo("");
   echo(
     collateralContracts.map((collateral, index) => (
@@ -279,10 +302,6 @@ async function getDeployedContracts(jsonPath: string) {
   throw new Error("Invalid deployment log: " + JSON.stringify(latestRun));
 }
 
-function filterProtocolContracts(contracts: Awaited<ReturnType<typeof getDeployedContracts>>) {
-  return contracts.filter(([name]) => PROTOCOL_CONTRACTS_VALID_NAMES.includes(name));
-}
-
 function safeParseInt(value: string) {
   const parsed = parseInt(value, 10);
   return isNaN(parsed) ? undefined : parsed;
@@ -298,6 +317,8 @@ async function parseArgs() {
     ledgerPath: argv["ledger-path"],
     openDemoTroves: argv["open-demo-troves"],
     rpcUrl: argv["rpc-url"],
+    dryRun: argv["dry-run"],
+    slow: argv["slow"],
     verify: argv["verify"],
     verifier: argv["verifier"],
     verifierUrl: argv["verifier-url"],
@@ -323,80 +344,4 @@ async function parseArgs() {
   options.verifierUrl ??= process.env.VERIFIER_URL;
 
   return { options, networkPreset };
-}
-
-async function castCall(
-  rpcUrl: string,
-  contract: string,
-  method: string,
-  ...args: string[]
-) {
-  try {
-    const result = await $`cast call ${contract} ${method} ${args.join(" ")} --rpc-url '${rpcUrl}'`;
-    return result.stdout.trim();
-  } catch (error) {
-    console.error(`Error calling ${contract} ${method} ${args.join(" ")}: ${error}`);
-    throw error;
-  }
-}
-
-async function getCollateralContracts(
-  collateralIndex: number,
-  collateralRegistry: string,
-  rpcUrl: string,
-) {
-  const [token, troveManager] = await Promise.all([
-    castCall(rpcUrl, collateralRegistry, "getToken(uint256)(address)", String(collateralIndex)),
-    castCall(rpcUrl, collateralRegistry, "getTroveManager(uint256)(address)", String(collateralIndex)),
-  ]);
-
-  const [
-    activePool,
-    borrowerOperations,
-    sortedTroves,
-    stabilityPool,
-  ] = await Promise.all([
-    castCall(rpcUrl, troveManager, "activePool()(address)"),
-    castCall(rpcUrl, troveManager, "borrowerOperations()(address)"),
-    castCall(rpcUrl, troveManager, "sortedTroves()(address)"),
-    castCall(rpcUrl, troveManager, "stabilityPool()(address)"),
-  ]);
-
-  return {
-    activePool,
-    borrowerOperations,
-    sortedTroves,
-    stabilityPool,
-    token,
-    troveManager,
-  };
-}
-
-async function getAllCollateralsContracts(
-  deployedContracts: Array<string[]>,
-  options: Awaited<ReturnType<typeof parseArgs>>["options"],
-) {
-  const deployedContractsRecord = Object.fromEntries(deployedContracts);
-
-  const ccall = async (contract: string, method: string, ...args: string[]) => {
-    const result = await $`cast call ${contract} ${method} ${args.join(" ")} --rpc-url '${options.rpcUrl}'`;
-    return result.stdout.trim();
-  };
-
-  const totalCollaterals = Number(
-    await ccall(
-      deployedContractsRecord.CollateralRegistry,
-      "totalCollaterals()",
-    ),
-  );
-
-  return Promise.all(
-    Array.from({ length: totalCollaterals }, (_, index) => (
-      getCollateralContracts(
-        index,
-        deployedContractsRecord.CollateralRegistry,
-        options.rpcUrl,
-      )
-    )),
-  );
 }

--- a/contracts/utils/deploy-cli.ts
+++ b/contracts/utils/deploy-cli.ts
@@ -72,6 +72,7 @@ const argv = minimist(process.argv.slice(2), {
     "rpc-url",
     "verifier",
     "verifier-url",
+    "gas-price",
   ],
 });
 
@@ -136,6 +137,11 @@ export async function main() {
 
   if (options.slow) {
     forgeArgs.push("--slow");
+  }
+
+  if (options.gasPrice) {
+    forgeArgs.push("--with-gas-price");
+    forgeArgs.push(options.gasPrice);
   }
 
   // verify
@@ -322,6 +328,7 @@ async function parseArgs() {
     verify: argv["verify"],
     verifier: argv["verifier"],
     verifierUrl: argv["verifier-url"],
+    gasPrice: argv["gas-price"],
   };
 
   const [networkPreset] = argv._;

--- a/contracts/utils/deploy-cli.ts
+++ b/contracts/utils/deploy-cli.ts
@@ -45,14 +45,6 @@ e.g. --chain-id can be set via CHAIN_ID instead. Parameters take precedence over
 
 const ANVIL_FIRST_ACCOUNT = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
 
-const PROTOCOL_CONTRACTS_VALID_NAMES = [
-  "WETHTester",
-  "BoldToken",
-  "CollateralRegistry",
-  "HintHelpers",
-  "MultiTroveGetter",
-];
-
 const argv = minimist(process.argv.slice(2), {
   alias: {
     h: "help",
@@ -261,52 +253,6 @@ Deploying Liquity contracts with the following settings:
   echo("");
   echo("Deployment complete.");
   echo("");
-}
-
-type Transaction = { transactionType: string };
-
-function isDeploymentLog(log: unknown): log is { transactions: Transaction[] } {
-  return (
-    typeof log === "object"
-    && log !== null
-    && "transactions" in log
-    && Array.isArray(log.transactions)
-    && (log.transactions as unknown[])
-      .every((tx) => (
-        typeof tx === "object"
-        && tx !== null
-        && "transactionType" in tx
-        && typeof tx.transactionType === "string"
-      ))
-  );
-}
-
-type ContractCreation = {
-  transactionType: "CREATE" | "CREATE2";
-  contractName: string;
-  contractAddress: string;
-};
-
-function isContractCreation(tx: Transaction): tx is ContractCreation {
-  return (
-    (tx.transactionType === "CREATE" || tx.transactionType === "CREATE2")
-    && "contractName" in tx
-    && typeof tx.contractName === "string"
-    && "contractAddress" in tx
-    && typeof tx.contractAddress === "string"
-  );
-}
-
-async function getDeployedContracts(jsonPath: string) {
-  const latestRun = await fs.readJson(jsonPath);
-
-  if (isDeploymentLog(latestRun)) {
-    return latestRun.transactions
-      .filter(isContractCreation)
-      .map((tx) => [tx.contractName, tx.contractAddress]);
-  }
-
-  throw new Error("Invalid deployment log: " + JSON.stringify(latestRun));
 }
 
 function safeParseInt(value: string) {

--- a/contracts/utils/deployment-artifacts-to-app-env.ts
+++ b/contracts/utils/deployment-artifacts-to-app-env.ts
@@ -33,7 +33,6 @@ const argv = minimist(process.argv.slice(2), {
 
 const ZAddress = z.string().regex(/^0x[0-9a-fA-F]{40}$/);
 const ZDeploymentContext = z.object({
-  deployedContracts: z.array(z.tuple([z.string(), ZAddress])),
   collateralContracts: z.array(
     z.object({
       activePool: ZAddress,


### PR DESCRIPTION
Add the new flag `--dry-run` to `deploy-cli`, which can be used to simulate the deployment without broadcasting transactions. To make this work, we generate a deployment manifest (a JSON file of deployed addresses) from the Solidity script (`DeployLiquity2`) itself, which lets us avoid having to make RPC calls to get the deployed addresses (which wouldn't work when simulating).

Also add the `--slow` flag which tells Foundry to broadcast one transaction at a time, which is needed when deploying through providers like Alchemy.

Further, add a `--gas-price` flag which can be used to set `maxFeePerGas` in broadcast transactions.