### PR TITLE
fix: effects of redemption missing from `BatchUpdated` event

### DIFF
--- a/contracts/src/TroveManager.sol
+++ b/contracts/src/TroveManager.sol
@@ -620,6 +620,19 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
             _collChangeFromOperation: -int256(_singleRedemption.collLot)
         });
 
+        if (_isTroveInBatch) {
+            emit BatchUpdated({
+                _interestBatchManager: _singleRedemption.batchAddress,
+                _operation: BatchOperation.troveChange,
+                _debt: batches[_singleRedemption.batchAddress].debt,
+                _coll: batches[_singleRedemption.batchAddress].coll,
+                _annualInterestRate: _singleRedemption.batch.annualInterestRate,
+                _annualManagementFee: _singleRedemption.batch.annualManagementFee,
+                _totalDebtShares: batches[_singleRedemption.batchAddress].totalDebtShares,
+                _debtIncreaseFromUpfrontFee: 0
+            });
+        }
+
         emit RedemptionFeePaidToTrove(_singleRedemption.troveId, _singleRedemption.collFee);
 
         return newDebt;
@@ -674,17 +687,6 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
             batch.entireDebtWithoutRedistribution * batch.annualManagementFee;
 
         _activePool.mintAggInterestAndAccountForTroveChange(batchTroveChange, _batchAddress);
-
-        emit BatchUpdated({
-            _interestBatchManager: _batchAddress,
-            _operation: BatchOperation.troveChange,
-            _debt: batch.entireDebtWithoutRedistribution,
-            _coll: batch.entireCollWithoutRedistribution,
-            _annualInterestRate: batch.annualInterestRate,
-            _annualManagementFee: batch.annualManagementFee,
-            _totalDebtShares: batches[_batchAddress].totalDebtShares,
-            _debtIncreaseFromUpfrontFee: 0
-        });
     }
 
     /* Send _boldamount Bold to the system and redeem the corresponding amount of collateral from as many Troves as are needed to fill the redemption


### PR DESCRIPTION
In case of redemptions, we were emitting the `BatchUpdated` event _before_ performing any redemptions within the batch, thus the coll/debt values emitted reflected only the applied interest + management fees, but none of the coll/debt reduction coming from redemptions.

In every other case, we adhere to the following event sequence:

1. `(Batched)?TroveUpdated`
2. `TroveOperation`
3. `(BatchUpdated)?`

Let's do the same for redemptions. Although — technically — a single `BatchUpdated` event per batch _would_ be enough (after the last redemption within each batch) and it'd be slightly cheaper; having one for each `BatchedTroveUpdated` is going to make it easier to write queries by being able to join event tables simply on block numbers and event indices.