### PR TITLE
fix: Use last zombie trove first in a redemption sequence

### DIFF
--- a/contracts/src/BorrowerOperations.sol
+++ b/contracts/src/BorrowerOperations.sol
@@ -128,7 +128,7 @@ contract BorrowerOperations is LiquityBase, AddRemoveManagers, IBorrowerOperatio
     error BatchInterestRateChangePeriodNotPassed();
     error TroveNotOpen();
     error TroveNotActive();
-    error TroveNotUnredeemable();
+    error TroveNotZombie();
     error TroveOpen();
     error UpfrontFeeTooHigh();
     error BelowCriticalThreshold();
@@ -470,7 +470,7 @@ contract BorrowerOperations is LiquityBase, AddRemoveManagers, IBorrowerOperatio
         _adjustTrove(troveManagerCached, _troveId, troveChange, _maxUpfrontFee);
     }
 
-    function adjustUnredeemableTrove(
+    function adjustZombieTrove(
         uint256 _troveId,
         uint256 _collChange,
         bool _isCollIncrease,
@@ -481,7 +481,7 @@ contract BorrowerOperations is LiquityBase, AddRemoveManagers, IBorrowerOperatio
         uint256 _maxUpfrontFee
     ) external override {
         ITroveManager troveManagerCached = troveManager;
-        _requireTroveIsUnredeemable(troveManagerCached, _troveId);
+        _requireTroveIsZombie(troveManagerCached, _troveId);
 
         TroveChange memory troveChange;
         _initTroveChange(troveChange, _collChange, _isCollIncrease, _boldChange, _isDebtIncrease);
@@ -650,8 +650,8 @@ contract BorrowerOperations is LiquityBase, AddRemoveManagers, IBorrowerOperatio
             }
         }
 
-        // Make sure the Trove doesn't end up unredeemable
-        // Now the max repayment is capped to stay above MIN_DEBT, so this only applies to adjustUnredeemableTrove
+        // Make sure the Trove doesn't end up zombie
+        // Now the max repayment is capped to stay above MIN_DEBT, so this only applies to adjustZombieTrove
         _requireAtLeastMinDebt(vars.newDebt);
 
         vars.newICR = LiquityMath._computeCR(vars.newColl, vars.newDebt, vars.price);
@@ -787,8 +787,8 @@ contract BorrowerOperations is LiquityBase, AddRemoveManagers, IBorrowerOperatio
         );
         activePool.mintAggInterestAndAccountForTroveChange(change, batchManager);
 
-        // If the trove was unredeemable, and now it’s not anymore, put it back in the list
-        if (_checkTroveIsUnredeemable(troveManagerCached, _troveId) && trove.entireDebt >= MIN_DEBT) {
+        // If the trove was zombie, and now it’s not anymore, put it back in the list
+        if (_checkTroveIsZombie(troveManagerCached, _troveId) && trove.entireDebt >= MIN_DEBT) {
             troveManagerCached.setTroveStatusToActive(_troveId);
             _reInsertIntoSortedTroves(
                 _troveId, trove.annualInterestRate, _upperHint, _lowerHint, batchManager, batch.annualInterestRate
@@ -1304,7 +1304,7 @@ contract BorrowerOperations is LiquityBase, AddRemoveManagers, IBorrowerOperatio
 
     function _requireTroveIsOpen(ITroveManager _troveManager, uint256 _troveId) internal view {
         ITroveManager.Status status = _troveManager.getTroveStatus(_troveId);
-        if (status != ITroveManager.Status.active && status != ITroveManager.Status.unredeemable) {
+        if (status != ITroveManager.Status.active && status != ITroveManager.Status.zombie) {
             revert TroveNotOpen();
         }
     }
@@ -1316,20 +1316,20 @@ contract BorrowerOperations is LiquityBase, AddRemoveManagers, IBorrowerOperatio
         }
     }
 
-    function _requireTroveIsUnredeemable(ITroveManager _troveManager, uint256 _troveId) internal view {
-        if (!_checkTroveIsUnredeemable(_troveManager, _troveId)) {
-            revert TroveNotUnredeemable();
+    function _requireTroveIsZombie(ITroveManager _troveManager, uint256 _troveId) internal view {
+        if (!_checkTroveIsZombie(_troveManager, _troveId)) {
+            revert TroveNotZombie();
         }
     }
 
-    function _checkTroveIsUnredeemable(ITroveManager _troveManager, uint256 _troveId) internal view returns (bool) {
+    function _checkTroveIsZombie(ITroveManager _troveManager, uint256 _troveId) internal view returns (bool) {
         ITroveManager.Status status = _troveManager.getTroveStatus(_troveId);
-        return status == ITroveManager.Status.unredeemable;
+        return status == ITroveManager.Status.zombie;
     }
 
     function _requireTroveIsNotOpen(ITroveManager _troveManager, uint256 _troveId) internal view {
         ITroveManager.Status status = _troveManager.getTroveStatus(_troveId);
-        if (status == ITroveManager.Status.active || status == ITroveManager.Status.unredeemable) {
+        if (status == ITroveManager.Status.active || status == ITroveManager.Status.zombie) {
             revert TroveOpen();
         }
     }

--- a/contracts/src/Interfaces/IBorrowerOperations.sol
+++ b/contracts/src/Interfaces/IBorrowerOperations.sol
@@ -67,7 +67,7 @@ interface IBorrowerOperations is ILiquityBase, IAddRemoveManagers {
         uint256 _maxUpfrontFee
     ) external;
 
-    function adjustUnredeemableTrove(
+    function adjustZombieTrove(
         uint256 _troveId,
         uint256 _collChange,
         bool _isCollIncrease,

--- a/contracts/src/Interfaces/ITroveManager.sol
+++ b/contracts/src/Interfaces/ITroveManager.sol
@@ -18,7 +18,7 @@ interface ITroveManager is ILiquityBase {
         active,
         closedByOwner,
         closedByLiquidation,
-        unredeemable
+        zombie
     }
 
     function shutdownTime() external view returns (uint256);
@@ -52,6 +52,8 @@ interface ITroveManager is ILiquityBase {
     function getTroveFromTroveIdsArray(uint256 _index) external view returns (uint256);
 
     function getCurrentICR(uint256 _troveId, uint256 _price) external view returns (uint256);
+
+    function lastZombieTroveId() external view returns (uint256);
 
     function batchLiquidateTroves(uint256[] calldata _troveArray) external;
 
@@ -88,7 +90,7 @@ interface ITroveManager is ILiquityBase {
         uint256 _batchDebt
     ) external;
 
-    // Called from `adjustUnredeemableTrove()`
+    // Called from `adjustZombieTrove()`
     function setTroveStatusToActive(uint256 _troveId) external;
 
     function onAdjustTroveInterestRate(

--- a/contracts/src/NFTMetadata/MetadataNFT.sol
+++ b/contracts/src/NFTMetadata/MetadataNFT.sol
@@ -62,7 +62,7 @@ contract MetadataNFT is IMetadataNFT {
         if (status == ITroveManager.Status.active) return "Active";
         if (status == ITroveManager.Status.closedByOwner) return "Closed";
         if (status == ITroveManager.Status.closedByLiquidation) return "Liquidated";
-        if (status == ITroveManager.Status.unredeemable) return "Unredeemable";
+        if (status == ITroveManager.Status.zombie) return "Zombie";
         return "";
     }
 }

--- a/contracts/src/TroveManager.sol
+++ b/contracts/src/TroveManager.sol
@@ -111,6 +111,8 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
     // Array of all batch managers - used to fetch them off-chain
     address[] public batchIds;
 
+    uint256 public lastZombieTroveId;
+
     // Error trackers for the trove redistribution calculation
     uint256 internal lastCollError_Redistribution;
     uint256 internal lastBoldDebtError_Redistribution;
@@ -149,6 +151,7 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
         uint256 oldWeightedRecordedDebt;
         uint256 newWeightedRecordedDebt;
         uint256 newStake;
+        bool isZombieTrove;
         LatestTroveData trove;
         LatestBatchData batch;
     }
@@ -452,7 +455,7 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
     }
 
     function _isLiquidatableStatus(Status _status) internal pure returns (bool) {
-        return _status == Status.active || _status == Status.unredeemable;
+        return _status == Status.active || _status == Status.zombie;
     }
 
     function _batchLiquidateTroves(
@@ -663,14 +666,26 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
         bool isTroveInBatch = _singleRedemption.batchAddress != address(0);
         uint256 newDebt = _applySingleRedemption(_defaultPool, _singleRedemption, isTroveInBatch);
 
-        // Make Trove unredeemable if it's tiny, in order to prevent griefing future (normal, sequential) redemptions
+        // Make Trove zombie if it's tiny (and it wasn’t already), in order to prevent griefing future (normal, sequential) redemptions
         if (newDebt < MIN_DEBT) {
-            Troves[_singleRedemption.troveId].status = Status.unredeemable;
-            if (isTroveInBatch) {
-                sortedTroves.removeFromBatch(_singleRedemption.troveId);
-            } else {
-                sortedTroves.remove(_singleRedemption.troveId);
+            if (!_singleRedemption.isZombieTrove) {
+                Troves[_singleRedemption.troveId].status = Status.zombie;
+                if (isTroveInBatch) {
+                    sortedTroves.removeFromBatch(_singleRedemption.troveId);
+                } else {
+                    sortedTroves.remove(_singleRedemption.troveId);
+                }
+                // If it’s a partial redemption, let’s store a pointer to it so it’s used first in the next one
+                if (newDebt > 0) {
+                    lastZombieTroveId = _singleRedemption.troveId;
+                }
+            } else if (newDebt == 0) {
+                // Reset last zombie trove pointer if the previous one was fully redeemed now
+                lastZombieTroveId = 0;
             }
+        } else {
+            // Reset last zombie trove pointer if the previous one ended up above min debt
+            lastZombieTroveId = 0;
         }
     }
 
@@ -730,7 +745,13 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
         uint256 remainingBold = _boldamount;
 
         SingleRedemptionValues memory singleRedemption;
-        singleRedemption.troveId = sortedTrovesCached.getLast();
+        // Let’s check if there’s a pending zombie trove from previous redemption
+        if (lastZombieTroveId != 0) {
+            singleRedemption.troveId = lastZombieTroveId;
+            singleRedemption.isZombieTrove = true;
+        } else {
+            singleRedemption.troveId = sortedTrovesCached.getLast();
+        }
         address lastBatchUpdatedInterest = address(0);
 
         // Loop through the Troves starting from the one with lowest collateral ratio until _amount of Bold is exchanged for collateral
@@ -738,7 +759,13 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
         while (singleRedemption.troveId != 0 && remainingBold > 0 && _maxIterations > 0) {
             _maxIterations--;
             // Save the uint256 of the Trove preceding the current one
-            uint256 nextUserToCheck = sortedTrovesCached.getPrev(singleRedemption.troveId);
+            uint256 nextUserToCheck;
+            if (singleRedemption.isZombieTrove) {
+                nextUserToCheck = sortedTrovesCached.getLast();
+            } else {
+                nextUserToCheck = sortedTrovesCached.getPrev(singleRedemption.troveId);
+            }
+
             // Skip if ICR < 100%, to make sure that redemptions always improve the CR of hit Troves
             if (getCurrentICR(singleRedemption.troveId, _price) < _100pct) {
                 singleRedemption.troveId = nextUserToCheck;
@@ -769,6 +796,7 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
 
             remainingBold -= singleRedemption.boldLot;
             singleRedemption.troveId = nextUserToCheck;
+            singleRedemption.isZombieTrove = false;
         }
 
         // We are removing this condition to prevent blocking redemptions
@@ -811,7 +839,7 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
         bool isTroveInBatch = _singleRedemption.batchAddress != address(0);
         _applySingleRedemption(_defaultPool, _singleRedemption, isTroveInBatch);
 
-        // No need to make this Trove unredeemable if it has tiny debt, since:
+        // No need to make this Trove zombie if it has tiny debt, since:
         // - This collateral branch has shut down and urgent redemptions are enabled
         // - Urgent redemptions aren't sequential, so they can't be griefed by tiny Troves.
     }
@@ -1284,6 +1312,9 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
     function setTroveStatusToActive(uint256 _troveId) external {
         _requireCallerIsBorrowerOperations();
         Troves[_troveId].status = Status.active;
+        if (lastZombieTroveId == _troveId) {
+            lastZombieTroveId = 0;
+        }
     }
 
     function onAdjustTroveInterestRate(
@@ -1436,6 +1467,8 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
         if (_batchAddress != address(0)) {
             if (trove.status == Status.active) {
                 sortedTroves.removeFromBatch(_troveId);
+            } else if (trove.status == Status.zombie && lastZombieTroveId == _troveId) {
+                lastZombieTroveId = 0;
             }
 
             _removeTroveSharesFromBatch(
@@ -1450,6 +1483,8 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
         } else {
             if (trove.status == Status.active) {
                 sortedTroves.remove(_troveId);
+            } else if (trove.status == Status.zombie && lastZombieTroveId == _troveId) {
+                lastZombieTroveId = 0;
             }
         }
 

--- a/contracts/src/Zappers/GasCompZapper.sol
+++ b/contracts/src/Zappers/GasCompZapper.sol
@@ -155,7 +155,7 @@ contract GasCompZapper is AddRemoveManagers {
         _adjustTrovePost(_collChange, _isCollIncrease, _boldChange, _isDebtIncrease, receiver);
     }
 
-    function adjustUnredeemableTroveWithRawETH(
+    function adjustZombieTroveWithRawETH(
         uint256 _troveId,
         uint256 _collChange,
         bool _isCollIncrease,
@@ -166,7 +166,7 @@ contract GasCompZapper is AddRemoveManagers {
         uint256 _maxUpfrontFee
     ) external {
         address receiver = _adjustTrovePre(_troveId, _collChange, _isCollIncrease, _boldChange, _isDebtIncrease);
-        borrowerOperations.adjustUnredeemableTrove(
+        borrowerOperations.adjustZombieTrove(
             _troveId, _collChange, _isCollIncrease, _boldChange, _isDebtIncrease, _upperHint, _lowerHint, _maxUpfrontFee
         );
         _adjustTrovePost(_collChange, _isCollIncrease, _boldChange, _isDebtIncrease, receiver);

--- a/contracts/src/Zappers/WETHZapper.sol
+++ b/contracts/src/Zappers/WETHZapper.sol
@@ -143,7 +143,7 @@ contract WETHZapper is AddRemoveManagers {
         _adjustTrovePost(_collChange, _isCollIncrease, _boldChange, _isDebtIncrease, receiver);
     }
 
-    function adjustUnredeemableTroveWithRawETH(
+    function adjustZombieTroveWithRawETH(
         uint256 _troveId,
         uint256 _collChange,
         bool _isCollIncrease,
@@ -154,7 +154,7 @@ contract WETHZapper is AddRemoveManagers {
         uint256 _maxUpfrontFee
     ) external {
         address payable receiver = _adjustTrovePre(_troveId, _collChange, _isCollIncrease, _boldChange, _isDebtIncrease);
-        borrowerOperations.adjustUnredeemableTrove(
+        borrowerOperations.adjustZombieTrove(
             _troveId, _collChange, _isCollIncrease, _boldChange, _isDebtIncrease, _upperHint, _lowerHint, _maxUpfrontFee
         );
         _adjustTrovePost(_collChange, _isCollIncrease, _boldChange, _isDebtIncrease, receiver);

--- a/contracts/src/test/AnchoredInvariantsTest.t.sol
+++ b/contracts/src/test/AnchoredInvariantsTest.t.sol
@@ -1,13 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.18;
 
+import {Strings} from "openzeppelin-contracts/contracts/utils/Strings.sol";
+
 import "./TestContracts/DevTestSetup.sol";
 import {BaseInvariantTest} from "./TestContracts/BaseInvariantTest.sol";
 import {BaseMultiCollateralTest} from "./TestContracts/BaseMultiCollateralTest.sol";
 import {AdjustedTroveProperties, InvariantsTestHandler} from "./TestContracts/InvariantsTestHandler.t.sol";
 import {Logging} from "./Utils/Logging.sol";
+import {TroveId} from "./Utils/TroveId.sol";
 
-contract AnchoredInvariantsTest is Logging, BaseInvariantTest, BaseMultiCollateralTest {
+contract AnchoredInvariantsTest is Logging, BaseInvariantTest, BaseMultiCollateralTest, TroveId {
+    using Strings for uint256;
     using StringFormatting for uint256;
 
     InvariantsTestHandler handler;
@@ -479,5 +483,500 @@ contract AnchoredInvariantsTest is Logging, BaseInvariantTest, BaseMultiCollater
         // pendingInterest: 0 ether
         vm.prank(hope);
         handler.provideToSP(1, 4.127947448768090932 ether, false);
+    }
+
+    function testSortedTroveSize() external {
+        uint256 i = 1;
+        TestDeployer.LiquityContractsDev memory c = branches[i];
+
+        vm.prank(adam);
+        handler.addMeToLiquidationBatch();
+
+        vm.prank(barb);
+        handler.addMeToLiquidationBatch();
+
+        vm.prank(adam);
+        handler.addMeToUrgentRedemptionBatch();
+
+        vm.prank(adam);
+        handler.registerBatchManager(3, 0.100944149373120884 ether, 0.377922952132481818 ether, 0.343424998629201343 ether, 0.489955880173256455 ether, 2070930);
+
+        vm.prank(carl);
+        handler.addMeToLiquidationBatch();
+
+        vm.prank(carl);
+        handler.warp(9_303_785);
+
+        vm.prank(barb);
+        handler.registerBatchManager(1, 0.301964103682871801 ether, 0.756908371280377546 ether, 0.540898165697757771 ether, 0.000017102564306416 ether, 27657915);
+
+        vm.prank(fran);
+        handler.addMeToLiquidationBatch();
+
+        vm.prank(eric);
+        handler.addMeToUrgentRedemptionBatch();
+
+        vm.prank(hope);
+        handler.addMeToLiquidationBatch();
+
+        // upper hint: 30979495632948298397104351002742564073201815129975103483277328125306028611241
+        // lower hint: 36051278007718023196469061266077621121244014979449590376694871896669965056265
+        // upfront fee: 118.231198854524639989 ether
+        vm.prank(gabe);
+        handler.openTrove(1, 7_591.289850943621327156 ether, 1.900000000017470971 ether, 0.812103428106344175 ether, 1121, 415425919);
+
+        // redemption rate: 0.005000000000000004 ether
+        // redeemed BOLD: 0.000000000000071705 ether
+        // redeemed Troves: [
+        //   [],
+        //   [gabe],
+        //   [],
+        //   [],
+        // ]
+        vm.prank(hope);
+        handler.redeemCollateral(0.000000000000071705 ether, 1);
+
+        // redemption rate: 0.387443853477360594 ether
+        // redeemed BOLD: 5_896.917877499258624384 ether
+        // redeemed Troves: [
+        //   [],
+        //   [gabe],
+        //   [],
+        //   [],
+        // ]
+        vm.prank(gabe);
+        handler.redeemCollateral(5_896.917877499258624384 ether, 1);
+
+        vm.prank(eric);
+        handler.warp(11_371_761);
+
+        vm.prank(gabe);
+        handler.registerBatchManager(0, 0.23834235868248997 ether, 0.761711006198436234 ether, 0.523368647516059893 ether, 0.761688376122671962 ether, 31535998);
+
+        vm.prank(hope);
+        handler.registerBatchManager(2, 0.036127532604869915 ether, 0.999999999999999999 ether, 0.963882428861225203 ether, 0.848537401570757863 ether, 29802393);
+
+        vm.prank(eric);
+        handler.addMeToUrgentRedemptionBatch();
+
+        // batch manager: hope
+        // upper hint: 111996671338791781291582287523793567344508255320483065919810498665837663289426
+        // lower hint: 37857035535383668733402580992354953018471987882089934484705744026840633200601
+        // upfront fee: 1_355.203530437779650125 ether
+        vm.prank(carl);
+        handler.openTroveAndJoinInterestBatchManager(2, 73_312.036791249214758342 ether, 1.900020510596646286 ether, 40, 115, 737);
+
+        vm.prank(barb);
+        handler.registerBatchManager(0, 0.955741837871335122 ether, 0.974535636428930833 ether, 0.964294359297779033 ether, 0.000000000000268875 ether, 3335617);
+
+        vm.prank(gabe);
+        handler.addMeToLiquidationBatch();
+
+        // initial deposit: 0 ether
+        // compounded deposit: 0 ether
+        // yield gain: 0 ether
+        // coll gain: 0 ether
+        // stashed coll: 0 ether
+        // blocked SP yield: 975.74654191520134809 ether
+        vm.prank(fran);
+        handler.provideToSP(2, 12_633.808570846161076142 ether, true);
+
+        // batch manager: adam
+        // upper hint: 7512901306961997563120107574274771509748256751277397278816998908345777536679
+        // lower hint: 27989025468780058605431608942843597971189459457295957311648808450848491056535
+        // upfront fee: 166.681364294341638522 ether
+        vm.prank(carl);
+        handler.openTroveAndJoinInterestBatchManager(3, 25_307.541971224954454066 ether, 2.401194840294921108 ether, 142, 6432363, 25223);
+
+        vm.prank(carl);
+        handler.addMeToUrgentRedemptionBatch();
+
+        vm.prank(adam);
+        handler.addMeToUrgentRedemptionBatch();
+
+        vm.prank(dana);
+        handler.warp(8_774_305);
+
+        vm.prank(adam);
+        handler.warp(3_835);
+
+        vm.prank(eric);
+        handler.warp(9_078_180);
+
+        // initial deposit: 0 ether
+        // compounded deposit: 0 ether
+        // yield gain: 0 ether
+        // coll gain: 0 ether
+        // stashed coll: 0 ether
+        // blocked SP yield: 0 ether
+        vm.prank(gabe);
+        handler.provideToSP(2, 5_179.259567321319728284 ether, true);
+
+        // price: 120.905132749610222778 ether
+        vm.prank(hope);
+        handler.setPrice(1, 2.100000000000002648 ether);
+
+        vm.prank(barb);
+        handler.lowerBatchManagementFee(1, 0.000008085711886436 ether);
+
+        vm.prank(hope);
+        handler.addMeToLiquidationBatch();
+
+        vm.prank(adam);
+        handler.addMeToLiquidationBatch();
+
+        vm.prank(gabe);
+        handler.addMeToLiquidationBatch();
+
+        // price: 80.314880400478576408 ether
+        vm.prank(gabe);
+        handler.setPrice(1, 1.394988326842136963 ether);
+
+        vm.prank(carl);
+        handler.warp(1_849_907);
+
+        // upper hint: 84800337471693920904250232874319843718400766719524250287777680170677855896573
+        // lower hint: 0
+        // upfront fee: 0 ether
+        // function: adjustZombieTrove()
+        vm.prank(gabe);
+        handler.adjustTrove(1, uint8(AdjustedTroveProperties.onlyColl), 29.524853479148084596 ether, true, 0 ether, true, 40, 14, 4554760);
+
+        info("SortedTroves size: ", c.sortedTroves.getSize().toString());
+        info("num troves:        ", handler.numTroves(i).toString());
+        info("num zombies:       ", handler.numZombies(i).toString());
+        info("gabe debt: ", c.troveManager.getTroveEntireDebt(addressToTroveId(gabe)).decimal());
+
+        // upper hint: 0
+        // lower hint: 74750724351164404027318726202729770837051588626953680774538886892291438048970
+        // upfront fee: 773.037543760336600445 ether
+        vm.prank(carl);
+        handler.openTrove(0, 40_510.940914935073773948 ether, 2.063402456659389908 ether, 0.995000000000000248 ether, 0, 55487655);
+
+        vm.prank(adam);
+        handler.registerBatchManager(0, 0.541865737266494949 ether, 0.672692246806001449 ether, 0.650860934960147488 ether, 0.070089828074852802 ether, 29179158);
+
+        vm.prank(fran);
+        handler.registerBatchManager(1, 0.566980989185701648 ether, 0.86881504225021711 ether, 0.702666683322997409 ether, 0.667232273668645041 ether, 7007521);
+
+        vm.prank(dana);
+        handler.addMeToUrgentRedemptionBatch();
+
+        // initial deposit: 0 ether
+        // compounded deposit: 0 ether
+        // yield gain: 0 ether
+        // coll gain: 0 ether
+        // stashed coll: 0 ether
+        // blocked SP yield: 1_129.588991574293634631 ether
+        vm.prank(barb);
+        handler.provideToSP(1, 0.000000000000000002 ether, false);
+
+        info("SortedTroves size: ", c.sortedTroves.getSize().toString());
+        info("num troves:        ", handler.numTroves(i).toString());
+        info("num zombies:       ", handler.numZombies(i).toString());
+        info("gabe debt: ", c.troveManager.getTroveEntireDebt(addressToTroveId(gabe)).decimal());
+
+        // redemption rate: 0.184202341360173417 ether
+        // redeemed BOLD: 66_462.494346928386331338 ether
+        // redeemed Troves: [
+        //   [carl],
+        //   [gabe],
+        //   [],
+        //   [carl],
+        // ]
+        vm.prank(eric);
+        handler.redeemCollateral(66_462.49434692838633134 ether, 1);
+
+        info("SortedTroves size: ", c.sortedTroves.getSize().toString());
+        info("num troves:        ", handler.numTroves(i).toString());
+        info("num zombies:       ", handler.numZombies(i).toString());
+        info("gabe trove Id:     ", addressToTroveId(gabe).toString());
+        info("gabe debt: ", c.troveManager.getTroveEntireDebt(addressToTroveId(gabe)).decimal());
+        assertEq(c.sortedTroves.getSize(), handler.numTroves(i) - handler.numZombies(i), "Wrong SortedTroves size");
+    }
+
+    function testAssertLastZombieTroveInABatchHasMoreThanMinDebt() external {
+        uint256 i = 1;
+        TestDeployer.LiquityContractsDev memory c = branches[i];
+
+        vm.prank(adam);
+        handler.addMeToUrgentRedemptionBatch();
+
+        vm.prank(hope);
+        handler.registerBatchManager(0, 0.99500000000072184 ether, 0.996944021609020651 ether, 0.99533906344899454 ether, 0.378970428480541887 ether, 314055);
+
+        vm.prank(dana);
+        handler.warp(2_225_439);
+
+        vm.prank(adam);
+        handler.addMeToUrgentRedemptionBatch();
+
+        vm.prank(barb);
+        handler.addMeToUrgentRedemptionBatch();
+
+        vm.prank(barb);
+        handler.registerBatchManager(2, 0.995000000000009379 ether, 0.999999999998128142 ether, 0.997477804125778004 ether, 0.000000001035389259 ether, 10046);
+
+        vm.prank(gabe);
+        handler.registerBatchManager(2, 0.346476084765605513 ether, 0.346476084765605514 ether, 0.346476084765605514 ether, 0.000000000000000002 ether, 27010346);
+
+        vm.prank(fran);
+        handler.warp(19_697_329);
+
+        vm.prank(gabe);
+        handler.addMeToUrgentRedemptionBatch();
+
+        vm.prank(fran);
+        handler.registerBatchManager(1, 0.995000000000019257 ether, 0.999999999996150378 ether, 0.999999999226237651 ether, 0.696688179568702502 ether, 7641047);
+
+        vm.prank(gabe);
+        handler.warp(977_685);
+
+        vm.prank(gabe);
+        handler.addMeToUrgentRedemptionBatch();
+
+        vm.prank(fran);
+        handler.addMeToLiquidationBatch();
+
+        // batch manager: fran
+        // upper hint: 0
+        // lower hint: 60678094901167127062962700790111047491633904950610080336398562382189456360809
+        // upfront fee: 242.684833433337541236 ether
+        vm.prank(gabe);
+        handler.openTroveAndJoinInterestBatchManager(1, 12_654.280610244006254376 ether, 2.145058504746006382 ether, 182, 22444926, 124118903);
+
+        // redemption rate: 0.005 ether
+        // redeemed BOLD: 0.000000000000017162 ether
+        // redeemed Troves: [
+        //   [],
+        //   [gabe],
+        //   [],
+        //   [],
+        // ]
+        vm.prank(hope);
+        info("gabe trove Id:     ", addressToTroveId(gabe).toString());
+        info("gabe debt: ", c.troveManager.getTroveEntireDebt(addressToTroveId(gabe)).decimal());
+        handler.redeemCollateral(0.000000000000017162 ether, 0);
+        info("gabe trove Id:     ", addressToTroveId(gabe).toString());
+        info("gabe debt: ", c.troveManager.getTroveEntireDebt(addressToTroveId(gabe)).decimal());
+
+        // upper hint: 79178440845664423591903906560915994242429107602729190780850212197412640295587
+        // lower hint: 0
+        // upfront fee: 624.393448965513162837 ether
+        vm.prank(hope);
+        handler.openTrove(0, 32_721.264734011072612096 ether, 2.333153121000516764 ether, 0.995000000000109949 ether, 52719, 31482);
+
+        // price: 244.435094708283018275 ether
+        vm.prank(dana);
+        handler.setPrice(1, 2.621637893811990143 ether);
+
+        vm.prank(carl);
+        handler.addMeToUrgentRedemptionBatch();
+
+        // redemption rate: 0.37622704640950591 ether
+        // redeemed BOLD: 34_333.025174298345667786 ether
+        // redeemed Troves: [
+        //   [hope],
+        //   [gabe],
+        //   [],
+        //   [],
+        // ]
+        vm.prank(carl);
+        info("gabe trove Id:     ", addressToTroveId(gabe).toString());
+        info("gabe debt: ", c.troveManager.getTroveEntireDebt(addressToTroveId(gabe)).decimal());
+        handler.redeemCollateral(34_333.025174298345667787 ether, 0);
+        info("gabe trove Id:     ", addressToTroveId(gabe).toString());
+        info("gabe debt: ", c.troveManager.getTroveEntireDebt(addressToTroveId(gabe)).decimal());
+
+        vm.prank(gabe);
+        handler.addMeToLiquidationBatch();
+
+        vm.prank(adam);
+        handler.addMeToLiquidationBatch();
+
+        // upper hint: hope
+        // lower hint: hope
+        // upfront fee: 45.851924869044942133 ether
+        vm.prank(carl);
+        handler.openTrove(0, 3_111.607048463492852195 ether, 1.16895262626418546 ether, 0.142852735597140811 ether, 1885973, 10937);
+
+        // upper hint: 2646484967802154597987056038088487662712072023062744056283555991417410575365
+        // lower hint: 20207836743015961388089283396921182522044498153231052202943306959004515414684
+        // upfront fee: 0 ether
+        // function: addColl()
+        info("gabe trove Id:     ", addressToTroveId(gabe).toString());
+        info("gabe debt: ", c.troveManager.getTroveEntireDebt(addressToTroveId(gabe)).decimal());
+        vm.prank(gabe);
+        handler.adjustTrove(1, uint8(AdjustedTroveProperties.onlyColl), 3.631424438531681645 ether, true, 0 ether, false, 86, 703, 9499);
+        info("gabe trove Id:     ", addressToTroveId(gabe).toString());
+        info("gabe debt: ", c.troveManager.getTroveEntireDebt(addressToTroveId(gabe)).decimal());
+
+        vm.prank(barb);
+        handler.lowerBatchManagementFee(2, 0.000000000204221707 ether);
+
+        vm.prank(hope);
+        handler.addMeToLiquidationBatch();
+
+        vm.prank(hope);
+        handler.addMeToLiquidationBatch();
+
+        vm.prank(hope);
+        handler.addMeToUrgentRedemptionBatch();
+
+        // redemption rate: 0.37622704640950591 ether
+        // redeemed BOLD: 0.000000000000005602 ether
+        // redeemed Troves: [
+        //   [carl],
+        //   [gabe],
+        //   [],
+        //   [],
+        // ]
+        vm.prank(carl);
+        info("gabe trove Id:     ", addressToTroveId(gabe).toString());
+        info("gabe debt: ", c.troveManager.getTroveEntireDebt(addressToTroveId(gabe)).decimal());
+        handler.redeemCollateral(0.000000000000005603 ether, 1);
+        info("gabe trove Id:     ", addressToTroveId(gabe).toString());
+        info("gabe debt: ", c.troveManager.getTroveEntireDebt(addressToTroveId(gabe)).decimal());
+
+        vm.prank(fran);
+        handler.addMeToUrgentRedemptionBatch();
+
+        vm.prank(dana);
+        handler.addMeToUrgentRedemptionBatch();
+
+        vm.prank(dana);
+        handler.registerBatchManager(1, 0.995000000000001129 ether, 1 ether, 0.999999999999799729 ether, 0.000000000000000001 ether, 31535999);
+
+        // redemption rate: 0.718476929948594246 ether
+        // redeemed BOLD: 5_431.066474911544502914 ether
+        // redeemed Troves: [
+        //   [carl],
+        //   [gabe],
+        //   [],
+        //   [],
+        // ]
+        vm.prank(barb);
+        info("gabe trove Id:     ", addressToTroveId(gabe).toString());
+        info("gabe debt: ", c.troveManager.getTroveEntireDebt(addressToTroveId(gabe)).decimal());
+        handler.redeemCollateral(10_313.397298437031513085 ether, 1);
+        info("gabe trove Id:     ", addressToTroveId(gabe).toString());
+        info("gabe ent debt: ", c.troveManager.getTroveEntireDebt(addressToTroveId(gabe)).decimal());
+        info("gabe rec debt: ", c.troveManager.getTroveDebt(addressToTroveId(gabe)).decimal());
+        info("lzti: ", c.troveManager.lastZombieTroveId().toString());
+
+        vm.prank(dana);
+        handler.warp(30_167_580);
+
+        info("gabe ent debt: ", c.troveManager.getTroveEntireDebt(addressToTroveId(gabe)).decimal());
+        info("gabe rec debt: ", c.troveManager.getTroveDebt(addressToTroveId(gabe)).decimal());
+        info("lzti: ", c.troveManager.lastZombieTroveId().toString());
+        vm.prank(gabe);
+        handler.registerBatchManager(1, 0.995000000000002877 ether, 0.999999999999430967 ether, 0.996456350847225481 ether, 0.000000001322368348 ether, 14343);
+        info("gabe ent debt 1: ", c.troveManager.getTroveEntireDebt(addressToTroveId(gabe)).decimal());
+        info("gabe rec debt 1: ", c.troveManager.getTroveDebt(addressToTroveId(gabe)).decimal());
+
+        vm.prank(hope);
+        handler.addMeToLiquidationBatch();
+
+        // initial deposit: 0 ether
+        // compounded deposit: 0 ether
+        // yield gain: 0 ether
+        // coll gain: 0 ether
+        // stashed coll: 0 ether
+        // blocked SP yield: 0 ether
+        vm.prank(barb);
+        handler.provideToSP(3, 1_933.156398582065633891 ether, false);
+
+        vm.prank(hope);
+        handler.addMeToUrgentRedemptionBatch();
+
+        // initial deposit: 0 ether
+        // compounded deposit: 0 ether
+        // yield gain: 0 ether
+        // coll gain: 0 ether
+        // stashed coll: 0 ether
+        // blocked SP yield: 6_368.077020894268536036 ether
+        vm.prank(hope);
+        handler.provideToSP(0, 6_184.412833814428802676 ether, true);
+
+        vm.prank(carl);
+        handler.addMeToLiquidationBatch();
+
+        // upper hint: 81940996894813545005963650320412669449148720334632109303327864712326705297348
+        // lower hint: carl
+        // upfront fee: 297.236383200558451701 ether
+        vm.prank(barb);
+        handler.openTrove(0, 69_695.596747080749922615 ether, 1.900000000000006402 ether, 0.153255449436557929 ether, 1498297936, 1276315316);
+
+        // upper hint: 0
+        // lower hint: 30960623452289762463130736603892188849115197753010878244835568881362241800197
+        // upfront fee: 56.245103106642574315 ether
+        // function: withdrawBold()
+        vm.prank(hope);
+        handler.adjustTrove(0, uint8(AdjustedTroveProperties.onlyDebt), 0 ether, false, 7_875.177407392532383015 ether, true, 5, 16648, 270);
+
+        // batch manager: gabe
+        // upper hint: gabe
+        // lower hint: 0
+        // upfront fee: 1_261.275141740191589507 ether
+        vm.prank(adam);
+        handler.openTroveAndJoinInterestBatchManager(1, 66_969.454138225567397381 ether, 2.984784797753777921 ether, 4294967294, 1, 52);
+        info("gabe ent debt 2: ", c.troveManager.getTroveEntireDebt(addressToTroveId(gabe)).decimal());
+        info("gabe rec debt 2: ", c.troveManager.getTroveDebt(addressToTroveId(gabe)).decimal());
+
+        // batch manager: hope
+        // upper hint: 0
+        // lower hint: barb
+        // upfront fee: 1_272.067039116734276271 ether
+        vm.prank(eric);
+        handler.openTroveAndJoinInterestBatchManager(0, 96_538.742068715532219745 ether, 2.762063859567414329 ether, 0, 61578232, 336273331);
+
+        // initial deposit: 6_184.412833814428802676 ether
+        // compounded deposit: 6_184.412833814428802676 ether
+        // yield gain: 7_538.471959199501948711 ether
+        // coll gain: 0 ether
+        // stashed coll: 0 ether
+        // blocked SP yield: 0 ether
+        vm.prank(hope);
+        handler.provideToSP(0, 0.000000001590447554 ether, true);
+
+        // initial deposit: 0 ether
+        // compounded deposit: 0 ether
+        // yield gain: 0 ether
+        // coll gain: 0 ether
+        // stashed coll: 0 ether
+        // blocked SP yield: 0 ether
+        vm.prank(fran);
+        handler.provideToSP(3, 180_836.387435487377369461 ether, true);
+
+        vm.prank(fran);
+        handler.addMeToLiquidationBatch();
+
+        // initial deposit: 0 ether
+        // compounded deposit: 0 ether
+        // yield gain: 0 ether
+        // coll gain: 0 ether
+        // stashed coll: 0 ether
+        // blocked SP yield: 0 ether
+        vm.prank(eric);
+        handler.provideToSP(2, 0.000000000000000012 ether, true);
+
+        vm.prank(carl);
+        handler.addMeToUrgentRedemptionBatch();
+
+        // redemption rate: 0.00500000000000102 ether
+        // redeemed BOLD: 0.000000000536305094 ether
+        // redeemed Troves: [
+        //   [barb],
+        //   [gabe],
+        //   [],
+        //   [],
+        // ]
+        info("gabe trove Id:     ", addressToTroveId(gabe).toString());
+        info("gabe ent debt e: ", c.troveManager.getTroveEntireDebt(addressToTroveId(gabe)).decimal());
+        info("gabe rec debt e: ", c.troveManager.getTroveDebt(addressToTroveId(gabe)).decimal());
+        info("lzti: ", c.troveManager.lastZombieTroveId().toString());
+        vm.prank(barb);
+        handler.redeemCollateral(0.000000000536305095 ether, 3);
     }
 }

--- a/contracts/src/test/HintHelpers.t.sol
+++ b/contracts/src/test/HintHelpers.t.sol
@@ -16,7 +16,7 @@ contract HintHelpersTest is DevTestSetup {
 
         assertEq(
             uint8(troveManager.getTroveStatus(redeemedTroveId)),
-            uint8(ITroveManager.Status.unredeemable),
+            uint8(ITroveManager.Status.zombie),
             "Redeemed Trove should have become a zombie"
         );
 

--- a/contracts/src/test/Invariants.t.sol
+++ b/contracts/src/test/Invariants.t.sol
@@ -109,6 +109,7 @@ contract InvariantsTest is Logging, BaseInvariantTest, BaseMultiCollateralTest {
             TestDeployer.LiquityContractsDev memory c = branches[i];
 
             assertEq(c.troveManager.getTroveIdsCount(), handler.numTroves(i), "Wrong number of Troves");
+            assertEq(c.troveManager.lastZombieTroveId(), handler.designatedVictimId(i), "Wrong designated victim");
             assertEq(c.sortedTroves.getSize(), handler.numTroves(i) - handler.numZombies(i), "Wrong SortedTroves size");
             assertApproxEqAbsDecimal(
                 c.activePool.calcPendingAggInterest(), handler.getPendingInterest(i), 1e-10 ether, 18, "Wrong interest"
@@ -186,8 +187,7 @@ contract InvariantsTest is Logging, BaseInvariantTest, BaseMultiCollateralTest {
                 ITroveManager.Status status = c.troveManager.getTroveStatus(troveId);
 
                 assertTrue(
-                    status == ITroveManager.Status.active || status == ITroveManager.Status.zombie,
-                    "Unexpected status"
+                    status == ITroveManager.Status.active || status == ITroveManager.Status.zombie, "Unexpected status"
                 );
 
                 if (status == ITroveManager.Status.active) {

--- a/contracts/src/test/Invariants.t.sol
+++ b/contracts/src/test/Invariants.t.sol
@@ -38,7 +38,7 @@ library ToStringFunctions {
         if (status == ITroveManager.Status.active) return "ITroveManager.Status.active";
         if (status == ITroveManager.Status.closedByOwner) return "ITroveManager.Status.closedByOwner";
         if (status == ITroveManager.Status.closedByLiquidation) return "ITroveManager.Status.closedByLiquidation";
-        if (status == ITroveManager.Status.unredeemable) return "ITroveManager.Status.unredeemable";
+        if (status == ITroveManager.Status.zombie) return "ITroveManager.Status.zombie";
         revert("Invalid status");
     }
 }
@@ -186,14 +186,14 @@ contract InvariantsTest is Logging, BaseInvariantTest, BaseMultiCollateralTest {
                 ITroveManager.Status status = c.troveManager.getTroveStatus(troveId);
 
                 assertTrue(
-                    status == ITroveManager.Status.active || status == ITroveManager.Status.unredeemable,
+                    status == ITroveManager.Status.active || status == ITroveManager.Status.zombie,
                     "Unexpected status"
                 );
 
                 if (status == ITroveManager.Status.active) {
                     assertTrue(c.sortedTroves.contains(troveId), "SortedTroves should contain active Troves");
                 } else {
-                    assertFalse(c.sortedTroves.contains(troveId), "SortedTroves shouldn't contain unredeemable Troves");
+                    assertFalse(c.sortedTroves.contains(troveId), "SortedTroves shouldn't contain zombie Troves");
                 }
             }
         }

--- a/contracts/src/test/TestContracts/BaseTest.sol
+++ b/contracts/src/test/TestContracts/BaseTest.sol
@@ -302,7 +302,7 @@ contract BaseTest is TestAccounts, Logging {
         vm.stopPrank();
     }
 
-    function adjustUnredeemableTrove(
+    function adjustZombieTrove(
         address _account,
         uint256 _troveId,
         uint256 _collChange,
@@ -312,7 +312,7 @@ contract BaseTest is TestAccounts, Logging {
     ) public {
         vm.startPrank(_account);
 
-        borrowerOperations.adjustUnredeemableTrove(
+        borrowerOperations.adjustZombieTrove(
             _troveId,
             _collChange,
             _isCollIncrease,

--- a/contracts/src/test/TestContracts/DevTestSetup.sol
+++ b/contracts/src/test/TestContracts/DevTestSetup.sol
@@ -258,8 +258,26 @@ contract DevTestSetup is BaseTest {
         assertLt(troveManager.getTroveEntireDebt(_troveIDs.B), MIN_DEBT);
 
         // Check A and B tagged as Zombie troves
-        assertEq(uint8(troveManager.getTroveStatus(_troveIDs.A)), uint8(ITroveManager.Status.unredeemable));
-        assertEq(uint8(troveManager.getTroveStatus(_troveIDs.A)), uint8(ITroveManager.Status.unredeemable));
+        assertEq(uint8(troveManager.getTroveStatus(_troveIDs.A)), uint8(ITroveManager.Status.zombie));
+        assertEq(uint8(troveManager.getTroveStatus(_troveIDs.A)), uint8(ITroveManager.Status.zombie));
+    }
+
+    function _redeemAndCreateEmptyZombieTrovesAAndB(ABCDEF memory _troveIDs) internal {
+        // Redeem enough to leave A with 0 debt and B with debt < MIN_DEBT
+        uint256 redeemFromA = troveManager.getTroveEntireDebt(_troveIDs.A);
+        uint256 redeemFromB = troveManager.getTroveEntireDebt(_troveIDs.B);
+        uint256 redeemAmount = redeemFromA + redeemFromB;
+
+        // Fully redeem A and B
+        redeem(E, redeemAmount);
+
+        // Check A, B has debt == 0
+        assertEq(troveManager.getTroveEntireDebt(_troveIDs.A), 0);
+        assertEq(troveManager.getTroveEntireDebt(_troveIDs.B), 0);
+
+        // Check A and B tagged as Zombie troves
+        assertEq(uint8(troveManager.getTroveStatus(_troveIDs.A)), uint8(ITroveManager.Status.zombie));
+        assertEq(uint8(troveManager.getTroveStatus(_troveIDs.A)), uint8(ITroveManager.Status.zombie));
     }
 
     function _redeemAndCreateZombieTroveAAndHitB(ABCDEF memory _troveIDs) internal {
@@ -276,7 +294,7 @@ contract DevTestSetup is BaseTest {
         assertGt(troveManager.getTroveEntireDebt(_troveIDs.B), MIN_DEBT);
 
         // // Check A is zombie Trove but B is not
-        assertEq(uint8(troveManager.getTroveStatus(_troveIDs.A)), uint8(ITroveManager.Status.unredeemable));
+        assertEq(uint8(troveManager.getTroveStatus(_troveIDs.A)), uint8(ITroveManager.Status.zombie));
         assertEq(uint8(troveManager.getTroveStatus(_troveIDs.B)), uint8(ITroveManager.Status.active));
     }
 

--- a/contracts/src/test/TestContracts/Interfaces/ITroveManagerTester.sol
+++ b/contracts/src/test/TestContracts/Interfaces/ITroveManagerTester.sol
@@ -40,7 +40,7 @@ interface ITroveManagerTester is ITroveManager {
     // Trove and batch getters
     function checkTroveIsActive(uint256 _troveId) external view returns (bool);
     function checkTroveIsOpen(uint256 _troveId) external view returns (bool);
-    function checkTroveIsUnredeemable(uint256 _troveId) external view returns (bool);
+    function checkTroveIsZombie(uint256 _troveId) external view returns (bool);
 
     function hasRedistributionGains(uint256 _troveId) external view returns (bool);
 

--- a/contracts/src/test/TestContracts/TroveManagerTester.t.sol
+++ b/contracts/src/test/TestContracts/TroveManagerTester.t.sol
@@ -152,7 +152,7 @@ contract TroveManagerTester is ITroveManagerTester, TroveManager {
 
     function checkTroveIsOpen(uint256 _troveId) public view returns (bool) {
         Status status = Troves[_troveId].status;
-        return status == Status.active || status == Status.unredeemable;
+        return status == Status.active || status == Status.zombie;
     }
 
     function checkTroveIsActive(uint256 _troveId) external view returns (bool) {
@@ -160,9 +160,9 @@ contract TroveManagerTester is ITroveManagerTester, TroveManager {
         return status == Status.active;
     }
 
-    function checkTroveIsUnredeemable(uint256 _troveId) external view returns (bool) {
+    function checkTroveIsZombie(uint256 _troveId) external view returns (bool) {
         Status status = Troves[_troveId].status;
-        return status == Status.unredeemable;
+        return status == Status.zombie;
     }
 
     function hasRedistributionGains(uint256 _troveId) external view override returns (bool) {

--- a/contracts/src/test/Utils/TroveId.sol
+++ b/contracts/src/test/Utils/TroveId.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+
+contract TroveId {
+    function addressToTroveId(address _owner, uint256 _ownerIndex) public pure returns (uint256) {
+        return uint256(keccak256(abi.encode(_owner, _ownerIndex)));
+    }
+
+    function addressToTroveId(address _owner) public pure returns (uint256) {
+        return addressToTroveId(_owner, 0);
+    }
+}

--- a/contracts/src/test/interestBatchManagement.t.sol
+++ b/contracts/src/test/interestBatchManagement.t.sol
@@ -114,7 +114,7 @@ contract InterestBatchManagementTest is DevTestSetup {
         vm.stopPrank();
     }
 
-    function testCannotSetBatchManagerIfTroveIsUnredeemable() public {
+    function testCannotSetBatchManagerIfTroveIsZombie() public {
         registerBatchManager(B);
 
         // Open trove
@@ -754,7 +754,7 @@ contract InterestBatchManagementTest is DevTestSetup {
         redeem(A, 500e18);
 
         // Check A is zombie
-        assertEq(uint8(troveManager.getTroveStatus(ATroveId)), uint8(ITroveManager.Status.unredeemable));
+        assertEq(uint8(troveManager.getTroveStatus(ATroveId)), uint8(ITroveManager.Status.zombie));
 
         // Fast-forward time
         vm.warp(block.timestamp + 3650 days);
@@ -1135,7 +1135,7 @@ contract InterestBatchManagementTest is DevTestSetup {
         assertEq(troveData.lastInterestRateAdjTime, block.timestamp, "Wrong interest rate adj time for A");
     }
 
-    function testAnUnredeemableTroveGoesBackToTheBatch() public {
+    function testAnZombieTroveGoesBackToTheBatch() public {
         // A opens trove and joins batch manager B
         uint256 troveId = openTroveAndJoinBatchManager(A, 100 ether, 2000e18, B, 5e16);
 
@@ -1144,11 +1144,11 @@ contract InterestBatchManagementTest is DevTestSetup {
 
         vm.warp(block.timestamp + 10 days);
 
-        // C redeems and makes A unredeemable
+        // C redeems and makes A zombie
         redeem(C, 1000e18);
 
         // A adjusts back to normal
-        adjustUnredeemableTrove(A, troveId, 0, false, 1000e18, true);
+        adjustZombieTrove(A, troveId, 0, false, 1000e18, true);
 
         assertEq(borrowerOperations.interestBatchManagerOf(troveId), B, "A should be in batch (BO)");
         (,,,,,,,, address tmBatchManagerAddress,) = troveManager.Troves(troveId);

--- a/contracts/src/test/interestIndividualDelegation.t.sol
+++ b/contracts/src/test/interestIndividualDelegation.t.sol
@@ -121,17 +121,17 @@ contract InterestIndividualDelegationTest is DevTestSetup {
         vm.stopPrank();
     }
 
-    function testSetDelegateRevertsIfTroveIsUnredeemable() public {
+    function testSetDelegateRevertsIfTroveIsZombie() public {
         vm.startPrank(B);
         borrowerOperations.registerBatchManager(1e16, 20e16, 5e16, 25e14, MIN_INTEREST_RATE_CHANGE_PERIOD);
         vm.stopPrank();
 
         // Open trove
         uint256 troveId = openTroveNoHints100pct(A, 100e18, 5000e18, 5e16);
-        // Make trove unredeemable
+        // Make trove zombie
         redeem(A, 4000e18);
-        // Check A’s trove is unredeemable
-        assertEq(troveManager.checkTroveIsUnredeemable(troveId), true, "A trove should be unredeemable");
+        // Check A’s trove is zombie
+        assertEq(troveManager.checkTroveIsZombie(troveId), true, "A trove should be zombie");
 
         // Set batch manager (B)
         vm.startPrank(A);

--- a/contracts/src/test/redemptions.t.sol
+++ b/contracts/src/test/redemptions.t.sol
@@ -22,12 +22,14 @@ contract Redemptions is DevTestSetup {
 
         uint256 debt_A = troveManager.getTroveEntireDebt(troveIDs.A);
         uint256 debt_B = troveManager.getTroveEntireDebt(troveIDs.B);
+        /*
         console.log(troveIDs.A, "A id");
         console.log(troveIDs.B, "B id");
         console.log(sortedTroves.contains(troveIDs.B), "B is in list t0");
         console.log(troveManager.getTroveEntireDebt(troveIDs.B), "A debt t0");
         console.log(troveManager.getTroveEntireDebt(troveIDs.B), "B debt t0");
         console.log(sortedTroves.getLast(), "first to redeem t0");
+        */
         uint256 debt_C = troveManager.getTroveEntireDebt(troveIDs.C);
         uint256 debt_D = troveManager.getTroveEntireDebt(troveIDs.D);
 
@@ -73,8 +75,8 @@ contract Redemptions is DevTestSetup {
         redeem(E, redeemAmount_1);
 
         // Check A and B still open
-        assertEq(uint8(troveManager.getTroveStatus(troveIDs.A)), uint8(ITroveManager.Status.unredeemable));
-        assertEq(uint8(troveManager.getTroveStatus(troveIDs.B)), uint8(ITroveManager.Status.unredeemable));
+        assertEq(uint8(troveManager.getTroveStatus(troveIDs.A)), uint8(ITroveManager.Status.zombie));
+        assertEq(uint8(troveManager.getTroveStatus(troveIDs.B)), uint8(ITroveManager.Status.zombie));
     }
 
     function testFullRedemptionLeavesTrovesWithDebtEqualToZero() public {
@@ -112,8 +114,8 @@ contract Redemptions is DevTestSetup {
         redeem(E, redeemAmount_2);
 
         // Check A and B still open with debt == zero
-        assertEq(uint8(troveManager.getTroveStatus(troveIDs.A)), uint8(ITroveManager.Status.unredeemable));
-        assertEq(uint8(troveManager.getTroveStatus(troveIDs.B)), uint8(ITroveManager.Status.unredeemable));
+        assertEq(uint8(troveManager.getTroveStatus(troveIDs.A)), uint8(ITroveManager.Status.zombie));
+        assertEq(uint8(troveManager.getTroveStatus(troveIDs.B)), uint8(ITroveManager.Status.zombie));
         assertEq(troveManager.getTroveEntireDebt(troveIDs.A), 0);
         assertEq(troveManager.getTroveEntireDebt(troveIDs.B), 0);
 
@@ -279,7 +281,8 @@ contract Redemptions is DevTestSetup {
 
         _redeemAndCreateZombieTrovesAAndB(troveIDs);
 
-        assertEq(uint8(troveManager.getTroveStatus(troveIDs.A)), uint8(ITroveManager.Status.unredeemable));
+        assertEq(uint8(troveManager.getTroveStatus(troveIDs.A)), uint8(ITroveManager.Status.zombie));
+        assertEq(troveManager.lastZombieTroveId(), troveIDs.B, "Wrong last zombie trove pointer");
     }
 
     function testTroveRedeemedToBelowMIN_DEBTBecomesZombieTrove() public {
@@ -287,7 +290,8 @@ contract Redemptions is DevTestSetup {
 
         _redeemAndCreateZombieTrovesAAndB(troveIDs);
 
-        assertEq(uint8(troveManager.getTroveStatus(troveIDs.B)), uint8(ITroveManager.Status.unredeemable));
+        assertEq(uint8(troveManager.getTroveStatus(troveIDs.B)), uint8(ITroveManager.Status.zombie));
+        assertEq(troveManager.lastZombieTroveId(), troveIDs.B, "Wrong last zombie trove pointer");
     }
 
     function testTroveRedeemedToAboveMIN_DEBTDoesNotBecomesZombieTrove() public {
@@ -296,6 +300,7 @@ contract Redemptions is DevTestSetup {
         _redeemAndCreateZombieTroveAAndHitB(troveIDs);
 
         assertEq(uint8(troveManager.getTroveStatus(troveIDs.C)), uint8(ITroveManager.Status.active));
+        assertEq(troveManager.lastZombieTroveId(), 0, "Wrong last zombie trove pointer");
     }
 
     function testZombieTrovesRemovedFromSortedList() public {
@@ -317,9 +322,12 @@ contract Redemptions is DevTestSetup {
 
         // Check Trove with lowest interest rate is C
         assertEq(sortedTroves.getLast(), troveIDs.C);
+
+        // Check last Zombie trove pointer
+        assertEq(troveManager.lastZombieTroveId(), troveIDs.B, "Wrong last zombie trove pointer");
     }
 
-    function testZombieTroveCantBeRedeemedFrom() public {
+    function testZombieTroveCanStillBeRedeemedFrom() public {
         (,, ABCDEF memory troveIDs) = _setupForRedemptionAscendingInterest();
 
         _redeemAndCreateZombieTrovesAAndB(troveIDs);
@@ -331,14 +339,143 @@ contract Redemptions is DevTestSetup {
         uint256 redeemAmount = debt_B / 2;
         redeem(E, redeemAmount);
 
-        // Check B's debt unchanged from redeemAmount < debt_B;
-        assertEq(debt_B, troveManager.getTroveEntireDebt(troveIDs.B));
+        // Check B's debt changed from redeemAmount < debt_B;
+        assertEq(troveManager.getTroveEntireDebt(troveIDs.B), debt_B - redeemAmount);
 
+        debt_B = troveManager.getTroveEntireDebt(troveIDs.B);
         redeemAmount = debt_B + 1;
         redeem(E, redeemAmount);
 
-        // Check B's debt unchanged from redeemAmount > debt_B;
-        assertEq(debt_B, troveManager.getTroveEntireDebt(troveIDs.B));
+        // Check B's debt changed from redeemAmount > debt_B;
+        assertEq(troveManager.getTroveEntireDebt(troveIDs.B), 0);
+    }
+
+    function testRedemptionsWithNoPartialLeaveNoPointerToZombieTroves() public {
+        (,, ABCDEF memory troveIDs) = _setupForRedemptionAscendingInterest();
+
+        _redeemAndCreateEmptyZombieTrovesAAndB(troveIDs);
+
+        // Check A, B removed from sorted list
+        assertFalse(sortedTroves.contains(troveIDs.A));
+        assertFalse(sortedTroves.contains(troveIDs.B));
+
+        // Check A, B zombie (already checked in helper above)
+        //assertEq(uint8(troveManager.getTroveStatus(troveIDs.A)), uint8(ITroveManager.Status.zombie));
+        //assertEq(uint8(troveManager.getTroveStatus(troveIDs.B)), uint8(ITroveManager.Status.zombie));
+
+        // Check A, B empty (already checked in helper above)
+        //assertEq(troveManager.getTroveEntireDebt(troveIDs.A), 0);
+        //assertEq(troveManager.getTroveEntireDebt(troveIDs.B), 0);
+
+        // Check last Zombie trove pointer
+        assertEq(troveManager.lastZombieTroveId(), 0, "Wrong last zombie trove pointer");
+    }
+
+    function testZombieTrovePointerGetsResetIfLastOneIsFullyRedemeed() public {
+        (,, ABCDEF memory troveIDs) = _setupForRedemptionAscendingInterest();
+
+        _redeemAndCreateZombieTrovesAAndB(troveIDs);
+
+        // Check last Zombie trove pointer
+        assertEq(troveManager.lastZombieTroveId(), troveIDs.B, "Wrong last zombie trove pointer before");
+
+        // Get B debt before 2nd redeem
+        uint256 debt_B = troveManager.getTroveEntireDebt(troveIDs.B);
+        assertGt(debt_B, 0, "B debt should be non zero");
+
+        uint256 redeemAmount = debt_B;
+        console2.log("redeem again");
+        console2.log(redeemAmount, "redeemAmount");
+        redeem(E, redeemAmount);
+
+        // Check B is empty now
+        assertEq(troveManager.getTroveEntireDebt(troveIDs.B), 0, "B debt should be zero");
+
+        // Check last Zombie trove pointer
+        assertEq(troveManager.lastZombieTroveId(), 0, "Wrong last zombie trove pointer after");
+    }
+
+    function testZombieTrovePointerGetsResetIfTroveIsResuscitatedManuallyByOwner() public {
+        (,, ABCDEF memory troveIDs) = _setupForRedemptionAscendingInterest();
+
+        _redeemAndCreateZombieTrovesAAndB(troveIDs);
+
+        // Check last Zombie trove pointer
+        assertEq(troveManager.lastZombieTroveId(), troveIDs.B, "Wrong last zombie trove pointer before");
+
+        // Restore trove
+        adjustZombieTrove(B, troveIDs.B, 0, false, MIN_DEBT, true);
+
+        // Check B is above min debt
+        assertGt(troveManager.getTroveEntireDebt(troveIDs.B), MIN_DEBT, "B debt should be above min");
+
+        // Check last Zombie trove pointer
+        assertEq(troveManager.lastZombieTroveId(), 0, "Wrong last zombie trove pointer after");
+    }
+
+    function testZombieTrovePointerGetsResetIfTroveIsResuscitatedViaInterest() public {
+        (,, ABCDEF memory troveIDs) = _setupForRedemptionAscendingInterest();
+
+        _redeemAndCreateZombieTrovesAAndB(troveIDs);
+
+        // Check last Zombie trove pointer
+        assertEq(troveManager.lastZombieTroveId(), troveIDs.B, "Wrong last zombie trove pointer before");
+
+        // Restore trove
+        adjustZombieTrove(B, troveIDs.B, 0, false, MIN_DEBT, true);
+        // fast-forward time a lot
+        vm.warp(block.timestamp + 3650 days);
+
+        // E applies interest on B's Trove
+        applyPendingDebt(E, troveIDs.B);
+
+        // Check B is above min debt
+        assertGt(troveManager.getTroveEntireDebt(troveIDs.B), MIN_DEBT, "B debt should be above min");
+
+        // Check last Zombie trove pointer
+        assertEq(troveManager.lastZombieTroveId(), 0, "Wrong last zombie trove pointer after");
+    }
+
+    function testZombieTrovePointerGetsResetIfTroveIsClosed() public {
+        (,, ABCDEF memory troveIDs) = _setupForRedemptionAscendingInterest();
+
+        _redeemAndCreateZombieTrovesAAndB(troveIDs);
+
+        // Check last Zombie trove pointer
+        assertEq(troveManager.lastZombieTroveId(), troveIDs.B, "Wrong last zombie trove pointer before");
+
+        // Get B debt before 2nd redeem
+        uint256 debt_B = troveManager.getTroveEntireDebt(troveIDs.B);
+        assertGt(debt_B, 0, "B debt should be non zero");
+
+        deal(address(boldToken), B, debt_B);
+        closeTrove(B, troveIDs.B);
+
+        // Check B is closed
+        assertEq(uint8(troveManager.getTroveStatus(troveIDs.B)), uint8(ITroveManager.Status.closedByOwner), "B trove should be closed");
+
+        // Check last Zombie trove pointer
+        assertEq(troveManager.lastZombieTroveId(), 0, "Wrong last zombie trove pointer after");
+    }
+
+    function testZombieTrovePointerGetsResetIfTroveIsLiquidated() public {
+        (,, ABCDEF memory troveIDs) = _setupForRedemptionAscendingInterest();
+
+        _redeemAndCreateZombieTrovesAAndB(troveIDs);
+
+        // Check last Zombie trove pointer
+        assertEq(troveManager.lastZombieTroveId(), troveIDs.B, "Wrong last zombie trove pointer before");
+
+        // Liquidate B
+        console2.log(troveManager.getCurrentICR(troveIDs.B, priceFeed.getPrice()), "troveManager.getCurrentICR(troveIDs.E, price)");
+        priceFeed.setPrice(priceFeed.getPrice() / 25);
+        liquidate(A, troveIDs.B);
+
+        // Check B is liquidated
+        assertEq(uint8(troveManager.getTroveStatus(troveIDs.B)), uint8(ITroveManager.Status.closedByLiquidation), "B trove should be liquidated");
+
+        // Check last Zombie trove pointer
+        assertEq(troveManager.lastZombieTroveId(), 0, "Wrong last zombie trove pointer after");
     }
 
     function testZombieTrovesCanReceiveRedistGains() public {
@@ -469,8 +606,8 @@ contract Redemptions is DevTestSetup {
         transferBold(E, A, boldToken.balanceOf(E) / 2);
         transferBold(E, B, boldToken.balanceOf(E));
 
-        assertEq(uint8(troveManager.getTroveStatus(troveIDs.A)), uint8(ITroveManager.Status.unredeemable));
-        assertEq(uint8(troveManager.getTroveStatus(troveIDs.B)), uint8(ITroveManager.Status.unredeemable));
+        assertEq(uint8(troveManager.getTroveStatus(troveIDs.A)), uint8(ITroveManager.Status.zombie));
+        assertEq(uint8(troveManager.getTroveStatus(troveIDs.B)), uint8(ITroveManager.Status.zombie));
 
         closeTrove(A, troveIDs.A);
         closeTrove(B, troveIDs.B);
@@ -496,8 +633,8 @@ contract Redemptions is DevTestSetup {
         uint256 surplusDebt = 37;
 
         // A and B withdraw Bold from their zombie Trove
-        adjustUnredeemableTrove(A, troveIDs.A, 0, false, debtDelta_A + surplusDebt, true);
-        adjustUnredeemableTrove(B, troveIDs.B, 0, false, debtDelta_A + surplusDebt, true);
+        adjustZombieTrove(A, troveIDs.A, 0, false, debtDelta_A + surplusDebt, true);
+        adjustZombieTrove(B, troveIDs.B, 0, false, debtDelta_A + surplusDebt, true);
 
         // Check they are above the min debt
         assertGt(troveManager.getTroveEntireDebt(troveIDs.A), MIN_DEBT);
@@ -521,8 +658,8 @@ contract Redemptions is DevTestSetup {
         uint256 surplusDebt = 37;
 
         // A and B withdraw Bold from their zombie Trove
-        adjustUnredeemableTrove(A, troveIDs.A, 0, false, debtDelta_A + surplusDebt, true);
-        adjustUnredeemableTrove(B, troveIDs.B, 0, false, debtDelta_A + surplusDebt, true);
+        adjustZombieTrove(A, troveIDs.A, 0, false, debtDelta_A + surplusDebt, true);
+        adjustZombieTrove(B, troveIDs.B, 0, false, debtDelta_A + surplusDebt, true);
 
         // Check they are above the min debt
         assertGt(troveManager.getTroveEntireDebt(troveIDs.A), MIN_DEBT);
@@ -554,8 +691,8 @@ contract Redemptions is DevTestSetup {
         assertFalse(sortedTroves.contains(troveIDs.B));
 
         // A and B withdraw Bold from their zombie Trove
-        adjustUnredeemableTrove(A, troveIDs.A, 0, false, debtDelta_A + surplusDebt, true);
-        adjustUnredeemableTrove(B, troveIDs.B, 0, false, debtDelta_A + surplusDebt, true);
+        adjustZombieTrove(A, troveIDs.A, 0, false, debtDelta_A + surplusDebt, true);
+        adjustZombieTrove(B, troveIDs.B, 0, false, debtDelta_A + surplusDebt, true);
 
         // Check they are above the min debt
         assertGt(troveManager.getTroveEntireDebt(troveIDs.A), MIN_DEBT);
@@ -586,8 +723,8 @@ contract Redemptions is DevTestSetup {
         uint256 surplusDebt = 37;
 
         // A and B withdraw Bold from their zombie Trove
-        adjustUnredeemableTrove(A, troveIDs.A, 0, false, debtDelta_A + surplusDebt, true);
-        adjustUnredeemableTrove(B, troveIDs.B, 0, false, debtDelta_A + surplusDebt, true);
+        adjustZombieTrove(A, troveIDs.A, 0, false, debtDelta_A + surplusDebt, true);
+        adjustZombieTrove(B, troveIDs.B, 0, false, debtDelta_A + surplusDebt, true);
 
         // Check they are above the min debt
         assertGt(troveManager.getTroveEntireDebt(troveIDs.A), MIN_DEBT, "A debt should be above min");
@@ -611,10 +748,10 @@ contract Redemptions is DevTestSetup {
 
         // A and B attempt to withdraw Bold, but not enough
         vm.expectRevert(BorrowerOperations.DebtBelowMin.selector);
-        this.adjustUnredeemableTrove(A, troveIDs.A, 0, false, borrow_A, true);
+        this.adjustZombieTrove(A, troveIDs.A, 0, false, borrow_A, true);
 
         vm.expectRevert(BorrowerOperations.DebtBelowMin.selector);
-        this.adjustUnredeemableTrove(B, troveIDs.B, 0, false, borrow_B, true);
+        this.adjustZombieTrove(B, troveIDs.B, 0, false, borrow_B, true);
     }
 
     function testZombieTroveBorrowerCanNotRepayDebt() public {
@@ -723,9 +860,9 @@ contract Redemptions is DevTestSetup {
         assertEq(troveManager.calcTroveAccruedInterest(troveIDs.A), 0);
         assertGt(troveManager.calcTroveAccruedInterest(troveIDs.B), 0);
         // Troves are zombie
-        assertTrue(troveManager.checkTroveIsUnredeemable(troveIDs.A));
+        assertTrue(troveManager.checkTroveIsZombie(troveIDs.A));
         assertFalse(sortedTroves.contains(troveIDs.A));
-        assertTrue(troveManager.checkTroveIsUnredeemable(troveIDs.B));
+        assertTrue(troveManager.checkTroveIsZombie(troveIDs.B));
         assertFalse(sortedTroves.contains(troveIDs.B));
 
         // E applies interest on A and B's Troves
@@ -736,9 +873,9 @@ contract Redemptions is DevTestSetup {
         assertEq(troveManager.calcTroveAccruedInterest(troveIDs.B), 0);
 
         // Troves are still zombie
-        assertTrue(troveManager.checkTroveIsUnredeemable(troveIDs.A));
+        assertTrue(troveManager.checkTroveIsZombie(troveIDs.A));
         assertFalse(sortedTroves.contains(troveIDs.A));
-        assertTrue(troveManager.checkTroveIsUnredeemable(troveIDs.B));
+        assertTrue(troveManager.checkTroveIsZombie(troveIDs.B));
         assertFalse(sortedTroves.contains(troveIDs.B));
     }
 
@@ -753,9 +890,9 @@ contract Redemptions is DevTestSetup {
         assertEq(troveManager.calcTroveAccruedInterest(troveIDs.A), 0);
         assertGt(troveManager.calcTroveAccruedInterest(troveIDs.B), 0);
         // Troves are zombie
-        assertTrue(troveManager.checkTroveIsUnredeemable(troveIDs.A));
+        assertTrue(troveManager.checkTroveIsZombie(troveIDs.A));
         assertFalse(sortedTroves.contains(troveIDs.A));
-        assertTrue(troveManager.checkTroveIsUnredeemable(troveIDs.B));
+        assertTrue(troveManager.checkTroveIsZombie(troveIDs.B));
         assertFalse(sortedTroves.contains(troveIDs.B));
 
         // E applies interest on A and B's Troves
@@ -765,9 +902,9 @@ contract Redemptions is DevTestSetup {
         assertEq(troveManager.calcTroveAccruedInterest(troveIDs.A), 0);
         assertEq(troveManager.calcTroveAccruedInterest(troveIDs.B), 0);
         // Troves B is not zombie anymore (A still is)
-        assertTrue(troveManager.checkTroveIsUnredeemable(troveIDs.A));
+        assertTrue(troveManager.checkTroveIsZombie(troveIDs.A));
         assertFalse(sortedTroves.contains(troveIDs.A));
-        assertFalse(troveManager.checkTroveIsUnredeemable(troveIDs.B));
+        assertFalse(troveManager.checkTroveIsZombie(troveIDs.B));
         assertTrue(sortedTroves.contains(troveIDs.B));
     }
 
@@ -791,7 +928,7 @@ contract Redemptions is DevTestSetup {
         // assertFalse(troveManager.checkBelowCriticalThreshold(price));
         assertLt(troveManager.getCurrentICR(troveIDs.B, price), MCR);
 
-        assertEq(uint8(troveManager.getTroveStatus(troveIDs.B)), uint8(ITroveManager.Status.unredeemable));
+        assertEq(uint8(troveManager.getTroveStatus(troveIDs.B)), uint8(ITroveManager.Status.zombie));
 
         // E liquidates B
         liquidate(E, troveIDs.B);

--- a/contracts/src/test/shutdown.t.sol
+++ b/contracts/src/test/shutdown.t.sol
@@ -219,11 +219,11 @@ contract ShutdownTest is DevTestSetup {
         vm.stopPrank();
     }
 
-    function testCannotAdjustUnredeemableTroveAfterShutdown() public {
+    function testCannotAdjustZombieTroveAfterShutdown() public {
         uint256 troveId = openMulticollateralTroveNoHints100pctWithIndex(0, A, 0, 11e18, 10000e18, 5e16);
         openMulticollateralTroveNoHints100pctWithIndex(0, B, 0, 22e18, 20000e18, 6e16);
 
-        // B redeems from A’s trove, to make it unredeemable
+        // B redeems from A’s trove, to make it zombie
         //deal(address(boldToken), B, 20000e18);
         vm.startPrank(B);
         collateralRegistry.redeemCollateral(10000e18, 0, 1e18);
@@ -234,12 +234,12 @@ contract ShutdownTest is DevTestSetup {
         contractsArray[0].priceFeed.setPrice(500e18);
         contractsArray[0].borrowerOperations.shutdown();
 
-        // Check A’s trove is unredeemable
-        assertEq(troveManager.checkTroveIsUnredeemable(troveId), true, "A trove should be unredeemable");
+        // Check A’s trove is zombie
+        assertEq(troveManager.checkTroveIsZombie(troveId), true, "A trove should be zombie");
 
         vm.startPrank(A);
         vm.expectRevert(BorrowerOperations.IsShutDown.selector);
-        borrowerOperations.adjustUnredeemableTrove(troveId, 1e18, true, 0, false, 0, 0, 1000e18);
+        borrowerOperations.adjustZombieTrove(troveId, 1e18, true, 0, false, 0, 0, 1000e18);
         vm.stopPrank();
     }
 

--- a/contracts/src/test/zapperGasComp.t.sol
+++ b/contracts/src/test/zapperGasComp.t.sol
@@ -307,7 +307,7 @@ contract ZapperGasCompTest is DevTestSetup {
     }
 
     // TODO: more adjustment combinations
-    function testCanAdjustUnredeemableTroveWithdrawCollAndBold() external {
+    function testCanAdjustZombieTroveWithdrawCollAndBold() external {
         uint256 collAmount1 = 10 ether;
         uint256 collAmount2 = 1 ether;
         uint256 boldAmount1 = 10000e18;
@@ -335,7 +335,7 @@ contract ZapperGasCompTest is DevTestSetup {
         gasCompZapper.setRemoveManagerWithReceiver(troveId, B, A);
         vm.stopPrank();
 
-        // Redeem to make trove unredeemable
+        // Redeem to make trove zombie
         vm.startPrank(A);
         collateralRegistry.redeemCollateral(boldAmount1 - boldAmount2, 10, 1e18);
         vm.stopPrank();
@@ -347,7 +347,7 @@ contract ZapperGasCompTest is DevTestSetup {
 
         // Adjust (withdraw coll and Bold)
         vm.startPrank(B);
-        gasCompZapper.adjustUnredeemableTroveWithRawETH(
+        gasCompZapper.adjustZombieTroveWithRawETH(
             troveId, collAmount2, false, boldAmount2, true, 0, 0, boldAmount2
         );
         vm.stopPrank();

--- a/contracts/src/test/zapperWETH.t.sol
+++ b/contracts/src/test/zapperWETH.t.sol
@@ -342,7 +342,7 @@ contract ZapperWETHTest is DevTestSetup {
     }
 
     // TODO: more adjustment combinations
-    function testCanAdjustUnredeemableTroveWithdrawCollAndBold() external {
+    function testCanAdjustZombieTroveWithdrawCollAndBold() external {
         uint256 ethAmount1 = 10 ether;
         uint256 ethAmount2 = 1 ether;
         uint256 boldAmount1 = 10000e18;
@@ -369,7 +369,7 @@ contract ZapperWETHTest is DevTestSetup {
         wethZapper.setRemoveManagerWithReceiver(troveId, B, A);
         vm.stopPrank();
 
-        // Redeem to make trove unredeemable
+        // Redeem to make trove zombie
         vm.startPrank(A);
         collateralRegistry.redeemCollateral(boldAmount1 - boldAmount2, 10, 1e18);
         vm.stopPrank();
@@ -381,7 +381,7 @@ contract ZapperWETHTest is DevTestSetup {
 
         // Adjust (withdraw coll and Bold)
         vm.startPrank(B);
-        wethZapper.adjustUnredeemableTroveWithRawETH(troveId, ethAmount2, false, boldAmount2, true, 0, 0, boldAmount2);
+        wethZapper.adjustZombieTroveWithRawETH(troveId, ethAmount2, false, boldAmount2, true, 0, 0, boldAmount2);
         vm.stopPrank();
 
         assertEq(troveManager.getTroveEntireColl(troveId), troveCollBefore - ethAmount2, "Trove coll mismatch");


### PR DESCRIPTION
Closes #425

Note: with this implementation, it can happen that a trove belonging to a batch, has both entire and recorded debt, due to the batch being updated (even the function `redeemCollateral` does that as a preliminary step) but without a direct action on the trove, and the trove is still zombie and holds the pointer to the last zombie trove, so it gets redeemed first in the list.

This seems like quite an edge case, and the user can easily prevent it by taking care of the trove before.
