### PR TITLE
Fixing import path for compatibility as Foundry dependency

### DIFF
--- a/contracts/src/NFTMetadata/MetadataNFT.sol
+++ b/contracts/src/NFTMetadata/MetadataNFT.sol
@@ -1,7 +1,7 @@
 //SPDX-License-Identifier: MIT
 pragma solidity 0.8.18;
 
-import "Solady/utils/SSTORE2.sol";
+import "lib/Solady/src/utils/SSTORE2.sol";
 import "./utils/JSON.sol";
 
 import "./utils/baseSVG.sol";


### PR DESCRIPTION
The import path previously specified in https://github.com/liquity/bold/blob/main/contracts/src/NFTMetadata/MetadataNFT.sol#L4

resulted in a build error when trying to add the liquity/bold repo as a dependency to a Foundry project 
![image](https://github.com/user-attachments/assets/1d6dd8e2-0084-4ca4-a196-3890c18a7688)

because there was no `Solady/utils/SSTORE2.sol` path. 

This PR resolves this issue and allows the repo to be successfully added as a dependency in a Foundry project.