### PR TITLE
fix: avoid overflow in batched Trove's `weightedRecordedDebt`

### DIFF
--- a/contracts/src/TroveManager.sol
+++ b/contracts/src/TroveManager.sol
@@ -963,8 +963,7 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
 
         if (totalDebtShares > 0) {
             _latestTroveData.recordedDebt = _latestBatchData.recordedDebt * batchDebtShares / totalDebtShares;
-            _latestTroveData.weightedRecordedDebt =
-                _latestBatchData.weightedRecordedDebt * batchDebtShares / totalDebtShares;
+            _latestTroveData.weightedRecordedDebt = _latestTroveData.recordedDebt * _latestBatchData.annualInterestRate;
             _latestTroveData.accruedInterest = _latestBatchData.accruedInterest * batchDebtShares / totalDebtShares;
             _latestTroveData.accruedBatchManagementFee =
                 _latestBatchData.accruedManagementFee * batchDebtShares / totalDebtShares;


### PR DESCRIPTION
The batch's `weightedRecordedDebt` is already a product of 2 big numbers (batch total debt * annual interest rate), so it's best to avoid multiplying it by a 3rd one.