### PR TITLE
Prevent shares to debt ratio in batches to be too low

### DIFF
--- a/contracts/src/Dependencies/Constants.sol
+++ b/contracts/src/Dependencies/Constants.sol
@@ -28,6 +28,11 @@ uint128 constant MIN_INTEREST_RATE_CHANGE_PERIOD = 1 seconds; // prevents more t
 
 uint256 constant REDEMPTION_FEE_FLOOR = _1pct / 2; // 0.5%
 
+// For the shares ratio to decrease 1e9 (1e18/MIN_BATCH_SHARES_RATIO),
+// at an average annual rate of 10%, it would take more than 217 years (log(1e9)/log(1.1))
+// at an average annual rate of 50%, it would take more than 51 years (log(1e9)/log(1.5))
+uint256 constant MIN_BATCH_SHARES_RATIO = 1e9;
+
 // Half-life of 12h. 12h = 720 min
 // (1/2) = d^720 => d = (1/2)^(1/720)
 uint256 constant REDEMPTION_MINUTE_DECAY_FACTOR = 999037758833783000;

--- a/contracts/src/Dependencies/Constants.sol
+++ b/contracts/src/Dependencies/Constants.sol
@@ -31,6 +31,8 @@ uint256 constant REDEMPTION_FEE_FLOOR = _1pct / 2; // 0.5%
 // For the debt / shares ratio to increase by a factor 1e9
 // at a average annual debt increase (compounded interest + fees) of 10%, it would take more than 217 years (log(1e9)/log(1.1))
 // at a average annual debt increase (compounded interest + fees) of 50%, it would take more than 51 years (log(1e9)/log(1.5))
+// The increase pace could be forced to be higher through an inflation attack,
+// but precisely the fact that we have this max value now prevents the attack
 uint256 constant MAX_BATCH_SHARES_RATIO = 1e9;
 
 // Half-life of 12h. 12h = 720 min

--- a/contracts/src/Dependencies/Constants.sol
+++ b/contracts/src/Dependencies/Constants.sol
@@ -28,10 +28,10 @@ uint128 constant MIN_INTEREST_RATE_CHANGE_PERIOD = 1 seconds; // prevents more t
 
 uint256 constant REDEMPTION_FEE_FLOOR = _1pct / 2; // 0.5%
 
-// For the shares ratio to decrease 1e9 (1e18/MIN_BATCH_SHARES_RATIO),
-// at an average annual rate of 10%, it would take more than 217 years (log(1e9)/log(1.1))
-// at an average annual rate of 50%, it would take more than 51 years (log(1e9)/log(1.5))
-uint256 constant MIN_BATCH_SHARES_RATIO = 1e9;
+// For the debt / shares ratio to increase by a factor 1e9
+// at a average annual debt increase (compounded interest + fees) of 10%, it would take more than 217 years (log(1e9)/log(1.1))
+// at a average annual debt increase (compounded interest + fees) of 50%, it would take more than 51 years (log(1e9)/log(1.5))
+uint256 constant MAX_BATCH_SHARES_RATIO = 1e9;
 
 // Half-life of 12h. 12h = 720 min
 // (1/2) = d^720 => d = (1/2)^(1/720)

--- a/contracts/src/TroveManager.sol
+++ b/contracts/src/TroveManager.sol
@@ -572,12 +572,15 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
 
             Troves[_singleRedemption.troveId].coll = newColl;
             // interest and fee were updated in the outer function
+            // This call could revert due to BatchSharesRatioTooHigh if trove.redistCollGain > boldLot
+            // so we skip that check to avoid blocking redemptions
             _updateBatchShares(
                 _singleRedemption.troveId,
                 _singleRedemption.batchAddress,
                 troveChange,
                 _singleRedemption.batch.entireCollWithoutRedistribution,
-                _singleRedemption.batch.entireDebtWithoutRedistribution
+                _singleRedemption.batch.entireDebtWithoutRedistribution,
+                false // _checkBatchSharesRatio
             );
         } else {
             _singleRedemption.oldWeightedRecordedDebt = _singleRedemption.trove.weightedRecordedDebt;
@@ -1267,7 +1270,7 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
         // Push the trove's id to the Trove list
         TroveIds.push(_troveId);
 
-        _updateBatchShares(_troveId, _batchAddress, _troveChange, _batchColl, _batchDebt);
+        _updateBatchShares(_troveId, _batchAddress, _troveChange, _batchColl, _batchDebt, true);
 
         uint256 newTotalStakes = totalStakes + newStake;
         totalStakes = newTotalStakes;
@@ -1519,7 +1522,7 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
         uint256 newStake = _updateStakeAndTotalStakes(_troveId, _newTroveColl);
 
         // Batch
-        _updateBatchShares(_troveId, _batchAddress, _troveChange, _newBatchColl, _newBatchDebt);
+        _updateBatchShares(_troveId, _batchAddress, _troveChange, _newBatchColl, _newBatchDebt, true);
 
         _movePendingTroveRewardsToActivePool(
             defaultPool, _troveChange.appliedRedistBoldDebtGain, _troveChange.appliedRedistCollGain
@@ -1574,7 +1577,7 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
         Troves[_troveId].coll = _newTroveColl;
 
         if (_batchAddress != address(0)) {
-            _updateBatchShares(_troveId, _batchAddress, _troveChange, _newBatchColl, _newBatchDebt);
+            _updateBatchShares(_troveId, _batchAddress, _troveChange, _newBatchColl, _newBatchDebt, true);
 
             emit BatchUpdated({
                 _interestBatchManager: _batchAddress,
@@ -1715,7 +1718,7 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
         _troveChange.collIncrease = _params.troveColl - _troveChange.appliedRedistCollGain;
         _troveChange.debtIncrease = _params.troveDebt - _troveChange.appliedRedistBoldDebtGain - _troveChange.upfrontFee;
         _updateBatchShares(
-            _params.troveId, _params.newBatchAddress, _troveChange, _params.newBatchColl, _params.newBatchDebt
+            _params.troveId, _params.newBatchAddress, _troveChange, _params.newBatchColl, _params.newBatchDebt, true
         );
 
         _movePendingTroveRewardsToActivePool(
@@ -1763,7 +1766,8 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
         address _batchAddress,
         TroveChange memory _troveChange,
         uint256 _batchColl, // without trove change
-        uint256 _batchDebt // entire (with interest, batch fee), but without trove change, nor upfront fee nor redist
+        uint256 _batchDebt, // entire (with interest, batch fee), but without trove change, nor upfront fee nor redist
+        bool _checkBatchSharesRatio
     ) internal {
         // Debt
         uint256 currentBatchDebtShares = batches[_batchAddress].totalDebtShares;
@@ -1787,7 +1791,7 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
                     batchDebtSharesDelta = debtIncrease;
                 } else {
                     // To avoid rebasing issues, let’s make sure the ratio debt / shares is not too high
-                    _requireBelowMaxSharesRatio(currentBatchDebtShares, _batchDebt);
+                    _requireBelowMaxSharesRatio(currentBatchDebtShares, _batchDebt, _checkBatchSharesRatio);
 
                     batchDebtSharesDelta = currentBatchDebtShares * debtIncrease / _batchDebt;
                 }
@@ -1834,9 +1838,9 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
     // at a average annual debt increase (compounded interest + fees) of 10%, it would take more than 217 years (log(1e9)/log(1.1))
     // at a average annual debt increase (compounded interest + fees) of 50%, it would take more than 51 years (log(1e9)/log(1.5))
     // When that happens, no more debt can be manually added to the batch, so batch should be migrated to a new one
-    function _requireBelowMaxSharesRatio(uint256 _currentBatchDebtShares, uint256 _batchDebt) internal pure {
+    function _requireBelowMaxSharesRatio(uint256 _currentBatchDebtShares, uint256 _batchDebt, bool _checkBatchSharesRatio) internal pure {
         // debt / shares should be below MAX_BATCH_SHARES_RATIO
-        if (_currentBatchDebtShares * MAX_BATCH_SHARES_RATIO < _batchDebt) {
+        if (_currentBatchDebtShares * MAX_BATCH_SHARES_RATIO < _batchDebt && _checkBatchSharesRatio) {
             revert BatchSharesRatioTooHigh();
         }
     }

--- a/contracts/src/TroveManager.sol
+++ b/contracts/src/TroveManager.sol
@@ -1767,7 +1767,7 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
         TroveChange memory _troveChange,
         uint256 _batchColl, // without trove change
         uint256 _batchDebt, // entire (with interest, batch fee), but without trove change, nor upfront fee nor redist
-        bool _checkBatchSharesRatio
+        bool _checkBatchSharesRatio // whether we do the check on the resulting ratio inside the func call
     ) internal {
         // Debt
         uint256 currentBatchDebtShares = batches[_batchAddress].totalDebtShares;

--- a/contracts/src/test/rebasingBatchShares.t.sol
+++ b/contracts/src/test/rebasingBatchShares.t.sol
@@ -142,9 +142,9 @@ contract RebasingBatchShares is DevTestSetup {
         uint256 batchShares = _getTotalBatchDebtShares(batch);
         console2.log("Batch Shares:         ", batchShares);
         // Log ratio
-        uint256 batchSharesRatio = batchShares * DECIMAL_PRECISION / batchDebt;
-        console2.log("shares / batch ratio: ", batchSharesRatio);
-        console2.log("Ratio too low?        ", batchSharesRatio < MIN_BATCH_SHARES_RATIO);
+        uint256 batchSharesRatio = batchDebt / batchShares;
+        console2.log("debt / shares ratio:  ", batchSharesRatio);
+        console2.log("Ratio too high?       ", batchSharesRatio > MAX_BATCH_SHARES_RATIO);
 
         // Trove
         /*
@@ -152,9 +152,9 @@ contract RebasingBatchShares is DevTestSetup {
         console2.log("Trove Debt:           ", troveData.entireDebt);
         uint256 troveBatchShares = _getBatchDebtShares(troveId);
         console2.log("Trove Shares:         ", troveBatchShares);
-        uint256 troveSharesRatio = troveBatchShares * DECIMAL_PRECISION / troveData.entireDebt;
+        uint256 troveSharesRatio = troveData.entireDebt / troveBatchShares;
         console2.log("Trove ratio:          ", troveSharesRatio);
-        console2.log("Ratio too low?        ", troveSharesRatio < MIN_BATCH_SHARES_RATIO);
+        console2.log("Ratio too high?       ", troveSharesRatio > MAX_BATCH_SHARES_RATIO);
         */
     }
 
@@ -224,7 +224,7 @@ contract RebasingBatchShares is DevTestSetup {
             receiver: address(0)
         });
         vm.startPrank(_troveOwner);
-        vm.expectRevert(TroveManager.BatchSharesRatioTooLow.selector);
+        vm.expectRevert(TroveManager.BatchSharesRatioTooHigh.selector);
         uint256 troveId = borrowerOperations.openTroveAndJoinInterestBatchManager(params);
         vm.stopPrank();
 

--- a/contracts/src/test/rebasingBatchShares.t.sol
+++ b/contracts/src/test/rebasingBatchShares.t.sol
@@ -97,7 +97,7 @@ contract RebasingBatchShares is DevTestSetup {
         _logTrovesAndBatch(B, BTroveId);
 
         // === 4: Free Loans === //
-        uint256 debtB4 = borrowerOperations.getEntireSystemDebt();
+        // uint256 debtB4 = borrowerOperations.getEntireSystemDebt();
         // We shouldn’t be able to open a new Trove now
         uint256 anotherATroveId = openTroveExpectRevert(A, 100 ether, MIN_DEBT, B);
         assertEq(anotherATroveId, 0);


### PR DESCRIPTION
Fixes issues 42 from @GalloDaSballo audit and `CS-BOLD-001` from ChainSecurity.

There are 2 calls to `updatedBatchShares` that deserve special attention:

1. From redistributions:
If trove redistribution is bigger than the amount being redeemed, it would revert. It would even affect other branches. Unpredictable and bad, as it breaks the foundation of the system. There are 2 alternatives:
- Skip the trove. Adding complexity. Besides by definition that’s not good (could someone use it to game the system? Seems unlikely, but it opens the door), it may lead to DoS: if the batch is huge, and the pending redemption is low, it may happen that we have to skip all troves in that batch and therefore running out of gas. Seems super unlikely, as we need a huge batch, full of troves pending redistribution gains (which never happened in v1 and likely will never happen in v2), and that has a bad debt/shares ratio (unlikely too). But not nice to have anyway.
- [Chosen one] Skip the check for redemptions. The problem is that some troves may get less shares than they should coming from redistributions. Again, unlikely, hard to exploit on purpose. Besides the max debt/shares ratio still has a lot of margin (1e9), so the effect would be negligible. I don’t think it would be feasible in practice to lower that amount really low only by applying redistributions, and even then, only the debt coming from redistributions after a redemption would benefit from that. 

2. From `onApplyTroveInterest`. More or less the same happens here: it would revert if it has redistribution gains of any size. We can skip the check or revert. Here I would revert normally, to avoid that trove owner tries to benefit from it. The downsize is that the rest of the system cannot extract the pending interest from that trove permissionlessly, but I don’t think that’s a big deal, as the owner can not do much with that trove until it leaves the blocked batch.