### PR TITLE
fix: zombie Trove pointer reset despite no new zombie

### DIFF
--- a/contracts/src/TroveManager.sol
+++ b/contracts/src/TroveManager.sol
@@ -683,9 +683,6 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
                 // Reset last zombie trove pointer if the previous one was fully redeemed now
                 lastZombieTroveId = 0;
             }
-        } else {
-            // Reset last zombie trove pointer if the previous one ended up above min debt
-            lastZombieTroveId = 0;
         }
     }
 

--- a/contracts/src/TroveManager.sol
+++ b/contracts/src/TroveManager.sol
@@ -684,6 +684,9 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
                 lastZombieTroveId = 0;
             }
         }
+        // Note: technically, it could happen that the Trove pointed to by `lastZombieTroveId` ends up with
+        // newDebt >= MIN_DEBT thanks to BOLD debt redistribution, which means it _could_ be made active again,
+        // however we don't do that here, as it would require hints for re-insertion into `SortedTroves`.
     }
 
     function _updateBatchInterestPriorToRedemption(IActivePool _activePool, address _batchAddress) internal {

--- a/contracts/src/test/TestContracts/InvariantsTestHandler.t.sol
+++ b/contracts/src/test/TestContracts/InvariantsTestHandler.t.sol
@@ -2477,17 +2477,16 @@ contract InvariantsTestHandler is BaseHandler, BaseMultiCollateralTest {
         }
     }
 
-    // function _dumpSortedTroves(uint256 i) internal {
-    //     ISortedTroves sortedTroves = branches[i].sortedTroves;
-    //     ITroveManager troveManager = branches[i].troveManager;
+    // function dumpSortedTroves(uint256 i) public view {
+    //     TestDeployer.LiquityContractsDev memory c = branches[i];
 
     //     info("SortedTroves: [");
-    //     for (uint256 curr = sortedTroves.getFirst(); curr != 0; curr = sortedTroves.getNext(curr)) {
+    //     for (uint256 curr = c.sortedTroves.getFirst(); curr != 0; curr = c.sortedTroves.getNext(curr)) {
     //         info(
     //             "  Trove({owner: ",
-    //             vm.getLabel(troveManager.ownerOf(curr)),
+    //             vm.getLabel(c.troveNFT.ownerOf(curr)),
     //             ", annualInterestRate: ",
-    //             troveManager.getTroveAnnualInterestRate(curr).decimal(),
+    //             c.troveManager.getTroveAnnualInterestRate(curr).decimal(),
     //             "}),"
     //         );
     //     }
@@ -2662,7 +2661,8 @@ contract InvariantsTestHandler is BaseHandler, BaseMultiCollateralTest {
         if (batchManager != address(0)) r[i].batchManagers.add(batchManager);
 
         uint256 newDebt = trove.entireDebt - debtRedeemed;
-        r[i].newDesignatedVictimId = 0 < newDebt && newDebt < MIN_DEBT ? troveId : 0;
+        if (troveId == designatedVictimId[i] && newDebt == 0) r[i].newDesignatedVictimId = 0;
+        if (0 < newDebt && newDebt < MIN_DEBT) r[i].newDesignatedVictimId = troveId;
     }
 
     function _planRedemption(uint256 amount, uint256 maxIterationsPerCollateral, uint256 feePct)

--- a/contracts/src/test/redemptions.t.sol
+++ b/contracts/src/test/redemptions.t.sol
@@ -489,6 +489,27 @@ contract Redemptions is DevTestSetup {
         assertEq(troveManager.lastZombieTroveId(), 0, "Wrong last zombie trove pointer after");
     }
 
+    function testZombieTrovePointerIsPreservedIfItIsSkippedAndNoNewZombieIsProduced() external {
+        // Trove to keep TCR high
+        openTroveWithExactICRAndDebt(B, 0, 10 ether, 10_000 ether, 0.1 ether);
+
+        (uint256 trove1,) = openTroveWithExactICRAndDebt(A, 0, 1.1 ether, 2_000 ether, 0.01 ether); // ICR 110%
+        (uint256 trove2,) = openTroveWithExactICRAndDebt(A, 1, 1.5 ether, 4_000 ether, 0.02 ether); // ICR 150%
+
+        redeem(A, 100 ether);
+        assertEq(troveManager.lastZombieTroveId(), trove1, "trove1 should have become lastZombieTroveId");
+
+        // Drop price by 20%, so that trove1's ICR < 100%
+        priceFeed.setPrice(priceFeed.getPrice() * 80 / 100);
+        assertLtDecimal(troveManager.getCurrentICR(trove1, priceFeed.getPrice()), 1 ether, 18, "ICR should be < 100%");
+
+        uint256 trove1Debt = troveManager.getTroveEntireDebt(trove1);
+        redeem(A, 100 ether);
+        assertEqDecimal(trove1Debt, troveManager.getTroveEntireDebt(trove1), 18, "trove1 shouldn't have been touched");
+
+        assertEq(troveManager.lastZombieTroveId(), trove1, "lastZombieTroveId should have been preserved");
+    }
+
     function testZombieTrovesCanReceiveRedistGains() public {
         uint256 interestRate_E = 5e16; // 5%
         uint256 troveDebtRequest_E = 2450e18;


### PR DESCRIPTION
Normally, `lastZombieTroveId` is first in line to get redeemed, however, it will be skipped if its ICR is less than 100%. Previously, we would have reset `lastZombieTroveId` to 0 if a subsequent redemption _doesn't_ result in a Trove having `0 < debt < MIN_DEBT`. However, there's no reason to reset `lastZombieTroveId` in this case, even if the chances of it escaping liquidation until its ICR recovers to >100% are slim.