### PR TITLE
fix: Use msg.sender instead of user-provided param in Zappers

### DIFF
--- a/contracts/src/Zappers/Interfaces/IExchange.sol
+++ b/contracts/src/Zappers/Interfaces/IExchange.sol
@@ -7,7 +7,7 @@ interface IExchange {
     function getBoldAmountToSwap(uint256 _boldAmount, uint256 _maxBoldAmount, uint256 _minCollAmount)
         external /* view */
         returns (uint256);
-    function swapFromBold(uint256 _boldAmount, uint256 _minCollAmount, address _zapper) external returns (uint256);
+    function swapFromBold(uint256 _boldAmount, uint256 _minCollAmount) external returns (uint256);
 
-    function swapToBold(uint256 _collAmount, uint256 _minBoldAmount, address _zapper) external returns (uint256);
+    function swapToBold(uint256 _collAmount, uint256 _minBoldAmount) external returns (uint256);
 }

--- a/contracts/src/Zappers/LeverageLSTZapper.sol
+++ b/contracts/src/Zappers/LeverageLSTZapper.sol
@@ -110,7 +110,7 @@ contract LeverageLSTZapper is GasCompZapper, IFlashLoanReceiver, ILeverageZapper
         _setRemoveManagerAndReceiver(vars.troveId, _params.removeManager, _params.receiver);
 
         // Swap Bold to Coll
-        exchange.swapFromBold(_params.boldAmount, _params.flashLoanAmount, address(this));
+        exchange.swapFromBold(_params.boldAmount, _params.flashLoanAmount);
 
         // Send coll back to return flash loan
         vars.collToken.safeTransfer(address(flashLoanProvider), _params.flashLoanAmount);
@@ -154,7 +154,7 @@ contract LeverageLSTZapper is GasCompZapper, IFlashLoanReceiver, ILeverageZapper
         // No need to use a min: if the obtained amount is not enough, the flash loan return below won’t be enough
         // And the flash loan provider will revert after this function exits
         // The frontend should calculate in advance the `_params.boldAmount` needed for this to work
-        exchange.swapFromBold(_params.boldAmount, _params.flashLoanAmount, address(this));
+        exchange.swapFromBold(_params.boldAmount, _params.flashLoanAmount);
 
         // Send coll back to return flash loan
         collToken.safeTransfer(address(flashLoanProvider), _params.flashLoanAmount);
@@ -187,8 +187,7 @@ contract LeverageLSTZapper is GasCompZapper, IFlashLoanReceiver, ILeverageZapper
         // We swap the flash loan minus the flash loan fee
         // The frontend should calculate in advance the `_params.minBoldAmount` to achieve the desired leverage ratio
         // (with some slippage tolerance)
-        uint256 receivedBoldAmount =
-            exchange.swapToBold(_effectiveFlashLoanAmount, _params.minBoldAmount, address(this));
+        uint256 receivedBoldAmount = exchange.swapToBold(_effectiveFlashLoanAmount, _params.minBoldAmount);
 
         // Adjust trove
         borrowerOperations.adjustTrove(

--- a/contracts/src/Zappers/LeverageWETHZapper.sol
+++ b/contracts/src/Zappers/LeverageWETHZapper.sol
@@ -102,7 +102,7 @@ contract LeverageWETHZapper is WETHZapper, IFlashLoanReceiver, ILeverageZapper {
         _setRemoveManagerAndReceiver(vars.troveId, _params.removeManager, _params.receiver);
 
         // Swap Bold to Coll
-        exchange.swapFromBold(_params.boldAmount, _params.flashLoanAmount, address(this));
+        exchange.swapFromBold(_params.boldAmount, _params.flashLoanAmount);
 
         // Send coll back to return flash loan
         vars.WETH.transfer(address(flashLoanProvider), _params.flashLoanAmount);
@@ -147,7 +147,7 @@ contract LeverageWETHZapper is WETHZapper, IFlashLoanReceiver, ILeverageZapper {
         // No need to use a min: if the obtained amount is not enough, the flash loan return below won’t be enough
         // And the flash loan provider will revert after this function exits
         // The frontend should calculate in advance the `_params.boldAmount` needed for this to work
-        exchange.swapFromBold(_params.boldAmount, _params.flashLoanAmount, address(this));
+        exchange.swapFromBold(_params.boldAmount, _params.flashLoanAmount);
 
         // Send coll back to return flash loan
         WETH.transfer(address(flashLoanProvider), _params.flashLoanAmount);
@@ -180,8 +180,7 @@ contract LeverageWETHZapper is WETHZapper, IFlashLoanReceiver, ILeverageZapper {
         // We swap the flash loan minus the flash loan fee
         // The frontend should calculate in advance the `_params.minBoldAmount` to achieve the desired leverage ratio
         // (with some slippage tolerance)
-        uint256 receivedBoldAmount =
-            exchange.swapToBold(_effectiveFlashLoanAmount, _params.minBoldAmount, address(this));
+        uint256 receivedBoldAmount = exchange.swapToBold(_effectiveFlashLoanAmount, _params.minBoldAmount);
 
         // Adjust trove
         borrowerOperations.adjustTrove(

--- a/contracts/src/Zappers/Modules/Exchanges/CurveExchange.sol
+++ b/contracts/src/Zappers/Modules/Exchanges/CurveExchange.sol
@@ -55,38 +55,38 @@ contract CurveExchange is IExchange {
         return boldAmountToSwap;
     }
 
-    function swapFromBold(uint256 _boldAmount, uint256 _minCollAmount, address _zapper) external returns (uint256) {
+    function swapFromBold(uint256 _boldAmount, uint256 _minCollAmount) external returns (uint256) {
         ICurvePool curvePoolCached = curvePool;
         uint256 initialBoldBalance = boldToken.balanceOf(address(this));
-        boldToken.transferFrom(_zapper, address(this), _boldAmount);
+        boldToken.transferFrom(msg.sender, address(this), _boldAmount);
         boldToken.approve(address(curvePoolCached), _boldAmount);
 
         // TODO: make this work
-        //return curvePoolCached.exchange(BOLD_TOKEN_INDEX, COLL_TOKEN_INDEX, _boldAmount, _minCollAmount, false, _zapper);
+        //return curvePoolCached.exchange(BOLD_TOKEN_INDEX, COLL_TOKEN_INDEX, _boldAmount, _minCollAmount, false, msg.sender);
         uint256 output = curvePoolCached.exchange(BOLD_TOKEN_INDEX, COLL_TOKEN_INDEX, _boldAmount, _minCollAmount);
-        collToken.safeTransfer(_zapper, output);
+        collToken.safeTransfer(msg.sender, output);
 
         uint256 currentBoldBalance = boldToken.balanceOf(address(this));
         if (currentBoldBalance > initialBoldBalance) {
-            boldToken.transfer(_zapper, currentBoldBalance - initialBoldBalance);
+            boldToken.transfer(msg.sender, currentBoldBalance - initialBoldBalance);
         }
 
         return output;
     }
 
-    function swapToBold(uint256 _collAmount, uint256 _minBoldAmount, address _zapper) external returns (uint256) {
+    function swapToBold(uint256 _collAmount, uint256 _minBoldAmount) external returns (uint256) {
         ICurvePool curvePoolCached = curvePool;
         uint256 initialCollBalance = collToken.balanceOf(address(this));
-        collToken.safeTransferFrom(_zapper, address(this), _collAmount);
+        collToken.safeTransferFrom(msg.sender, address(this), _collAmount);
         collToken.approve(address(curvePoolCached), _collAmount);
 
-        //return curvePoolCached.exchange(COLL_TOKEN_INDEX, BOLD_TOKEN_INDEX, _collAmount, _minBoldAmount, false, _zapper);
+        //return curvePoolCached.exchange(COLL_TOKEN_INDEX, BOLD_TOKEN_INDEX, _collAmount, _minBoldAmount, false, msg.sender);
         uint256 output = curvePoolCached.exchange(COLL_TOKEN_INDEX, BOLD_TOKEN_INDEX, _collAmount, _minBoldAmount);
-        boldToken.transfer(_zapper, output);
+        boldToken.transfer(msg.sender, output);
 
         uint256 currentCollBalance = collToken.balanceOf(address(this));
         if (currentCollBalance > initialCollBalance) {
-            collToken.transfer(_zapper, currentCollBalance - initialCollBalance);
+            collToken.transfer(msg.sender, currentCollBalance - initialCollBalance);
         }
 
         return output;

--- a/contracts/src/Zappers/Modules/Exchanges/UniV3Exchange.sol
+++ b/contracts/src/Zappers/Modules/Exchanges/UniV3Exchange.sol
@@ -67,21 +67,21 @@ contract UniV3Exchange is LeftoversSweep, IExchange, IUniswapV3SwapCallback {
         return amountIn;
     }
 
-    function swapFromBold(uint256 _boldAmount, uint256 _minCollAmount, address _zapper) external returns (uint256) {
+    function swapFromBold(uint256 _boldAmount, uint256 _minCollAmount) external returns (uint256) {
         ISwapRouter uniV3RouterCached = uniV3Router;
 
         // Set initial balances to make sure there are not lefovers
         InitialBalances memory initialBalances;
         _setInitialBalances(collToken, boldToken, initialBalances);
 
-        boldToken.transferFrom(_zapper, address(this), _boldAmount);
+        boldToken.transferFrom(msg.sender, address(this), _boldAmount);
         boldToken.approve(address(uniV3RouterCached), _boldAmount);
 
         ISwapRouter.ExactOutputSingleParams memory params = ISwapRouter.ExactOutputSingleParams({
             tokenIn: address(boldToken),
             tokenOut: address(collToken),
             fee: fee,
-            recipient: _zapper,
+            recipient: msg.sender,
             deadline: block.timestamp,
             amountOut: _minCollAmount,
             amountInMaximum: _boldAmount,
@@ -96,21 +96,21 @@ contract UniV3Exchange is LeftoversSweep, IExchange, IUniswapV3SwapCallback {
         return amountIn;
     }
 
-    function swapToBold(uint256 _collAmount, uint256 _minBoldAmount, address _zapper) external returns (uint256) {
+    function swapToBold(uint256 _collAmount, uint256 _minBoldAmount) external returns (uint256) {
         ISwapRouter uniV3RouterCached = uniV3Router;
 
         // Set initial balances to make sure there are not lefovers
         InitialBalances memory initialBalances;
         _setInitialBalances(collToken, boldToken, initialBalances);
 
-        collToken.safeTransferFrom(_zapper, address(this), _collAmount);
+        collToken.safeTransferFrom(msg.sender, address(this), _collAmount);
         collToken.approve(address(uniV3RouterCached), _collAmount);
 
         ISwapRouter.ExactInputSingleParams memory params = ISwapRouter.ExactInputSingleParams({
             tokenIn: address(collToken),
             tokenOut: address(boldToken),
             fee: fee,
-            recipient: _zapper,
+            recipient: msg.sender,
             deadline: block.timestamp,
             amountIn: _collAmount,
             amountOutMinimum: _minBoldAmount,


### PR DESCRIPTION
Fixes #475 