### PR TITLE
fix: Check for remaining bold redemption amount early

### DIFF
--- a/contracts/src/TroveManager.sol
+++ b/contracts/src/TroveManager.sol
@@ -849,6 +849,8 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
 
         uint256 remainingBold = _boldAmount;
         for (uint256 i = 0; i < _troveIds.length; i++) {
+            if (remainingBold == 0) break;
+
             SingleRedemptionValues memory singleRedemption;
             singleRedemption.troveId = _troveIds[i];
             _getLatestTroveData(singleRedemption.troveId, singleRedemption.trove);
@@ -876,7 +878,6 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
             totalsTroveChange.oldWeightedRecordedDebt += singleRedemption.oldWeightedRecordedDebt;
 
             remainingBold -= singleRedemption.boldLot;
-            if (remainingBold == 0) break;
         }
 
         if (totalsTroveChange.collDecrease < _minCollateral) {

--- a/contracts/src/test/TestContracts/InvariantsTestHandler.t.sol
+++ b/contracts/src/test/TestContracts/InvariantsTestHandler.t.sol
@@ -2727,6 +2727,8 @@ contract InvariantsTestHandler is BaseHandler, BaseMultiCollateralTest {
         r = _urgentRedemption;
 
         for (uint256 j = 0; j < r.batch.length; ++j) {
+            if (amount == 0) break;
+
             uint256 troveId = _troveIdOf(i, r.batch[j]);
             if (!_troveIds[i].has(troveId)) continue; // skip non-existent Trove
 
@@ -2753,7 +2755,6 @@ contract InvariantsTestHandler is BaseHandler, BaseMultiCollateralTest {
             r.totalDebtRedeemed += debtRedeemed;
 
             amount -= debtRedeemed;
-            if (amount == 0) break; // XXX why at the end?
         }
     }
 


### PR DESCRIPTION
To avoid applying debt to a trove after shutdown by passing zero as `_boldAmount`.

Fixes #537 