### PR TITLE
fix: Make batch shares rounding favour the system

### DIFF
--- a/contracts/src/TroveManager.sol
+++ b/contracts/src/TroveManager.sol
@@ -2,6 +2,8 @@
 
 pragma solidity 0.8.24;
 
+import "openzeppelin-contracts/contracts/utils/math/Math.sol";
+
 import "./Interfaces/ITroveManager.sol";
 import "./Interfaces/IAddressesRegistry.sol";
 import "./Interfaces/IStabilityPool.sol";
@@ -1793,7 +1795,7 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
                     // To avoid rebasing issues, let’s make sure the ratio debt / shares is not too high
                     _requireBelowMaxSharesRatio(currentBatchDebtShares, _batchDebt, _checkBatchSharesRatio);
 
-                    batchDebtSharesDelta = currentBatchDebtShares * debtIncrease / _batchDebt;
+                    batchDebtSharesDelta = Math.ceilDiv(currentBatchDebtShares * debtIncrease, _batchDebt);
                 }
 
                 Troves[_troveId].batchDebtShares += batchDebtSharesDelta;

--- a/contracts/src/test/rebasingBatchShares.t.sol
+++ b/contracts/src/test/rebasingBatchShares.t.sol
@@ -35,7 +35,7 @@ contract RebasingBatchShares is DevTestSetup {
         LatestBatchData memory b4Batch = troveManager.getLatestBatchData(address(B));
 
         // TODO: Open A, Mint 1 extra (forgiven to A)
-        _addOneDebtAndEnsureItDoesntMintShares(ATroveId, A);
+        _addOneDebtAndEnsureItMintsShares(ATroveId, A);
         /// @audit MED impact
 
         LatestBatchData memory afterBatch = troveManager.getLatestBatchData(address(B));
@@ -178,6 +178,7 @@ contract RebasingBatchShares is DevTestSetup {
         closeTrove(A, ATroveId); // Close A (also remove from batch is fine)
 
         LatestTroveData memory troveAfter = troveManager.getLatestTroveData(BTroveId);
+        //assertGt(troveAfter.entireDebt, troveBefore.entireDebt, "we're rebasing");
         assertEq(troveAfter.entireDebt, troveBefore.entireDebt, "rebasing is not working");
         assertEq(troveAfter.entireDebt, 0, "trove B was closed");
     }
@@ -192,18 +193,8 @@ contract RebasingBatchShares is DevTestSetup {
         assertLt(b4BatchDebtShares, afterBatchDebtShares, "Shares should increase");
     }
 
-    function _addDebtAndEnsureItDoesntMintShares(uint256 troveId, address caller, uint256 amt) internal {
-        (,,,,,,,,, uint256 b4BatchDebtShares) = troveManager.Troves(troveId);
-
-        withdrawBold100pct(caller, troveId, amt);
-
-        (,,,,,,,,, uint256 afterBatchDebtShares) = troveManager.Troves(troveId);
-
-        assertEq(b4BatchDebtShares, afterBatchDebtShares, "Same Shares");
-    }
-
-    function _addOneDebtAndEnsureItDoesntMintShares(uint256 troveId, address caller) internal {
-        _addDebtAndEnsureItDoesntMintShares(troveId, caller, 1);
+    function _addOneDebtAndEnsureItMintsShares(uint256 troveId, address caller) internal {
+        _addDebtAndEnsureItMintsShares(troveId, caller, 1);
     }
 
     function _getLatestBatchDebt(address batch) internal view returns (uint256) {
@@ -272,7 +263,7 @@ contract RebasingBatchShares is DevTestSetup {
         if (WITH_INTEREST) {
             vm.warp(block.timestamp + 12);
         }
-        _addOneDebtAndEnsureItDoesntMintShares(BTroveId, B);
+        _addOneDebtAndEnsureItMintsShares(BTroveId, B);
 
         (uint256 debtBefore,,,,,,, uint256 allBatchDebtSharesBefore) = troveManager.getBatch(B);
         uint256 sharesBeforeRepay = _getBatchDebtShares(BTroveId);


### PR DESCRIPTION
It uses ceil division in `TroveManager._updateBatchShares`, so that the rounding error goes against the user instead of the rest of the batch.

- Pros
  - It seems safer, as it would prevent the flagged issues of borrowing for free
  - It’s more consistent with the other direction
- Cons
  - It can still be gamed: other batch users may frontrun a borrowing operation, so that the user increasing debt owes more than minted due to rounding error.
  - The impact may be higher: now a user would swallow all the rounding error if frontrun (otherwise, the user can choose the right amount to prevent it), while before the error would be shared among the rest of the batch (most cases that would be higher, unless a user has >= 50% of the batch)
  - Introducing changes so late always poses some risk, and it seems the rounding issues have been quite mitigated by #455 