### PR TITLE
Eth price fallback 2 fixes

### DIFF
--- a/contracts/src/PriceFeeds/CompositePriceFeed.sol
+++ b/contracts/src/PriceFeeds/CompositePriceFeed.sol
@@ -101,9 +101,6 @@ contract CompositePriceFeed is MainnetPriceFeedBase {
         uint256 max = _referencePrice * (DECIMAL_PRECISION + _deviationThreshold) / 1e18;
         uint256 min = _referencePrice * (DECIMAL_PRECISION - _deviationThreshold) / 1e18;
 
-        console2.log(_priceToCheck, "_priceToCheck");
-        console2.log(_referencePrice, "_referencePrice");
-        console2.log(_priceToCheck >= min && _priceToCheck <= max, "is within threshold");
         return _priceToCheck >= min && _priceToCheck <= max;
     }
 

--- a/contracts/src/PriceFeeds/CompositePriceFeed.sol
+++ b/contracts/src/PriceFeeds/CompositePriceFeed.sol
@@ -9,7 +9,7 @@ import "./MainnetPriceFeedBase.sol";
 
 // The CompositePriceFeed is used for feeds that incorporate both a market price oracle (e.g. STETH-USD, or RETH-ETH)
 // and an LST canonical rate (e.g. WSTETH:STETH, or RETH:ETH).
-contract CompositePriceFeed is MainnetPriceFeedBase {
+abstract contract CompositePriceFeed is MainnetPriceFeedBase {
     address public rateProviderAddress;
 
     constructor(

--- a/contracts/src/PriceFeeds/CompositePriceFeed.sol
+++ b/contracts/src/PriceFeeds/CompositePriceFeed.sol
@@ -96,6 +96,17 @@ contract CompositePriceFeed is MainnetPriceFeedBase {
         return bestPrice;
     }
 
+    function _withinDeviationThreshold(uint256 _priceToCheck, uint256 _referencePrice, uint256 _deviationThreshold) internal pure returns (bool) {
+        // Calculate the price deviation of the oracle market price relative to the canonical price
+        uint256 max = _referencePrice * (DECIMAL_PRECISION + _deviationThreshold) / 1e18;
+        uint256 min = _referencePrice * (DECIMAL_PRECISION - _deviationThreshold) / 1e18;
+
+        console2.log(_priceToCheck, "_priceToCheck");
+        console2.log(_referencePrice, "_referencePrice");
+        console2.log(_priceToCheck >= min && _priceToCheck <= max, "is within threshold");
+        return _priceToCheck >= min && _priceToCheck <= max;
+    }
+
     // An individual Pricefeed instance implements _fetchPricePrimary according to the data sources it uses. Returns:
     // - The price
     // - A bool indicating whether a new oracle failure or exchange rate failure was detected in the call

--- a/contracts/src/PriceFeeds/MainnetPriceFeedBase.sol
+++ b/contracts/src/PriceFeeds/MainnetPriceFeedBase.sol
@@ -31,6 +31,7 @@ abstract contract MainnetPriceFeedBase is IMainnetPriceFeed, Ownable {
         bool success;
     }
 
+    error InsufficientGasForExternalCall();
     event ShutDownFromOracleFailure(address _failedOracleAddr);
 
     Oracle public ethUsdOracle;
@@ -84,7 +85,9 @@ abstract contract MainnetPriceFeedBase is IMainnetPriceFeed, Ownable {
         view
         returns (ChainlinkResponse memory chainlinkResponse)
     {
-        // Secondly, try to get latest price data:
+        uint256 gasBefore = gasleft();
+
+        // Try to get latest price data:
         try _aggregator.latestRoundData() returns (
             uint80 roundId, int256 answer, uint256, /* startedAt */ uint256 updatedAt, uint80 /* answeredInRound */
         ) {
@@ -96,6 +99,11 @@ abstract contract MainnetPriceFeedBase is IMainnetPriceFeed, Ownable {
 
             return chainlinkResponse;
         } catch {
+            // Require that enough gas was provided to prevent an OOG revert in the call to Chainlink 
+            // causing a shutdown. Instead, just revert. Slightly conservative, as it includes gas used 
+            // in the check itself.
+            if (gasleft() <= gasBefore / 64) {revert InsufficientGasForExternalCall();}
+
             // If call to Chainlink aggregator reverts, return a zero response with success = false
             return chainlinkResponse;
         }

--- a/contracts/src/test/OracleMainnet.t.sol
+++ b/contracts/src/test/OracleMainnet.t.sol
@@ -2,6 +2,11 @@
 
 pragma solidity 0.8.18;
 
+import "../PriceFeeds/WSTETHPriceFeed.sol";
+import "../PriceFeeds/MainnetPriceFeedBase.sol";
+import "../PriceFeeds/RETHPriceFeed.sol";
+import "../PriceFeeds/WETHPriceFeed.sol";
+
 import "./TestContracts/Accounts.sol";
 import "./TestContracts/ChainlinkOracleMock.sol";
 import "./TestContracts/RETHTokenMock.sol";
@@ -1971,6 +1976,24 @@ contract OraclesMainnet is TestAccounts {
         // Confirm the received amount coll is the expected amount (i.e. used the expected price)
         assertEq(contractsArray[1].collToken.balanceOf(A), A_collBefore + expectedCollDelta, "A's coll didn't change" );
     }
+
+    // --- Low gas reverts ---
+
+// --- Call these functions with 10k gas - i.e. enough to run out of gas in the Chainlink calls ---
+function testRevertLowGasWSTETH() public {
+    vm.expectRevert(MainnetPriceFeedBase.InsufficientGasForExternalCall.selector);
+    address(wstethPriceFeed).call{gas: 10000}(abi.encodeWithSignature("fetchPrice()"));
+}
+
+function testRevertLowGasRETH() public {
+    vm.expectRevert(MainnetPriceFeedBase.InsufficientGasForExternalCall.selector);
+    address(rethPriceFeed).call{gas: 10000}(abi.encodeWithSignature("fetchPrice()"));
+}
+
+function testRevertLowGasWETH() public {
+    vm.expectRevert(MainnetPriceFeedBase.InsufficientGasForExternalCall.selector);
+    address(wethPriceFeed).call{gas: 10000}(abi.encodeWithSignature("fetchPrice()"));
+}
 
     // - More basic actions tests (adjust, close, etc)
     // - liq tests (manipulate aggregator stored price)


### PR DESCRIPTION
This PR:

- Implements CS's recommendation for using the `max(STETH-USD,ETH-USD)` for redemptions only if those prices differ by 1%, otherwise take the min:

<img width="760" alt="image" src="https://github.com/user-attachments/assets/a8e3e746-fd11-4e8d-a7cb-292a974ccb6f">

- Stops out-of-gas errors in external calls to Chainlink and LST causing a shutdown. Fixed by ensuring the remaining post-call gas is > 1/64 the pre-call gas, which guarantees an OOG didn't occur ( CS-030:  https://github.com/liquity/bold/issues/488)
- Makes CompositePriceFeed an abstract contract (Coinspect BOLD-06)