### PR TITLE
App: update TransactionFlow to add a postCheck() status

### DIFF
--- a/frontend/app/src/comps/Positions/PositionCardBorrow.tsx
+++ b/frontend/app/src/comps/Positions/PositionCardBorrow.tsx
@@ -1,9 +1,9 @@
-import type { PositionLoan } from "@/src/types";
+import type { PositionLoanCommitted } from "@/src/types";
 
 import { formatLiquidationRisk } from "@/src/formatting";
 import { fmtnum } from "@/src/formatting";
 import { getLiquidationRisk, getLtv, getRedemptionRisk } from "@/src/liquity-math";
-import { shortenTroveId, getCollToken } from "@/src/liquity-utils";
+import { getCollToken, shortenTroveId } from "@/src/liquity-utils";
 import { usePrice } from "@/src/services/Prices";
 import { riskLevelToStatusMode } from "@/src/uikit-utils";
 import { css } from "@/styled-system/css";
@@ -20,7 +20,7 @@ export function PositionCardBorrow({
   interestRate,
   troveId,
 }: Pick<
-  PositionLoan,
+  PositionLoanCommitted,
   | "batchManager"
   | "borrowed"
   | "collIndex"

--- a/frontend/app/src/comps/Positions/PositionCardLeverage.tsx
+++ b/frontend/app/src/comps/Positions/PositionCardLeverage.tsx
@@ -1,4 +1,4 @@
-import type { PositionLoan } from "@/src/types";
+import type { PositionLoanCommitted } from "@/src/types";
 
 import { getContracts } from "@/src/contracts";
 import { formatRedemptionRisk } from "@/src/formatting";
@@ -18,7 +18,7 @@ export function PositionCardLeverage({
   interestRate,
   troveId,
 }: Pick<
-  PositionLoan,
+  PositionLoanCommitted,
   | "borrowed"
   | "collIndex"
   | "deposit"

--- a/frontend/app/src/comps/Positions/PositionCardLoan.tsx
+++ b/frontend/app/src/comps/Positions/PositionCardLoan.tsx
@@ -1,4 +1,4 @@
-import type { PositionLoan } from "@/src/types";
+import type { PositionLoanCommitted } from "@/src/types";
 
 import { getPrefixedTroveId } from "@/src/liquity-utils";
 import { useStoredState } from "@/src/services/StoredState";
@@ -7,7 +7,7 @@ import { PositionCardLeverage } from "./PositionCardLeverage";
 
 export function PositionCardLoan(
   props: Pick<
-    PositionLoan,
+    PositionLoanCommitted,
     | "type"
     | "batchManager"
     | "borrowed"
@@ -18,6 +18,12 @@ export function PositionCardLoan(
   >,
 ) {
   const storedState = useStoredState();
+
+  // only works for existing troves
+  if (!props.troveId) {
+    return null;
+  }
+
   const prefixedTroveId = getPrefixedTroveId(props.collIndex, props.troveId);
   const loanMode = storedState.loanModes[prefixedTroveId] ?? props.type;
   return loanMode === "leverage"

--- a/frontend/app/src/comps/Positions/Positions.tsx
+++ b/frontend/app/src/comps/Positions/Positions.tsx
@@ -7,11 +7,9 @@ import { ACCOUNT_POSITIONS } from "@/src/demo-mode";
 import { DEMO_MODE } from "@/src/env";
 import { useStakePosition } from "@/src/liquity-utils";
 import { useEarnPositionsByAccount, useLoansByAccount } from "@/src/subgraph-hooks";
-import { sleep } from "@/src/utils";
 import { css } from "@/styled-system/css";
 import { StrongCard } from "@liquity2/uikit";
 import { a, useSpring, useTransition } from "@react-spring/web";
-import { useQuery } from "@tanstack/react-query";
 import * as dn from "dnum";
 import { useRef } from "react";
 import { match, P } from "ts-pattern";
@@ -41,36 +39,25 @@ export function Positions({
   const earnPositions = useEarnPositionsByAccount(address);
   const stakePosition = useStakePosition(address);
 
-  const positions = useQuery({
-    enabled: Boolean(
-      address
-        && !loans.isPending
-        && !earnPositions.isPending
-        && !stakePosition.isPending,
-    ),
-    queryKey: ["CombinedPositions", address],
-    queryFn: async () => {
-      await sleep(300);
-      if (DEMO_MODE) {
-        return ACCOUNT_POSITIONS;
-      }
-      return [
-        ...loans.data ?? [],
-        ...earnPositions.data ?? [],
-        ...stakePosition.data && dn.gt(stakePosition.data.deposit, 0) ? [stakePosition.data] : [],
-      ];
-    },
-  });
-
-  const positionsPending = Boolean(
+  const isPositionsPending = Boolean(
     address && (
-      loans.isPending || earnPositions.isPending || positions.isPending
+      loans.isPending
+      || earnPositions.isPending
+      || stakePosition.isPending
     ),
   );
 
-  let mode: Mode = address && positions.data && positions.data.length > 0
+  const positions = isPositionsPending ? [] : (
+    DEMO_MODE ? ACCOUNT_POSITIONS : [
+      ...loans.data ?? [],
+      ...earnPositions.data ?? [],
+      ...stakePosition.data && dn.gt(stakePosition.data.deposit, 0) ? [stakePosition.data] : [],
+    ]
+  );
+
+  let mode: Mode = address && positions && positions.length > 0
     ? "positions"
-    : positionsPending
+    : isPositionsPending
     ? "loading"
     : "actions";
 
@@ -78,7 +65,7 @@ export function Positions({
     <PositionsGroup
       columns={columns}
       mode={mode}
-      positions={positions.data ?? []}
+      positions={positions ?? []}
       showNewPositionCard={showNewPositionCard}
       title={title}
     />

--- a/frontend/app/src/comps/Positions/Positions.tsx
+++ b/frontend/app/src/comps/Positions/Positions.tsx
@@ -1,4 +1,4 @@
-import type { Address, Position } from "@/src/types";
+import type { Address, Position, PositionLoanUncommitted } from "@/src/types";
 import type { ReactNode } from "react";
 
 import { ActionCard } from "@/src/comps/ActionCard/ActionCard";
@@ -83,7 +83,7 @@ function PositionsGroup({
   columns?: number;
   mode: Mode;
   onTitleClick?: () => void;
-  positions: Position[];
+  positions: Exclude<Position, PositionLoanUncommitted>[];
   title: (mode: Mode) => ReactNode;
   showNewPositionCard: boolean;
 }) {

--- a/frontend/app/src/constants.ts
+++ b/frontend/app/src/constants.ts
@@ -26,7 +26,7 @@ export const UPFRONT_INTEREST_PERIOD = 7n * ONE_DAY_IN_SECONDS;
 
 export const SP_YIELD_SPLIT = 72n * 10n ** 16n; // 72%
 
-export const DATA_REFRESH_INTERVAL = 30_000; // 30 seconds
+export const DATA_REFRESH_INTERVAL = 30_000;
 
 export const CLOSE_FROM_COLLATERAL_SLIPPAGE = 0.05; // 5%
 export const MAX_UPFRONT_FEE = 1000n * 10n ** 18n;

--- a/frontend/app/src/demo-mode/demo-data.ts
+++ b/frontend/app/src/demo-mode/demo-data.ts
@@ -1,4 +1,4 @@
-import type { Delegate, Position } from "@/src/types";
+import type { Delegate, Position, PositionLoanUncommitted } from "@/src/types";
 import type { CollateralToken } from "@liquity2/uikit";
 import type { Dnum } from "dnum";
 
@@ -40,7 +40,7 @@ function getTime() {
   return lastTime += 24 * 60 * 60 * 1000;
 }
 
-export const ACCOUNT_POSITIONS: Position[] = [
+export const ACCOUNT_POSITIONS: Exclude<Position, PositionLoanUncommitted>[] = [
   {
     type: "borrow",
     borrowed: dn.from(12_789, 18),

--- a/frontend/app/src/demo-mode/demo-data.ts
+++ b/frontend/app/src/demo-mode/demo-data.ts
@@ -35,6 +35,11 @@ export const ACCOUNT_BALANCES = {
 
 const DEMO_ACCOUNT = `0x${"0".repeat(39)}1` as const;
 
+let lastTime = new Date("2024-01-01T00:00:00Z").getTime();
+function getTime() {
+  return lastTime += 24 * 60 * 60 * 1000;
+}
+
 export const ACCOUNT_POSITIONS: Position[] = [
   {
     type: "borrow",
@@ -45,6 +50,8 @@ export const ACCOUNT_POSITIONS: Position[] = [
     troveId: "0x01",
     collIndex: 1,
     batchManager: null,
+    createdAt: getTime(),
+    updatedAt: getTime(),
   },
   {
     type: "leverage",
@@ -55,6 +62,8 @@ export const ACCOUNT_POSITIONS: Position[] = [
     troveId: "0x02",
     collIndex: 0,
     batchManager: null,
+    createdAt: getTime(),
+    updatedAt: getTime(),
   },
   {
     type: "earn",

--- a/frontend/app/src/screens/LeverageScreen/LeverageScreen.tsx
+++ b/frontend/app/src/screens/LeverageScreen/LeverageScreen.tsx
@@ -302,7 +302,7 @@ export function LeverageScreen() {
 
                   ownerIndex: troveCount.data ?? 0,
                   leverageFactor: leverageField.leverageFactor,
-                  loanPosition: {
+                  loan: {
                     type: "leverage",
                     batchManager: interestRateDelegate,
                     borrowed: leverageField.debt,
@@ -313,7 +313,7 @@ export function LeverageScreen() {
                       leverageField.leverageFactor,
                     ),
                     interestRate: interestRate,
-                    troveId: "0x1",
+                    troveId: null,
                   },
                 });
               }

--- a/frontend/app/src/screens/LoanScreen/PanelClosePosition.tsx
+++ b/frontend/app/src/screens/LoanScreen/PanelClosePosition.tsx
@@ -1,4 +1,4 @@
-import type { PositionLoan } from "@/src/types";
+import type { PositionLoanCommitted } from "@/src/types";
 
 import { ConnectWarningBox } from "@/src/comps/ConnectWarningBox/ConnectWarningBox";
 import { ErrorBox } from "@/src/comps/ErrorBox/ErrorBox";
@@ -14,7 +14,11 @@ import { addressesEqual, Button, Dropdown, TokenIcon, TOKENS_BY_SYMBOL, VFlex } 
 import * as dn from "dnum";
 import { useState } from "react";
 
-export function PanelClosePosition({ loan }: { loan: PositionLoan }) {
+export function PanelClosePosition({
+  loan,
+}: {
+  loan: PositionLoanCommitted;
+}) {
   const account = useAccount();
   const txFlow = useTransactionFlow();
 

--- a/frontend/app/src/screens/LoanScreen/PanelUpdateBorrowPosition.tsx
+++ b/frontend/app/src/screens/LoanScreen/PanelUpdateBorrowPosition.tsx
@@ -13,7 +13,7 @@ import { dnum18, dnumMin } from "@/src/dnum-utils";
 import { useInputFieldValue } from "@/src/form-utils";
 import { fmtnum, formatRisk } from "@/src/formatting";
 import { getLoanDetails } from "@/src/liquity-math";
-import { getCollToken, getPrefixedTroveId } from "@/src/liquity-utils";
+import { getCollToken } from "@/src/liquity-utils";
 import { useAccount, useBalance } from "@/src/services/Ethereum";
 import { usePrice } from "@/src/services/Prices";
 import { useTransactionFlow } from "@/src/services/TransactionFlow";
@@ -369,11 +369,12 @@ export function PanelUpdateBorrowPosition({
                 successLink: ["/", "Go to the dashboard"],
                 successMessage: "The position has been updated successfully.",
 
-                collIndex: loan.collIndex,
-                prefixedTroveId: getPrefixedTroveId(loan.collIndex, loan.troveId),
-                owner: account.address,
-                collChange: dn.sub(newDeposit ?? dnum18(0), loan.deposit),
-                debtChange: dn.sub(newDebt ?? dnum18(0), loan.borrowed),
+                prevLoan: loan,
+                loan: {
+                  ...loan,
+                  deposit: newDeposit ?? loan.deposit,
+                  borrowed: newDebt ?? loan.borrowed,
+                },
                 maxUpfrontFee: dnum18(maxUint256),
               });
             }

--- a/frontend/app/src/screens/LoanScreen/PanelUpdateBorrowPosition.tsx
+++ b/frontend/app/src/screens/LoanScreen/PanelUpdateBorrowPosition.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { PositionLoan } from "@/src/types";
+import type { PositionLoanCommitted } from "@/src/types";
 
 import { ARROW_RIGHT } from "@/src/characters";
 import { Amount } from "@/src/comps/Amount/Amount";
@@ -41,7 +41,7 @@ type ValueUpdateMode = "add" | "remove";
 export function PanelUpdateBorrowPosition({
   loan,
 }: {
-  loan: PositionLoan;
+  loan: PositionLoanCommitted;
 }) {
   const account = useAccount();
   const txFlow = useTransactionFlow();

--- a/frontend/app/src/screens/LoanScreen/PanelUpdateBorrowPosition.tsx
+++ b/frontend/app/src/screens/LoanScreen/PanelUpdateBorrowPosition.tsx
@@ -369,7 +369,7 @@ export function PanelUpdateBorrowPosition({
                 successLink: ["/", "Go to the dashboard"],
                 successMessage: "The position has been updated successfully.",
 
-                prevLoan: loan,
+                prevLoan: { ...loan },
                 loan: {
                   ...loan,
                   deposit: newDeposit ?? loan.deposit,

--- a/frontend/app/src/screens/LoanScreen/PanelUpdateLeveragePosition.tsx
+++ b/frontend/app/src/screens/LoanScreen/PanelUpdateLeveragePosition.tsx
@@ -1,4 +1,4 @@
-import type { PositionLoan } from "@/src/types";
+import type { PositionLoanCommitted } from "@/src/types";
 
 import { INFINITY } from "@/src/characters";
 import { Amount } from "@/src/comps/Amount/Amount";
@@ -39,7 +39,7 @@ import { useEffect, useRef, useState } from "react";
 export function PanelUpdateLeveragePosition({
   loan,
 }: {
-  loan: PositionLoan;
+  loan: PositionLoanCommitted;
 }) {
   const account = useAccount();
   const txFlow = useTransactionFlow();

--- a/frontend/app/src/screens/LoanScreen/PanelUpdateRate.tsx
+++ b/frontend/app/src/screens/LoanScreen/PanelUpdateRate.tsx
@@ -1,5 +1,5 @@
 import type { DelegateMode } from "@/src/comps/InterestRateField/InterestRateField";
-import type { PositionLoan } from "@/src/types";
+import type { PositionLoanCommitted } from "@/src/types";
 
 import { ARROW_RIGHT } from "@/src/characters";
 import { Amount } from "@/src/comps/Amount/Amount";
@@ -25,7 +25,7 @@ import { useState } from "react";
 export function PanelUpdateRate({
   loan,
 }: {
-  loan: PositionLoan;
+  loan: PositionLoanCommitted;
 }) {
   const account = useAccount();
   const txFlow = useTransactionFlow();

--- a/frontend/app/src/screens/LoanScreen/PanelUpdateRate.tsx
+++ b/frontend/app/src/screens/LoanScreen/PanelUpdateRate.tsx
@@ -185,8 +185,8 @@ export function PanelUpdateRate({
                 successLink: ["/", "Go to the dashboard"],
                 successMessage: "The position interest rate has been updated successfully.",
 
-                prevLoanPosition: { ...loan },
-                loanPosition: {
+                prevLoan: { ...loan },
+                loan: {
                   ...loan,
                   batchManager: interestRateMode === "delegate" ? interestRateDelegate : null,
                   interestRate,

--- a/frontend/app/src/screens/TransactionsScreen/LoanCard.tsx
+++ b/frontend/app/src/screens/TransactionsScreen/LoanCard.tsx
@@ -589,6 +589,7 @@ function LoadingCard({
         display: "flex",
         justifyContent: "center",
         flexDirection: "column",
+        width: 534,
       })}
       style={{
         height: spring.containerHeight,

--- a/frontend/app/src/screens/TransactionsScreen/TransactionsScreen.tsx
+++ b/frontend/app/src/screens/TransactionsScreen/TransactionsScreen.tsx
@@ -74,9 +74,8 @@ export function TransactionsScreen() {
         href: flow.request.backLink[0],
         label: "Back",
       }}
+      heading={<fd.Summary flow={flow} />}
     >
-      <fd.Summary flow={flow} />
-
       <header
         className={css({
           display: "flex",

--- a/frontend/app/src/screens/TransactionsScreen/TransactionsScreen.tsx
+++ b/frontend/app/src/screens/TransactionsScreen/TransactionsScreen.tsx
@@ -197,7 +197,17 @@ export function TransactionsScreen() {
                   to be confirmed…
                 </>
               ))
-              .with("post-check", () => "Waiting for the transaction to be indexed…")
+              .with("post-check", () => (
+                <>
+                  Waiting for the{" "}
+                  <AnchorTextButton
+                    label="transaction"
+                    href={`${CHAIN_BLOCK_EXPLORER?.url}tx/${currentStep.txHash}`}
+                    external
+                  />{"  "}
+                  transaction to be indexed…
+                </>
+              ))
               .with("confirmed", () => (
                 <>
                   The{" "}

--- a/frontend/app/src/services/TransactionFlow.tsx
+++ b/frontend/app/src/services/TransactionFlow.tsx
@@ -47,7 +47,7 @@ import { noop } from "@/src/utils";
 import { vAddress, vHash } from "@/src/valibot-utils";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
-import { createContext, useCallback, useContext, useEffect, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import * as v from "valibot";
 import { useTransactionReceipt, useWriteContract } from "wagmi";
 
@@ -153,7 +153,10 @@ export const FlowStepsSchema = v.union([
         error: v.null(),
         txHash: vHash(),
         txReceiptData: v.union([v.null(), v.string()]),
-        txStatus: v.literal("confirmed"),
+        txStatus: v.union([
+          v.literal("post-check"),
+          v.literal("confirmed"),
+        ]),
       }),
     ]),
   ),
@@ -175,7 +178,7 @@ type FlowStepUpdate =
   | {
     error: null;
     txHash: `0x${string}`;
-    txStatus: "confirmed";
+    txStatus: "post-check" | "confirmed";
     txReceiptData: null | string;
   };
 
@@ -185,7 +188,8 @@ export type FlowSteps = NonNullable<
 
 export type FlowStepStatus = FlowSteps[number]["txStatus"];
 
-// The context of a transaction flow, as stored in local storage
+// The context of a transaction flow, as stored in local storage,
+// not to be confused with the React context used to manage the flow.
 export type FlowContext<FR extends FlowRequest> = {
   account: Address | null;
   request: FR;
@@ -233,6 +237,10 @@ export type FlowDeclaration<
   title: ReactNode;
   Summary: ComponentType<{ flow: FlowContext<FR> }>;
   Details: ComponentType<{ flow: FlowContext<FR> }>;
+
+  // optional, if present it will be called at the end of the
+  // last step of the flow, before the success status gets activated
+  postFlowCheck?: (args: FlowArgs<FR>) => Promise<void>;
   getSteps: GetStepsFn<FR, StepId>;
   getStepName: (stepId: StepId, args: {
     contracts: Contracts;
@@ -250,8 +258,8 @@ export type FlowDeclaration<
   writeContractParams: WriteContractParamsFn<FR, StepId>;
 };
 
-type Context<FR extends FlowRequest = FlowRequest> = {
-  contracts: null | Contracts;
+type TransactionFlowReactContext<FR extends FlowRequest = FlowRequest> = {
+  currentStep: null | FlowSteps[number];
   currentStepIndex: number;
   discard: () => void;
   signAndSend: () => Promise<void>;
@@ -260,8 +268,8 @@ type Context<FR extends FlowRequest = FlowRequest> = {
   flowDeclaration: null | FlowDeclaration<FR, ExtractStepId<typeof flowDeclarations[FR["flowId"]]>>;
 };
 
-const TransactionFlowContext = createContext<Context>({
-  contracts: null,
+const TransactionFlowContext = createContext<TransactionFlowReactContext>({
+  currentStep: null,
   currentStepIndex: -1,
   discard: noop,
   signAndSend: async () => {},
@@ -271,62 +279,20 @@ const TransactionFlowContext = createContext<Context>({
 });
 
 export function TransactionFlow({ children }: { children: ReactNode }) {
+  const account = useAccount();
   const router = useRouter();
   const wagmiConfig = useWagmiConfig();
-  const account = useAccount();
-  const contracts = getContracts();
 
-  const [{ flow }, setFlowAndStatus] = useState<{
-    flow: null | FlowContext<FlowRequest>;
-  }>({
-    flow: null,
-  });
-
-  const currentStepIndex = getCurrentStepIndex(flow);
-
-  const declaration = flow?.request.flowId ? getFlowDeclaration(flow.request.flowId) : null;
-
-  // initiate a new transaction flow (triggers fetching the steps)
-  const start: Context["start"] = useCallback((request) => {
-    if (!account.address) {
-      return;
-    }
-
-    const newFlow = {
-      account: account.address,
-      request,
-      steps: null,
-    };
-
-    setFlowAndStatus({ flow: newFlow });
-    FlowContextStorage.set(newFlow);
-
-    router.push("/transactions");
-  }, [account]);
-
-  // discard the current transaction flow (remove it from local storage)
-  const discard: Context["discard"] = useCallback(() => {
-    setFlowAndStatus({ flow: null });
-    FlowContextStorage.clear();
-  }, []);
-
-  // update a specific step in the flow
-  const updateStep = (index: number, update: FlowStepUpdate) => {
-    if (!flow) {
-      return;
-    }
-
-    const newFlow = {
-      ...flow,
-      steps: flow.steps?.map((step, index_) => (
-        index_ === index ? { ...step, ...update } : step
-      )) ?? null,
-    };
-
-    // update state + local storage
-    setFlowAndStatus({ flow: newFlow });
-    FlowContextStorage.set(newFlow);
-  };
+  const {
+    currentStep,
+    currentStepIndex,
+    discardFlow,
+    flow,
+    flowDeclaration,
+    setFlowSteps,
+    startFlow,
+    updateFlowStep,
+  } = useFlowManager(account.address ?? null);
 
   useSteps({
     flow,
@@ -337,186 +303,43 @@ export function TransactionFlow({ children }: { children: ReactNode }) {
         && flow.steps === null,
     ),
     account,
-    contracts,
     wagmiConfig,
     onSteps: (steps) => {
-      if (!flow) {
-        return;
-      }
-
-      const newFlow = {
-        ...flow,
-        steps: steps.map((id) => ({
-          id,
-          error: null,
-          txHash: null,
-          txReceiptData: null,
-          txStatus: "idle" as const,
-        })),
-      };
-
-      setFlowAndStatus({ flow: newFlow });
-      FlowContextStorage.set(newFlow);
-    },
-  });
-
-  // update the active flow when the account changes
-  useEffect(() => {
-    // no account: no active flow
-    if (!account.address) {
-      if (flow) {
-        setFlowAndStatus({ flow: null });
-      }
-      return;
-    }
-
-    // no flow: try to restore from local storage
-    if (!flow) {
-      const flow = FlowContextStorage.get() ?? null;
-      if (flow?.account === account.address) {
-        setFlowAndStatus({ flow });
-      }
-      return;
-    }
-
-    // flow exists, but different account: no active flow
-    if (account.address !== flow.account) {
-      setFlowAndStatus({ flow: null });
-    }
-  }, [account, flow]);
-
-  const contractWrite = useWriteContract({
-    mutation: {
-      onError: (err) => {
-        updateStep(currentStepIndex, {
-          error: `${err.name}: ${err.message}`,
-          txHash: null,
-          txReceiptData: null,
-          txStatus: "error",
-        });
-      },
-      onSuccess: (txHash) => {
-        updateStep(currentStepIndex, {
-          error: null,
-          txHash,
-          txReceiptData: null,
-          txStatus: "awaiting-confirmation",
-        });
-      },
-      onMutate: () => {
-        updateStep(currentStepIndex, {
-          error: null,
-          txHash: null,
-          txReceiptData: null,
-          txStatus: "awaiting-signature",
-        });
-      },
-    },
-  });
-
-  const currentStep = flow?.steps?.[currentStepIndex];
-
-  const txReceipt = useTransactionReceipt({
-    hash: contractWrite.data ?? (
-      (currentStep?.txStatus === "awaiting-confirmation" && currentStep.txHash) || undefined
-    ),
-    query: {
-      retry: true,
-    },
-  });
-
-  const flowDeclaration = flow && getFlowDeclaration(flow.request.flowId);
-
-  const signAndSend = useCallback(async () => {
-    const currentStepId = flow?.steps?.[currentStepIndex]?.id;
-
-    if (!currentStepId || currentStepIndex < 0 || !account || !flow || !flowDeclaration) {
-      return;
-    }
-
-    const params = await flowDeclaration.writeContractParams(currentStepId, {
-      account,
-      contracts,
-      request: flow.request,
-      steps: flow.steps,
-      wagmiConfig,
-    });
-
-    if (params) {
-      contractWrite.writeContract(params);
-    }
-  }, [
-    account,
-    contractWrite,
-    contracts,
-    currentStepIndex,
-    flow,
-    flowDeclaration,
-    updateStep,
-    wagmiConfig,
-  ]);
-
-  const totalSteps = flow?.steps?.length ?? 0;
-
-  const queryClient = useQueryClient();
-
-  // handle transaction receipt
-  useEffect(() => {
-    if (txReceipt.status !== "pending") {
-      contractWrite.reset();
-    }
-    if (txReceipt.status === "error") {
-      updateStep(currentStepIndex, {
-        error: txReceipt.error.message,
+      setFlowSteps(steps.map((id) => ({
+        id,
+        error: null,
         txHash: null,
         txReceiptData: null,
-        txStatus: "error",
-      });
-      return;
-    }
-    if (txReceipt.data?.status === "reverted") {
-      updateStep(currentStepIndex, {
-        error: "Transaction reverted.",
-        txHash: txReceipt.data.transactionHash,
-        txReceiptData: null,
-        txStatus: "error",
-      });
-      return;
-    }
-    if (txReceipt.status === "success" && flow?.request) {
-      updateStep(currentStepIndex, {
-        error: null,
-        txHash: txReceipt.data.transactionHash,
-        txReceiptData: declaration?.parseReceipt?.(
-          flow?.steps?.[currentStepIndex]?.id ?? "",
-          txReceipt.data,
-          { contracts, request: flow.request },
-        ) ?? null,
-        txStatus: "confirmed",
-      });
-      queryClient.invalidateQueries();
-      return;
-    }
-  }, [
-    contractWrite,
+        txStatus: "idle" as const,
+      })));
+    },
+  });
+
+  const txExecution = useTransactionExecution({
+    flow,
+    currentStep,
     currentStepIndex,
-    declaration,
-    queryClient,
-    totalSteps,
-    txReceipt,
-    updateStep,
-  ]);
+    flowDeclaration,
+    updateFlowStep,
+  });
+
+  const start: TransactionFlowReactContext["start"] = useCallback((request) => {
+    if (account.address) {
+      startFlow(request, account.address);
+      router.push("/transactions");
+    }
+  }, [account]);
 
   return (
     <TransactionFlowContext.Provider
       value={{
-        contracts,
+        currentStep,
         currentStepIndex,
-        discard,
+        discard: discardFlow,
         start,
         flow,
         flowDeclaration,
-        signAndSend,
+        signAndSend: txExecution.signAndSend,
       }}
     >
       {children}
@@ -528,17 +351,17 @@ function useSteps<FR extends FlowRequest>({
   flow,
   enabled,
   account,
-  contracts,
   wagmiConfig,
   onSteps,
 }: {
   flow: FlowContext<FR> | null;
   enabled: boolean;
   account: ReturnType<typeof useAccount>;
-  contracts: Contracts;
   wagmiConfig: ReturnType<typeof useWagmiConfig>;
   onSteps: (steps: string[]) => void;
 }) {
+  const contracts = getContracts();
+
   const steps = useQuery({
     enabled,
     queryKey: [
@@ -582,14 +405,271 @@ function useSteps<FR extends FlowRequest>({
   }, [steps.data, flow, onSteps]);
 }
 
-export function useTransactionFlow() {
-  return useContext(TransactionFlowContext);
+export function useFlowManager(account: Address | null) {
+  const [flow, setFlow] = useState<FlowContext<FlowRequest> | null>(null);
+
+  useEffect(() => {
+    // no account or wrong account => set flow to null (but preserve local storage state)
+    if (!account || (flow && flow.account !== account)) {
+      setFlow(null);
+      return;
+    }
+
+    // no flow => attempt to restore from local storage
+    if (!flow) {
+      const savedFlow = FlowContextStorage.get();
+      if (savedFlow?.account === account) {
+        setFlow(savedFlow);
+      }
+    }
+  }, [account, flow]);
+
+  const startFlow = useCallback((request: FlowRequest, account: Address) => {
+    const newFlow = { account, request, steps: null };
+    setFlow(newFlow);
+    FlowContextStorage.set(newFlow);
+  }, []);
+
+  const discardFlow = useCallback(() => {
+    setFlow(null);
+    FlowContextStorage.clear();
+  }, []);
+
+  const setFlowSteps = useCallback((steps: FlowSteps | null) => {
+    if (!flow) return;
+
+    const newFlow = { ...flow, steps };
+    setFlow(newFlow);
+    FlowContextStorage.set(newFlow);
+  }, [flow]);
+
+  const updateFlowStep = useCallback((stepIndex: number, update: FlowStepUpdate) => {
+    if (!flow) return;
+
+    const newSteps = flow.steps?.map((step, i) => (
+      i === stepIndex ? { ...step, ...update } : step
+    )) ?? null;
+
+    setFlowSteps(newSteps);
+  }, [flow, setFlowSteps]);
+
+  const currentStepIndex = useMemo(() => {
+    const firstUnconfirmed = flow?.steps?.findIndex((step) => step.txStatus !== "confirmed") ?? -1;
+    return firstUnconfirmed === -1 ? (flow?.steps?.length ?? 0) - 1 : firstUnconfirmed;
+  }, [flow]);
+
+  const currentStep = useMemo(() => flow?.steps?.[currentStepIndex] ?? null, [flow, currentStepIndex]);
+
+  const flowDeclaration = useMemo(() => flow && getFlowDeclaration(flow.request.flowId), [flow]);
+
+  const isFlowComplete = useMemo(() => flow?.steps?.at(-1)?.txStatus === "confirmed", [flow]);
+
+  const queryClient = useQueryClient();
+  useEffect(() => {
+    if (isFlowComplete) {
+      console.log("Flow is complete, invalidating queries");
+      queryClient.invalidateQueries();
+    }
+  }, [isFlowComplete, queryClient]);
+
+  return {
+    currentStep,
+    currentStepIndex,
+    discardFlow,
+    flow,
+    flowDeclaration,
+    isFlowComplete,
+    setFlowSteps,
+    startFlow,
+    updateFlowStep,
+  };
 }
 
-function getCurrentStepIndex(flow: FlowContext<FlowRequest> | null) {
-  if (!flow?.steps) return 0;
-  const index = flow.steps.findIndex((step) => step.txStatus !== "confirmed");
-  return index === -1 ? flow.steps.length - 1 : index;
+function useTransactionExecution({
+  flow,
+  currentStep,
+  currentStepIndex,
+  flowDeclaration,
+  updateFlowStep,
+}: {
+  flow: FlowContext<FlowRequest> | null;
+  currentStep: FlowSteps[number] | null;
+  currentStepIndex: number;
+  flowDeclaration: FlowDeclaration<FlowRequest> | null;
+  updateFlowStep: (index: number, update: FlowStepUpdate) => void;
+}) {
+  const account = useAccount();
+  const contracts = getContracts();
+  const queryClient = useQueryClient();
+  const wagmiConfig = useWagmiConfig();
+
+  // step status updates
+  const setStepToAwaitingSignature = () => {
+    updateFlowStep(currentStepIndex, {
+      error: null,
+      txHash: null,
+      txReceiptData: null,
+      txStatus: "awaiting-signature",
+    });
+  };
+  const setStepToAwaitingConfirmation = (txHash: `0x${string}`) => {
+    updateFlowStep(currentStepIndex, {
+      error: null,
+      txHash,
+      txReceiptData: null,
+      txStatus: "awaiting-confirmation",
+    });
+  };
+  const setStepToPostCheck = (receipt: GetTransactionReceiptReturnType) => {
+    if (!flow?.request) return;
+    updateFlowStep(currentStepIndex, {
+      error: null,
+      txHash: receipt.transactionHash,
+      txReceiptData: flowDeclaration?.parseReceipt?.(
+        flow.steps?.[currentStepIndex]?.id ?? "",
+        receipt,
+        { contracts, request: flow.request },
+      ) ?? null,
+      txStatus: "post-check",
+    });
+  };
+  const setStepToConfirmed = (receipt: GetTransactionReceiptReturnType) => {
+    if (!flow?.request) return;
+    updateFlowStep(currentStepIndex, {
+      error: null,
+      txHash: receipt.transactionHash,
+      txReceiptData: flowDeclaration?.parseReceipt?.(
+        flow.steps?.[currentStepIndex]?.id ?? "",
+        receipt,
+        { contracts, request: flow.request },
+      ) ?? null,
+      txStatus: "confirmed",
+    });
+  };
+  const setStepToError = (error: Error, txHash: `0x${string}` | null = null) => {
+    updateFlowStep(currentStepIndex, {
+      error: error.message,
+      txHash,
+      txReceiptData: null,
+      txStatus: "error",
+    });
+  };
+
+  const contractWrite = useWriteContract({
+    mutation: {
+      onMutate: setStepToAwaitingSignature,
+      onError: (err) => setStepToError(err),
+      onSuccess: setStepToAwaitingConfirmation,
+    },
+  });
+
+  const txReceipt = useTransactionReceipt({
+    hash: contractWrite.data ?? ((
+      currentStep?.txStatus === "awaiting-confirmation" && currentStep.txHash
+    ) || undefined),
+    query: { retry: true },
+  });
+
+  const runPostCheck = useCallback(async (receipt: GetTransactionReceiptReturnType) => {
+    if (!flow?.request || !flowDeclaration?.postFlowCheck) {
+      return;
+    }
+
+    while (true) {
+      try {
+        await flowDeclaration.postFlowCheck({
+          account,
+          contracts,
+          request: flow.request,
+          steps: flow.steps,
+          wagmiConfig,
+        });
+        // check passed
+        setStepToConfirmed(receipt);
+        break;
+      } catch (error) {
+        console.error("Post-check failed, retrying in 1 second", error);
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+    }
+  }, [
+    account,
+    contracts,
+    flow,
+    flowDeclaration,
+    wagmiConfig,
+  ]);
+
+  const postCheckReceipt = useRef<GetTransactionReceiptReturnType | null>(null);
+
+  useEffect(() => {
+    if (txReceipt.status !== "pending") {
+      contractWrite.reset();
+    }
+
+    if (txReceipt.status === "error") {
+      setStepToError(txReceipt.error);
+      return;
+    }
+
+    if (txReceipt.data?.status === "reverted") {
+      setStepToError(
+        new Error("Transaction reverted."),
+        txReceipt.data.transactionHash,
+      );
+      return;
+    }
+
+    if (txReceipt.status === "success") {
+      const isLastStep = currentStepIndex === (flow?.steps?.length ?? 0) - 1;
+
+      if (isLastStep && flowDeclaration?.postFlowCheck) {
+        postCheckReceipt.current = txReceipt.data;
+        setStepToPostCheck(txReceipt.data);
+      } else {
+        setStepToConfirmed(txReceipt.data);
+      }
+    }
+  }, [txReceipt]);
+
+  useEffect(() => {
+    if (currentStep?.txStatus === "post-check" && postCheckReceipt.current) {
+      runPostCheck(postCheckReceipt.current).catch(console.error);
+    }
+  }, [currentStep?.txStatus, runPostCheck]);
+
+  const signAndSend = useCallback(async () => {
+    const currentStepId = flow?.steps?.[currentStepIndex]?.id;
+
+    if (!currentStepId || currentStepIndex < 0 || !account || !flow || !flowDeclaration) {
+      return;
+    }
+
+    const writeParams = await flowDeclaration.writeContractParams(currentStepId, {
+      account,
+      contracts,
+      request: flow.request,
+      steps: flow.steps,
+      wagmiConfig,
+    });
+
+    if (writeParams) {
+      contractWrite.writeContract(writeParams);
+    }
+  }, [
+    account,
+    contractWrite,
+    contracts,
+    currentStepIndex,
+    flow,
+    flowDeclaration,
+    wagmiConfig,
+  ]);
+
+  return {
+    signAndSend,
+    isProcessing: txReceipt.status === "pending",
+  };
 }
 
 const FlowContextStorage = {
@@ -598,12 +678,21 @@ const FlowContextStorage = {
   },
   get(): FlowContext<FlowRequest> | null {
     try {
-      const storedState = localStorage.getItem(TRANSACTION_FLOW_KEY) ?? "";
+      const storedState = (localStorage.getItem(TRANSACTION_FLOW_KEY) ?? "").trim();
+      if (!storedState) return null;
+
       const { request, steps, account } = v.parse(FlowStateSchema, jsonParseWithDnum(storedState));
       const declaration = getFlowDeclaration(request.flowId);
       const parsedRequest = declaration.parseRequest(request);
-      const parsedSteps = v.parse(FlowStepsSchema, steps);
+      let parsedSteps = v.parse(FlowStepsSchema, steps);
+
       if (account && parsedRequest && parsedSteps) {
+        parsedSteps = parsedSteps.map((step) => (
+          step.txStatus === "post-check"
+            ? { ...step, txStatus: "confirmed" }
+            : step
+        ));
+
         return {
           account,
           request: parsedRequest,
@@ -613,6 +702,8 @@ const FlowContextStorage = {
       // eslint-disable-next-line no-unused-vars
     } catch (err) {
       console.error(err);
+      // clean up invalid state
+      localStorage.removeItem(TRANSACTION_FLOW_KEY);
     }
     return null;
   },
@@ -620,3 +711,7 @@ const FlowContextStorage = {
     localStorage.removeItem(TRANSACTION_FLOW_KEY);
   },
 };
+
+export function useTransactionFlow() {
+  return useContext(TransactionFlowContext);
+}

--- a/frontend/app/src/services/TransactionFlow.tsx
+++ b/frontend/app/src/services/TransactionFlow.tsx
@@ -326,7 +326,9 @@ export function TransactionFlow({ children }: { children: ReactNode }) {
   const start: TransactionFlowReactContext["start"] = useCallback((request) => {
     if (account.address) {
       startFlow(request, account.address);
-      router.push("/transactions");
+      setTimeout(() => {
+        router.push("/transactions");
+      }, 0);
     }
   }, [account]);
 
@@ -467,8 +469,7 @@ export function useFlowManager(account: Address | null) {
   const queryClient = useQueryClient();
   useEffect(() => {
     if (isFlowComplete) {
-      console.log("Flow is complete, invalidating queries");
-      queryClient.invalidateQueries();
+      queryClient.resetQueries();
     }
   }, [isFlowComplete, queryClient]);
 
@@ -500,7 +501,6 @@ function useTransactionExecution({
 }) {
   const account = useAccount();
   const contracts = getContracts();
-  const queryClient = useQueryClient();
   const wagmiConfig = useWagmiConfig();
 
   // step status updates

--- a/frontend/app/src/subgraph-queries.graphql
+++ b/frontend/app/src/subgraph-queries.graphql
@@ -13,7 +13,11 @@ query TrovesCount($id: ID!) {
 }
 
 query TrovesByAccount($account: Bytes!) {
-  troves(where: { borrower: $account, closedAt: null }) {
+  troves(
+    where: { borrower: $account, closedAt: null }
+    orderBy: updatedAt
+    orderDirection: desc
+  ) {
     id
     borrower
     closedAt
@@ -27,6 +31,7 @@ query TrovesByAccount($account: Bytes!) {
       collIndex
     }
     createdAt
+    updatedAt
     debt
     deposit
     interestBatch {
@@ -57,6 +62,7 @@ query TroveById($id: ID!) {
       collIndex
     }
     createdAt
+    updatedAt
     debt
     deposit
     interestBatch {

--- a/frontend/app/src/tx-flows/openBorrowPosition.tsx
+++ b/frontend/app/src/tx-flows/openBorrowPosition.tsx
@@ -1,13 +1,15 @@
 import type { FlowDeclaration } from "@/src/services/TransactionFlow";
 
+import { getBuiltGraphSDK } from "@/.graphclient";
 import { Amount } from "@/src/comps/Amount/Amount";
 import { ETH_GAS_COMPENSATION } from "@/src/constants";
 import { dnum18 } from "@/src/dnum-utils";
 import { fmtnum } from "@/src/formatting";
-import { getCollToken, usePredictOpenTroveUpfrontFee } from "@/src/liquity-utils";
+import { getCollToken, getPrefixedTroveId, usePredictOpenTroveUpfrontFee } from "@/src/liquity-utils";
 import { LoanCard } from "@/src/screens/TransactionsScreen/LoanCard";
 import { TransactionDetailsRow } from "@/src/screens/TransactionsScreen/TransactionsScreen";
 import { usePrice } from "@/src/services/Prices";
+import { isTroveId } from "@/src/types";
 import { vAddress, vCollIndex, vDnum } from "@/src/valibot-utils";
 import { ADDRESS_ZERO, COLLATERALS as KNOWN_COLLATERALS, shortenAddress } from "@liquity2/uikit";
 import * as dn from "dnum";
@@ -16,6 +18,8 @@ import { parseEventLogs } from "viem";
 import { readContract } from "wagmi/actions";
 
 const FlowIdSchema = v.literal("openBorrowPosition");
+
+const graph = getBuiltGraphSDK();
 
 const RequestSchema = v.object({
   flowId: FlowIdSchema,
@@ -240,7 +244,8 @@ export const openBorrowPosition: FlowDeclaration<Request, Step> = {
 
   parseReceipt(stepId, receipt, { request, contracts }): string | null {
     const collateral = contracts.collaterals[request.collIndex];
-    if (stepId === "openTroveEth") {
+
+    if (stepId === "openTroveEth" || stepId === "openTroveLst") {
       const [troveOperation] = parseEventLogs({
         abi: collateral.contracts.TroveManager.abi,
         logs: receipt.logs,
@@ -250,6 +255,7 @@ export const openBorrowPosition: FlowDeclaration<Request, Step> = {
         return "0x" + (troveOperation.args._troveId.toString(16));
       }
     }
+
     return null;
   },
 
@@ -327,5 +333,23 @@ export const openBorrowPosition: FlowDeclaration<Request, Step> = {
     }
 
     throw new Error("Not implemented");
+  },
+
+  async postFlowCheck({ request, steps }) {
+    const lastStep = steps?.at(-1);
+
+    if (lastStep?.txStatus !== "post-check" || !isTroveId(lastStep.txReceiptData)) {
+      return;
+    }
+
+    const prefixedTroveId = getPrefixedTroveId(
+      request.collIndex,
+      lastStep.txReceiptData,
+    );
+
+    while (true) {
+      const { trove } = await graph.TroveById({ id: prefixedTroveId });
+      if (trove !== null) return;
+    }
   },
 };

--- a/frontend/app/src/tx-flows/openBorrowPosition.tsx
+++ b/frontend/app/src/tx-flows/openBorrowPosition.tsx
@@ -19,8 +19,6 @@ import { readContract } from "wagmi/actions";
 
 const FlowIdSchema = v.literal("openBorrowPosition");
 
-const graph = getBuiltGraphSDK();
-
 const RequestSchema = v.object({
   flowId: FlowIdSchema,
   backLink: v.union([
@@ -346,6 +344,8 @@ export const openBorrowPosition: FlowDeclaration<Request, Step> = {
       request.collIndex,
       lastStep.txReceiptData,
     );
+
+    const graph = getBuiltGraphSDK();
 
     while (true) {
       const { trove } = await graph.TroveById({ id: prefixedTroveId });

--- a/frontend/app/src/tx-flows/openBorrowPosition.tsx
+++ b/frontend/app/src/tx-flows/openBorrowPosition.tsx
@@ -77,7 +77,7 @@ export const openBorrowPosition: FlowDeclaration<Request, Step> = {
         loadingState="success"
         loan={{
           type: "borrow",
-          troveId: "0x",
+          troveId: null,
           borrower: request.owner,
           batchManager: request.interestRateDelegate?.[0] ?? null,
           borrowed: boldAmountWithFee ?? dnum18(0),

--- a/frontend/app/src/tx-flows/openLeveragePosition.tsx
+++ b/frontend/app/src/tx-flows/openLeveragePosition.tsx
@@ -1,17 +1,19 @@
 import type { FlowDeclaration } from "@/src/services/TransactionFlow";
 
+import { getBuiltGraphSDK } from "@/.graphclient";
 import { Amount } from "@/src/comps/Amount/Amount";
 import { ETH_GAS_COMPENSATION, MAX_UPFRONT_FEE } from "@/src/constants";
 import { dnum18 } from "@/src/dnum-utils";
 import { fmtnum } from "@/src/formatting";
 import { getOpenLeveragedTroveParams } from "@/src/liquity-leverage";
-import { getCollToken, usePredictOpenTroveUpfrontFee } from "@/src/liquity-utils";
+import { getCollToken, getPrefixedTroveId, usePredictOpenTroveUpfrontFee } from "@/src/liquity-utils";
 import { AccountButton } from "@/src/screens/TransactionsScreen/AccountButton";
 import { LoanCard } from "@/src/screens/TransactionsScreen/LoanCard";
 import { TransactionDetailsRow } from "@/src/screens/TransactionsScreen/TransactionsScreen";
 import { usePrice } from "@/src/services/Prices";
+import { isTroveId } from "@/src/types";
 import { noop } from "@/src/utils";
-import { vPositionLoan } from "@/src/valibot-utils";
+import { vPositionLoanUncommited } from "@/src/valibot-utils";
 import { ADDRESS_ZERO } from "@liquity2/uikit";
 import * as dn from "dnum";
 import * as v from "valibot";
@@ -19,6 +21,8 @@ import { parseEventLogs } from "viem";
 import { readContract } from "wagmi/actions";
 
 const FlowIdSchema = v.literal("openLeveragePosition");
+
+const graph = getBuiltGraphSDK();
 
 const RequestSchema = v.object({
   flowId: FlowIdSchema,
@@ -301,5 +305,21 @@ export const openLeveragePosition: FlowDeclaration<Request, Step> = {
     }
 
     throw new Error("Not implemented");
+  },
+
+  async postFlowCheck({ request, steps }) {
+    const lastStep = steps?.at(-1);
+
+    if (lastStep?.txStatus !== "post-check" || !isTroveId(lastStep.txReceiptData)) {
+      return;
+    }
+
+    const prefixedTroveId = getPrefixedTroveId(request.loan.collIndex, lastStep.txReceiptData);
+    while (true) {
+      const { trove } = await graph.TroveById({ id: prefixedTroveId });
+      if (trove !== null) {
+        return;
+      }
+    }
   },
 };

--- a/frontend/app/src/tx-flows/openLeveragePosition.tsx
+++ b/frontend/app/src/tx-flows/openLeveragePosition.tsx
@@ -37,7 +37,7 @@ const RequestSchema = v.object({
 
   ownerIndex: v.number(),
   leverageFactor: v.number(),
-  loanPosition: vPositionLoan(),
+  loan: vPositionLoanUncommited(),
 });
 
 export type Request = v.InferOutput<typeof RequestSchema>;
@@ -50,7 +50,7 @@ export const openLeveragePosition: FlowDeclaration<Request, Step> = {
   title: "Review & Send Transaction",
   Summary({ flow }) {
     const { request } = flow;
-    const loan = request.loanPosition;
+    const { loan } = request;
 
     const collateral = getCollToken(loan.collIndex);
 
@@ -70,7 +70,7 @@ export const openLeveragePosition: FlowDeclaration<Request, Step> = {
   },
   Details({ flow }) {
     const { request } = flow;
-    const loan = request.loanPosition;
+    const { loan } = request;
 
     const collateral = getCollToken(loan.collIndex);
     const collPrice = usePrice(collateral?.symbol ?? null);
@@ -154,7 +154,7 @@ export const openLeveragePosition: FlowDeclaration<Request, Step> = {
     request,
     wagmiConfig,
   }) {
-    const loan = request.loanPosition;
+    const { loan } = request;
     const collateral = contracts.collaterals[loan.collIndex];
 
     if (collateral.symbol === "ETH") {
@@ -190,7 +190,7 @@ export const openLeveragePosition: FlowDeclaration<Request, Step> = {
   },
 
   getStepName(stepId, { request }) {
-    const loan = request.loanPosition;
+    const { loan } = request;
     const collateral = getCollToken(loan.collIndex);
     if (!collateral) {
       throw new Error("Invalid collateral index: " + loan.collIndex);
@@ -206,7 +206,7 @@ export const openLeveragePosition: FlowDeclaration<Request, Step> = {
   },
 
   parseReceipt(stepId, receipt, { request, contracts }): string | null {
-    const loan = request.loanPosition;
+    const { loan } = request;
     const collateral = contracts.collaterals[loan.collIndex];
     if (stepId === "openLeveragedTrove") {
       const [troveOperation] = parseEventLogs({
@@ -222,7 +222,7 @@ export const openLeveragePosition: FlowDeclaration<Request, Step> = {
   },
 
   async writeContractParams(stepId, { contracts, request, wagmiConfig }) {
-    const loan = request.loanPosition;
+    const { loan } = request;
     const collateral = contracts.collaterals[loan.collIndex];
     const initialDeposit = dn.div(loan.deposit, request.leverageFactor);
 

--- a/frontend/app/src/tx-flows/updateBorrowPosition.tsx
+++ b/frontend/app/src/tx-flows/updateBorrowPosition.tsx
@@ -1,5 +1,6 @@
 import type { LoadingState } from "@/src/screens/TransactionsScreen/TransactionsScreen";
 import type { FlowDeclaration } from "@/src/services/TransactionFlow";
+import type { PositionLoanCommitted } from "@/src/types";
 
 import { Amount } from "@/src/comps/Amount/Amount";
 import { fmtnum } from "@/src/formatting";
@@ -119,16 +120,17 @@ export const updateBorrowPosition: FlowDeclaration<Request, Step> = {
       debtChangeWithFee,
     );
 
-    const newLoan = !loan.data || !newBorrowed ? null : {
-      troveId,
-      borrower: loan.data.borrower,
+    const newLoan: null | PositionLoanCommitted = !loan.data || !newBorrowed ? null : {
+      type: "borrow" as const,
       batchManager: loan.data.batchManager,
       borrowed: newBorrowed,
+      borrower: loan.data.borrower,
       collIndex: request.collIndex,
-      collateral: collateral.symbol,
+      createdAt: loan.data.createdAt,
       deposit: newDeposit,
       interestRate: loan.data.interestRate,
-      type: "borrow" as const,
+      troveId,
+      updatedAt: loan.data.updatedAt,
     };
 
     const prevLoan = !newLoan || !loan.data ? null : {

--- a/frontend/app/src/tx-flows/updateLeveragePosition.tsx
+++ b/frontend/app/src/tx-flows/updateLeveragePosition.tsx
@@ -1,14 +1,16 @@
 import type { LoadingState } from "@/src/screens/TransactionsScreen/TransactionsScreen";
 import type { FlowDeclaration } from "@/src/services/TransactionFlow";
 
+import { getBuiltGraphSDK } from "@/.graphclient";
 import { Amount } from "@/src/comps/Amount/Amount";
 import { MAX_UPFRONT_FEE } from "@/src/constants";
 import { fmtnum } from "@/src/formatting";
 import { getLeverDownTroveParams, getLeverUpTroveParams } from "@/src/liquity-leverage";
-import { getCollToken, usePredictAdjustTroveUpfrontFee } from "@/src/liquity-utils";
+import { getCollToken, getPrefixedTroveId, usePredictAdjustTroveUpfrontFee } from "@/src/liquity-utils";
 import { LoanCard } from "@/src/screens/TransactionsScreen/LoanCard";
 import { TransactionDetailsRow } from "@/src/screens/TransactionsScreen/TransactionsScreen";
 import { usePrice } from "@/src/services/Prices";
+import { isTroveId } from "@/src/types";
 import { vDnum, vPositionLoanCommited } from "@/src/valibot-utils";
 import * as dn from "dnum";
 import { match, P } from "ts-pattern";
@@ -84,11 +86,16 @@ export const updateLeveragePosition: FlowDeclaration<Request, Step> = {
       .with({ data: P.nonNullable }, () => "success")
       .otherwise(() => "error");
 
+    const borrowedWithFee = dn.add(
+      loan.borrowed,
+      upfrontFeeData.data?.upfrontFee ?? dn.from(0, 18),
+    );
+
     return (
       <LoanCard
         leverageMode={true}
         loadingState={loadingState}
-        loan={loan}
+        loan={{ ...loan, borrowed: borrowedWithFee }}
         prevLoan={prevLoan}
         onRetry={() => {
           upfrontFeeData.refetch();
@@ -291,6 +298,31 @@ export const updateLeveragePosition: FlowDeclaration<Request, Step> = {
     }
 
     throw new Error("Invalid step");
+  },
+
+  async postFlowCheck({ request, steps }) {
+    const lastStep = steps?.at(-1);
+    if (lastStep?.txStatus !== "post-check" || !isTroveId(lastStep.txReceiptData)) {
+      return;
+    }
+
+    const lastUpdate = request.loan.updatedAt;
+
+    const prefixedTroveId = getPrefixedTroveId(
+      request.loan.collIndex,
+      lastStep.txReceiptData,
+    );
+
+    const graph = getBuiltGraphSDK();
+
+    while (true) {
+      const { trove } = await graph.TroveById({ id: prefixedTroveId });
+
+      // trove found and updated: check done
+      if (trove && Number(trove.updatedAt) * 1000 !== lastUpdate) {
+        break;
+      }
+    }
   },
 };
 

--- a/frontend/app/src/tx-flows/updateLeveragePosition.tsx
+++ b/frontend/app/src/tx-flows/updateLeveragePosition.tsx
@@ -9,7 +9,7 @@ import { getCollToken, usePredictAdjustTroveUpfrontFee } from "@/src/liquity-uti
 import { LoanCard } from "@/src/screens/TransactionsScreen/LoanCard";
 import { TransactionDetailsRow } from "@/src/screens/TransactionsScreen/TransactionsScreen";
 import { usePrice } from "@/src/services/Prices";
-import { vDnum, vPositionLoan } from "@/src/valibot-utils";
+import { vDnum, vPositionLoanCommited } from "@/src/valibot-utils";
 import * as dn from "dnum";
 import { match, P } from "ts-pattern";
 import * as v from "valibot";
@@ -43,8 +43,8 @@ const RequestSchema = v.object({
     ]),
   ]),
 
-  prevLoan: vPositionLoan(),
-  loan: vPositionLoan(),
+  prevLoan: vPositionLoanCommited(),
+  loan: vPositionLoanCommited(),
 });
 
 export type Request = v.InferOutput<typeof RequestSchema>;

--- a/frontend/app/src/tx-flows/updateLoanInterestRate.tsx
+++ b/frontend/app/src/tx-flows/updateLoanInterestRate.tsx
@@ -8,7 +8,7 @@ import { usePredictAdjustInterestRateUpfrontFee } from "@/src/liquity-utils";
 import { AccountButton } from "@/src/screens/TransactionsScreen/AccountButton";
 import { LoanCard } from "@/src/screens/TransactionsScreen/LoanCard";
 import { TransactionDetailsRow } from "@/src/screens/TransactionsScreen/TransactionsScreen";
-import { vPositionLoan } from "@/src/valibot-utils";
+import { vPositionLoanCommited } from "@/src/valibot-utils";
 import { css } from "@/styled-system/css";
 import { ADDRESS_ZERO } from "@liquity2/uikit";
 import * as dn from "dnum";
@@ -35,8 +35,8 @@ const RequestSchema = v.object({
   ]),
   successMessage: v.string(),
 
-  prevLoanPosition: vPositionLoan(),
-  loanPosition: vPositionLoan(),
+  prevLoanPosition: vPositionLoanCommited(),
+  loanPosition: vPositionLoanCommited(),
 });
 
 export type Request = v.InferOutput<typeof RequestSchema>;

--- a/frontend/app/src/tx-flows/updateLoanInterestRate.tsx
+++ b/frontend/app/src/tx-flows/updateLoanInterestRate.tsx
@@ -1,13 +1,15 @@
 import type { LoadingState } from "@/src/screens/TransactionsScreen/TransactionsScreen";
 import type { FlowDeclaration } from "@/src/services/TransactionFlow";
 
+import { getBuiltGraphSDK } from "@/.graphclient";
 import { MAX_ANNUAL_INTEREST_RATE, MIN_ANNUAL_INTEREST_RATE } from "@/src/constants";
 import { dnum18 } from "@/src/dnum-utils";
 import { fmtnum } from "@/src/formatting";
-import { usePredictAdjustInterestRateUpfrontFee } from "@/src/liquity-utils";
+import { getPrefixedTroveId, usePredictAdjustInterestRateUpfrontFee } from "@/src/liquity-utils";
 import { AccountButton } from "@/src/screens/TransactionsScreen/AccountButton";
 import { LoanCard } from "@/src/screens/TransactionsScreen/LoanCard";
 import { TransactionDetailsRow } from "@/src/screens/TransactionsScreen/TransactionsScreen";
+import { isTroveId } from "@/src/types";
 import { vPositionLoanCommited } from "@/src/valibot-utils";
 import { css } from "@/styled-system/css";
 import { ADDRESS_ZERO } from "@liquity2/uikit";
@@ -35,8 +37,8 @@ const RequestSchema = v.object({
   ]),
   successMessage: v.string(),
 
-  prevLoanPosition: vPositionLoanCommited(),
-  loanPosition: vPositionLoanCommited(),
+  prevLoan: vPositionLoanCommited(),
+  loan: vPositionLoanCommited(),
 });
 
 export type Request = v.InferOutput<typeof RequestSchema>;
@@ -50,8 +52,7 @@ export const updateLoanInterestRate: FlowDeclaration<Request, Step> = {
   title: "Review & Confirm",
   Summary({ flow }) {
     const { request } = flow;
-    const loan = request.loanPosition;
-    const prevLoan = request.prevLoanPosition;
+    const { loan, prevLoan } = request;
 
     const upfrontFee = usePredictAdjustInterestRateUpfrontFee(
       loan.collIndex,
@@ -87,8 +88,7 @@ export const updateLoanInterestRate: FlowDeclaration<Request, Step> = {
   },
   Details({ flow }) {
     const { request } = flow;
-    const loan = request.loanPosition;
-    const prevLoanPosition = request.prevLoanPosition;
+    const { loan, prevLoan } = request;
 
     const yearlyBoldInterest = dn.mul(loan.borrowed, loan.interestRate);
 
@@ -120,7 +120,7 @@ export const updateLoanInterestRate: FlowDeclaration<Request, Step> = {
               </div>,
             ]}
           />
-          {prevLoanPosition.batchManager && (
+          {prevLoan.batchManager && (
             <TransactionDetailsRow
               label="Remove interest rate delegate"
               value={[
@@ -130,7 +130,7 @@ export const updateLoanInterestRate: FlowDeclaration<Request, Step> = {
                     textDecoration: "line-through",
                   })}
                 >
-                  <AccountButton address={prevLoanPosition.batchManager} />
+                  <AccountButton address={prevLoan.batchManager} />
                 </div>,
                 <div
                   key="end"
@@ -138,8 +138,8 @@ export const updateLoanInterestRate: FlowDeclaration<Request, Step> = {
                     textDecoration: "line-through",
                   })}
                 >
-                  {fmtnum(prevLoanPosition.interestRate, "full", 100)}% (~{fmtnum(
-                    dn.mul(prevLoanPosition.borrowed, prevLoanPosition.interestRate),
+                  {fmtnum(prevLoan.interestRate, "full", 100)}% (~{fmtnum(
+                    dn.mul(prevLoan.borrowed, prevLoan.interestRate),
                     4,
                   )} BOLD per year)
                 </div>,
@@ -150,8 +150,7 @@ export const updateLoanInterestRate: FlowDeclaration<Request, Step> = {
       );
   },
   async getSteps({ request, contracts, wagmiConfig }) {
-    const loan = request.loanPosition;
-
+    const loan = request.loan;
     const collateral = contracts.collaterals[loan.collIndex];
 
     if (loan.batchManager) {
@@ -180,8 +179,7 @@ export const updateLoanInterestRate: FlowDeclaration<Request, Step> = {
   },
 
   async writeContractParams(stepId, { contracts, request }) {
-    const loan = request.loanPosition;
-
+    const { loan } = request;
     const { BorrowerOperations } = contracts.collaterals[loan.collIndex].contracts;
 
     if (stepId === "adjustInterestRate") {
@@ -227,5 +225,30 @@ export const updateLoanInterestRate: FlowDeclaration<Request, Step> = {
     }
 
     return null;
+  },
+  async postFlowCheck({ request, steps }) {
+    const lastStep = steps?.at(-1);
+    if (lastStep?.txStatus !== "post-check" || !isTroveId(lastStep.txReceiptData)) {
+      return;
+    }
+
+    const { loan } = request;
+    const lastUpdate = loan.updatedAt;
+
+    const prefixedTroveId = getPrefixedTroveId(
+      loan.collIndex,
+      lastStep.txReceiptData,
+    );
+
+    const graph = getBuiltGraphSDK();
+
+    while (true) {
+      const { trove } = await graph.TroveById({ id: prefixedTroveId });
+
+      // trove found and updated: check done
+      if (trove && Number(trove.updatedAt) * 1000 !== lastUpdate) {
+        break;
+      }
+    }
   },
 };

--- a/frontend/app/src/types.ts
+++ b/frontend/app/src/types.ts
@@ -39,7 +39,7 @@ export type MenuSection = {
   label: ReactNode;
 };
 
-export type PositionLoan = {
+export type PositionLoanBase = {
   type: "borrow" | "leverage";
   batchManager: null | Address;
   borrowed: Dnum;
@@ -47,11 +47,32 @@ export type PositionLoan = {
   collIndex: CollIndex;
   deposit: Dnum;
   interestRate: Dnum;
-  troveId: TroveId;
 };
+
+export type PositionLoanCommitted = PositionLoanBase & {
+  troveId: TroveId;
+  updatedAt: number;
+  createdAt: number;
+};
+
+export type PositionLoanUncommitted = PositionLoanBase & {
+  troveId: null;
+};
+
+export type PositionLoan = PositionLoanCommitted | PositionLoanUncommitted;
 
 export function isPositionLoan(position: Position): position is PositionLoan {
   return position.type === "borrow" || position.type === "leverage";
+}
+export function isPositionLoanCommitted(
+  position: Position,
+): position is PositionLoanCommitted {
+  return isPositionLoan(position) && position.troveId !== null;
+}
+export function isPositionLoanUncommitted(
+  position: Position,
+): position is PositionLoanUncommitted {
+  return isPositionLoan(position) && position.troveId === null;
 }
 
 export type PositionEarn = {

--- a/frontend/app/src/valibot-utils.ts
+++ b/frontend/app/src/valibot-utils.ts
@@ -142,18 +142,42 @@ export function vPositionStake() {
   });
 }
 
+const VPositionLoanBase = v.object({
+  type: v.union([
+    v.literal("borrow"),
+    v.literal("leverage"),
+  ]),
+  batchManager: v.union([v.null(), vAddress()]),
+  borrowed: vDnum(),
+  borrower: vAddress(),
+  collIndex: vCollIndex(),
+  deposit: vDnum(),
+  interestRate: vDnum(),
+});
+
+export function vPositionLoanCommited() {
+  return v.intersect([
+    VPositionLoanBase,
+    v.object({
+      troveId: vTroveId(),
+      updatedAt: v.number(),
+      createdAt: v.number(),
+    }),
+  ]);
+}
+
+export function vPositionLoanUncommited() {
+  return v.intersect([
+    VPositionLoanBase,
+    v.object({
+      troveId: v.null(),
+    }),
+  ]);
+}
+
 export function vPositionLoan() {
-  return v.object({
-    type: v.union([
-      v.literal("borrow"),
-      v.literal("leverage"),
-    ]),
-    batchManager: v.union([v.null(), vAddress()]),
-    borrowed: vDnum(),
-    borrower: vAddress(),
-    collIndex: vCollIndex(),
-    deposit: vDnum(),
-    interestRate: vDnum(),
-    troveId: vTroveId(),
-  });
+  return v.intersect([
+    vPositionLoanCommited(),
+    vPositionLoanUncommited(),
+  ]);
 }


### PR DESCRIPTION
This allows to add an additional check that will ensure the change has been propagated (generally to the indexer) before showing the success screen. We also invalidate the queryClient cache at this stage, ensuring that the data will get reload on the next screen.

Post flow checks:

- [x] closeLoanPosition.tsx
- [x] openBorrowPosition.tsx
- [x] openLeveragePosition.tsx
- [x] updateBorrowPosition.tsx
- [x] updateLeveragePosition.tsx
- [x] updateLoanInterestRate.tsx

Also in this PR:
- Animate the tx screen like the other screens.
- Animate the success message.
- Add `PositionLoanUncommitted` and `PositionLoanCommitted` types to distinguish the new (UI only) loans from the existing ones.
- Add persistent preview to the updateBorrowPosition tx flow
- Add upfront fee to the updateLeveragePosition summary card