### PR TITLE
App: tweak dashboard positions

### DIFF
--- a/frontend/app/src/comps/Positions/PositionCardBorrow.tsx
+++ b/frontend/app/src/comps/Positions/PositionCardBorrow.tsx
@@ -66,7 +66,7 @@ export function PositionCardBorrow({
             <div
               className={css({
                 display: "flex",
-                color: "strongSurfaceContentAlt2",
+                color: "white",
               })}
             >
               <IconBorrow size={16} />

--- a/frontend/app/src/comps/Positions/PositionCardEarn.tsx
+++ b/frontend/app/src/comps/Positions/PositionCardEarn.tsx
@@ -41,7 +41,7 @@ export function PositionCardEarn({
             <div
               className={css({
                 display: "flex",
-                color: "strongSurfaceContentAlt2",
+                color: "brandLightBlue",
               })}
             >
               <IconEarn size={16} />

--- a/frontend/app/src/comps/Positions/PositionCardLeverage.tsx
+++ b/frontend/app/src/comps/Positions/PositionCardLeverage.tsx
@@ -61,7 +61,7 @@ export function PositionCardLeverage({
             <div
               className={css({
                 display: "flex",
-                color: "strongSurfaceContentAlt2",
+                color: "brandGreen",
               })}
             >
               <IconLeverage size={16} />

--- a/frontend/app/src/comps/Positions/PositionCardStake.tsx
+++ b/frontend/app/src/comps/Positions/PositionCardStake.tsx
@@ -36,7 +36,7 @@ export function PositionCardStake({
             <div
               className={css({
                 display: "flex",
-                color: "strongSurfaceContentAlt2",
+                color: "brandGolden",
               })}
             >
               <IconStake size={16} />

--- a/frontend/app/src/comps/Positions/Positions.tsx
+++ b/frontend/app/src/comps/Positions/Positions.tsx
@@ -11,7 +11,7 @@ import { css } from "@/styled-system/css";
 import { StrongCard } from "@liquity2/uikit";
 import { a, useSpring, useTransition } from "@react-spring/web";
 import * as dn from "dnum";
-import { useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { match, P } from "ts-pattern";
 import { NewPositionCard } from "./NewPositionCard";
 import { PositionCardEarn } from "./PositionCardEarn";
@@ -60,6 +60,20 @@ export function Positions({
     : isPositionsPending
     ? "loading"
     : "actions";
+
+  // preloading for 1 second, prevents flickering
+  // since the account doesn’t reconnect instantly
+  const [preLoading, setPreLoading] = useState(true);
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setPreLoading(false);
+    }, 500);
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (preLoading) {
+    mode = "loading";
+  }
 
   return (
     <PositionsGroup
@@ -147,21 +161,25 @@ function PositionsGroup({
   const positionTransitions = useTransition(cards, {
     keys: ([index]) => `${mode}${index}`,
     from: {
+      display: "none",
       opacity: 0,
-      transform: "scale3d(0.97, 0.97, 1)",
+      transform: "scale(0.9)",
     },
     enter: {
+      display: "grid",
       opacity: 1,
-      transform: "scale3d(1, 1, 1)",
+      transform: "scale(1)",
     },
     leave: {
       display: "none",
+      opacity: 0,
+      transform: "scale(1)",
       immediate: true,
     },
     config: {
-      mass: 2,
-      tension: 1800,
-      friction: 80,
+      mass: 1,
+      tension: 1600,
+      friction: 120,
     },
   });
 


### PR DESCRIPTION
- Icon colors.
- Tweaked animation.
- Add a 500ms delay during which the cards stay in loading state, to prevent flickering (needed because the account don’t reconnect instantly).