### PR TITLE
Various app changes

### DIFF
--- a/frontend/app/src/comps/AppLayout/AppLayout.tsx
+++ b/frontend/app/src/comps/AppLayout/AppLayout.tsx
@@ -18,7 +18,7 @@ export function AppLayout({
       className={css({
         display: "flex",
         flexDirection: "column",
-        alignItems: "center",
+        alignItems: "flex-start",
         width: "100%",
         minHeight: "100vh",
         margin: "0 auto",

--- a/frontend/app/src/comps/LeverageField/LeverageField.tsx
+++ b/frontend/app/src/comps/LeverageField/LeverageField.tsx
@@ -2,7 +2,7 @@ import type { CollateralToken } from "@liquity2/uikit";
 import type { Dnum } from "dnum";
 import type { ComponentPropsWithoutRef } from "react";
 
-import { LEVERAGE_FACTOR_MIN, LEVERAGE_FACTOR_SUGGESTIONS, LTV_RISK, MAX_LTV_ALLOWED } from "@/src/constants";
+import { LEVERAGE_FACTOR_MIN, LEVERAGE_FACTOR_SUGGESTIONS, LTV_RISK, MAX_LTV_ALLOWED_RATIO } from "@/src/constants";
 import content from "@/src/content";
 import { useInputFieldValue } from "@/src/form-utils";
 import { fmtnum } from "@/src/formatting";
@@ -144,7 +144,7 @@ export function useLeverageField({
   collPrice,
   collToken,
   depositPreLeverage,
-  maxLtvAllowedRatio = MAX_LTV_ALLOWED,
+  maxLtvAllowedRatio = MAX_LTV_ALLOWED_RATIO,
   onFocusChange,
 }: {
   collPrice: Dnum;

--- a/frontend/app/src/comps/Screen/Screen.tsx
+++ b/frontend/app/src/comps/Screen/Screen.tsx
@@ -44,12 +44,32 @@ export function Screen({
     },
   });
 
+  const headingSpring = useSpring({
+    from: {
+      opacity: 0,
+      transform: `
+        translate(0, 48px)
+      `,
+    },
+    to: {
+      opacity: 1,
+      transform: `
+        translate(0, 0px)
+      `,
+    },
+    config: {
+      mass: 1,
+      tension: 2200,
+      friction: 220,
+    },
+  });
+
   const screenSpring = useSpring({
     from: {
       opacity: 0,
       transform: `
-        scale3d(1.03, 1.03, 1)
-        translate3d(0, 40px, 0)
+        scale3d(0.95, 0.95, 1)
+        translate3d(0, 20px, 0)
       `,
     },
     to: {
@@ -59,33 +79,11 @@ export function Screen({
         translate3d(0, 0px, 0)
       `,
     },
-    delay: 100,
+    delay: 150,
     config: {
-      mass: 1,
-      tension: 1600,
-      friction: 120,
-    },
-  });
-
-  const headingSpring = useSpring({
-    from: {
-      opacity: 1,
-      transform: `
-        scale(1.08)
-        translate(0, 16px)
-      `,
-    },
-    to: {
-      opacity: 1,
-      transform: `
-        scale(1)
-        translate(0, 0px)
-      `,
-    },
-    config: {
-      mass: 1,
+      mass: 2,
       tension: 2400,
-      friction: 120,
+      friction: 220,
     },
   });
 
@@ -194,6 +192,8 @@ export function Screen({
           display: "flex",
           flexDirection: "column",
           position: "relative",
+          transformOrigin: "50% 0",
+          willChange: "transform, opacity",
         })}
         style={{
           gap,

--- a/frontend/app/src/comps/StakePositionSummary/StakePositionSummary.tsx
+++ b/frontend/app/src/comps/StakePositionSummary/StakePositionSummary.tsx
@@ -16,10 +16,6 @@ export function StakePositionSummary({
   stakePosition: null | PositionStake;
   txPreviewMode?: boolean;
 }) {
-  // We might want to use an inactive state like for the Earn positions.
-  // For now, it's always active.
-  const active = true;
-
   return (
     <div
       className={css({
@@ -28,28 +24,12 @@ export function StakePositionSummary({
         flexDirection: "column",
         width: "100%",
         padding: 16,
+        color: "token(colors.strongSurfaceContent)",
+        background: "token(colors.strongSurface)",
         borderRadius: 8,
         userSelect: "none",
-
-        "--fg-primary-active": "token(colors.strongSurfaceContent)",
-        "--fg-primary-inactive": "token(colors.content)",
-
-        "--fg-secondary-active": "token(colors.strongSurfaceContentAlt)",
-        "--fg-secondary-inactive": "token(colors.contentAlt)",
-
-        "--border-active": "color-mix(in srgb, token(colors.secondary) 15%, transparent)",
-        "--border-inactive": "token(colors.infoSurfaceBorder)",
-
-        "--bg-active": "token(colors.strongSurface)",
-        "--bg-inactive": "token(colors.infoSurface)",
-
         "--update-color": "token(colors.positiveAlt)",
       })}
-      style={{
-        color: `var(--fg-primary-${active ? "active" : "inactive"})`,
-        background: `var(--bg-${active ? "active" : "inactive"})`,
-        border: active ? 0 : "1px solid var(--border-inactive)",
-      }}
     >
       {txPreviewMode && <TagPreview />}
       <div
@@ -58,10 +38,8 @@ export function StakePositionSummary({
           alignItems: "flex-start",
           flexDirection: "column",
           paddingBottom: 12,
+          borderBottom: "1px solid color-mix(in srgb, token(colors.secondary) 15%, transparent)",
         })}
-        style={{
-          borderBottom: `1px solid var(--border-${active ? "active" : "inactive"})`,
-        }}
       >
         <h1
           title="LQTY Stake"
@@ -158,7 +136,7 @@ export function StakePositionSummary({
           <div
             className={css({
               fontSize: 14,
-              color: "var(--fg-secondary-active)",
+              color: "token(colors.strongSurfaceContentAlt)",
             })}
           >
             Staked
@@ -190,110 +168,99 @@ export function StakePositionSummary({
             })}
           >
             <div
-              style={{
-                color: `var(--fg-secondary-${active ? "active" : "inactive"})`,
-              }}
+              className={css({
+                color: "token(colors.strongSurfaceContentAlt)",
+              })}
             >
               Rewards
             </div>
-            {active
-              ? (
-                <HFlex
-                  gap={8}
-                >
-                  <HFlex
-                    gap={4}
-                    className={css({
-                      color: txPreviewMode
-                          && stakePosition?.rewards.lusd
-                          && dn.gt(stakePosition?.rewards.lusd, 0)
-                        ? "var(--update-color)"
-                        : "inherit",
-                    })}
-                  >
-                    <Amount
-                      format="2diff"
-                      value={stakePosition?.rewards.lusd ?? 0}
-                    />
-                    <TokenIcon symbol="LUSD" size="mini" />
-                  </HFlex>
-                  <HFlex
-                    gap={4}
-                    className={css({
-                      color: txPreviewMode
-                          && stakePosition?.rewards.eth
-                          && dn.gt(stakePosition?.rewards.eth, 0)
-                        ? "var(--update-color)"
-                        : "inherit",
-                    })}
-                  >
-                    <Amount
-                      format="2diff"
-                      value={stakePosition?.rewards.eth ?? 0}
-                    />
-                    <TokenIcon symbol="ETH" size="mini" />
-                  </HFlex>
-                </HFlex>
-              )
-              : (
-                <TokenIcon.Group size="mini">
-                  <TokenIcon symbol="LUSD" />
-                  <TokenIcon symbol="ETH" />
-                </TokenIcon.Group>
-              )}
-          </div>
-          {active && (
-            <div>
-              <div
-                style={{
-                  color: `var(--fg-secondary-${active ? "active" : "inactive"})`,
-                }}
-              >
-                Voting power
-              </div>
-              <div
+            <HFlex
+              gap={8}
+            >
+              <HFlex
+                gap={4}
                 className={css({
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 4,
+                  color: txPreviewMode
+                      && stakePosition?.rewards.lusd
+                      && dn.gt(stakePosition?.rewards.lusd, 0)
+                    ? "var(--update-color)"
+                    : "inherit",
                 })}
               >
-                <div
-                  style={{
-                    color: txPreviewMode
-                        && prevStakePosition
-                        && stakePosition?.share
-                        && !dn.eq(prevStakePosition.share, stakePosition.share)
-                      ? "var(--update-color)"
-                      : "inherit",
-                  }}
-                >
-                  <Amount
-                    percentage
-                    value={stakePosition?.share ?? 0}
-                  />
-                </div>
-                {prevStakePosition && stakePosition && !dn.eq(prevStakePosition.share, stakePosition.share)
-                  ? (
-                    <div
-                      className={css({
-                        color: "contentAlt",
-                        textDecoration: "line-through",
-                      })}
-                    >
-                      <Amount
-                        percentage
-                        value={prevStakePosition?.share ?? 0}
-                      />
-                    </div>
-                  )
-                  : " of pool"}
-                <InfoTooltip>
-                  Voting power is the percentage of the total staked LQTY that you own.
-                </InfoTooltip>
-              </div>
+                <Amount
+                  format="2diff"
+                  value={stakePosition?.rewards.lusd ?? 0}
+                />
+                <TokenIcon symbol="LUSD" size="mini" />
+              </HFlex>
+              <HFlex
+                gap={4}
+                className={css({
+                  color: txPreviewMode
+                      && stakePosition?.rewards.eth
+                      && dn.gt(stakePosition?.rewards.eth, 0)
+                    ? "var(--update-color)"
+                    : "inherit",
+                })}
+              >
+                <Amount
+                  format="2diff"
+                  value={stakePosition?.rewards.eth ?? 0}
+                />
+                <TokenIcon symbol="ETH" size="mini" />
+              </HFlex>
+            </HFlex>
+          </div>
+          <div>
+            <div
+              className={css({
+                color: "token(colors.strongSurfaceContentAlt)",
+              })}
+            >
+              Voting power
             </div>
-          )}
+            <div
+              className={css({
+                display: "flex",
+                alignItems: "center",
+                gap: 4,
+              })}
+            >
+              <div
+                style={{
+                  color: txPreviewMode
+                      && prevStakePosition
+                      && stakePosition?.share
+                      && !dn.eq(prevStakePosition.share, stakePosition.share)
+                    ? "var(--update-color)"
+                    : "inherit",
+                }}
+              >
+                <Amount
+                  percentage
+                  value={stakePosition?.share ?? 0}
+                />
+              </div>
+              {prevStakePosition && stakePosition && !dn.eq(prevStakePosition.share, stakePosition.share)
+                ? (
+                  <div
+                    className={css({
+                      color: "contentAlt",
+                      textDecoration: "line-through",
+                    })}
+                  >
+                    <Amount
+                      percentage
+                      value={prevStakePosition?.share ?? 0}
+                    />
+                  </div>
+                )
+                : " of pool"}
+              <InfoTooltip>
+                Voting power is the percentage of the total staked LQTY that you own.
+              </InfoTooltip>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/app/src/constants.ts
+++ b/frontend/app/src/constants.ts
@@ -8,7 +8,10 @@ import * as dn from "dnum";
 export const LOCAL_STORAGE_PREFIX = "liquity2:";
 
 export const LEVERAGE_FACTOR_MIN = 1.1;
-export const MAX_LTV_ALLOWED = 0.916; // ratio of the max LTV allowed by the app
+
+export const MAX_LTV_ALLOWED_RATIO = 0.916; // ratio of the max LTV allowed by the app (when opening a position)
+export const MAX_LTV_RESERVE_RATIO = 0.04; // ratio of the max LTV in non-limited mode (e.g. when updating a position), to prevent reaching the max LTV
+
 export const ETH_MAX_RESERVE = dn.from(0.1, 18); // leave 0.1 ETH when users click on "max" to deposit from their account
 export const ETH_GAS_COMPENSATION = dn.from(0.0375, 18); // see contracts/src/Dependencies/Constants.sol
 

--- a/frontend/app/src/liquity-math.ts
+++ b/frontend/app/src/liquity-math.ts
@@ -3,7 +3,7 @@ import type { Dnum } from "dnum";
 
 import {
   LTV_RISK,
-  MAX_LTV_ALLOWED,
+  MAX_LTV_ALLOWED_RATIO,
   ONE_YEAR_IN_SECONDS,
   REDEMPTION_RISK,
   UPFRONT_INTEREST_PERIOD,
@@ -116,7 +116,7 @@ export function getLoanDetails(
   collPrice: Dnum | null,
 ): LoanDetails {
   const maxLtv = dn.div(dn.from(1, 18), minCollRatio);
-  const maxLtvAllowed = dn.mul(maxLtv, MAX_LTV_ALLOWED);
+  const maxLtvAllowed = dn.mul(maxLtv, MAX_LTV_ALLOWED_RATIO);
   const depositUsd = deposit && collPrice ? dn.mul(deposit, collPrice) : null;
 
   const ltv = debt && depositUsd && !dn.eq(depositUsd, 0)

--- a/frontend/app/src/screens/BorrowScreen/BorrowScreen.tsx
+++ b/frontend/app/src/screens/BorrowScreen/BorrowScreen.tsx
@@ -140,7 +140,7 @@ export function BorrowScreen() {
         collPrice,
       );
 
-      // don’t show if ltv > MAX_LTV_ALLOWED
+      // don’t show if ltv > max LTV
       if (ltv && dn.gt(ltv, loanDetails.maxLtv)) {
         return null;
       }
@@ -211,9 +211,8 @@ export function BorrowScreen() {
                   menuWidth={300}
                   onSelect={(index) => {
                     deposit.setValue("");
-                    const { symbol } = collaterals[index];
                     router.push(
-                      `/borrow/${symbol.toLowerCase()}`,
+                      `/borrow/${collaterals[index].symbol.toLowerCase()}`,
                       { scroll: false },
                     );
                   }}

--- a/frontend/app/src/screens/LoanScreen/LoanScreenCard.tsx
+++ b/frontend/app/src/screens/LoanScreen/LoanScreenCard.tsx
@@ -254,7 +254,20 @@ function LoanCardHeading({
         }}
       >
         {mode === "leverage"
-          ? <IconLeverage size={16} />
+          ? (
+            inheritColor
+              ? <IconLeverage size={16} />
+              : (
+                <div
+                  className={css({
+                    display: "flex",
+                    color: "brandGreen",
+                  })}
+                >
+                  <IconLeverage size={16} />
+                </div>
+              )
+          )
           : <IconBorrow size={16} />}
       </div>
       <div>{title}</div>

--- a/frontend/app/src/screens/LoanScreen/LoanScreenCard.tsx
+++ b/frontend/app/src/screens/LoanScreen/LoanScreenCard.tsx
@@ -539,8 +539,8 @@ function LoanCard({
                           </div>
                         ),
                         label: mode === "leverage"
-                          ? "View as loan"
-                          : "View as leverage",
+                          ? "Convert to BOLD loan"
+                          : "Convert to leverage loan",
                       },
                       {
                         icon: (

--- a/frontend/app/src/screens/LoanScreen/PanelClosePosition.tsx
+++ b/frontend/app/src/screens/LoanScreen/PanelClosePosition.tsx
@@ -156,7 +156,7 @@ export function PanelClosePosition({
           }}
         />
         <Field
-          label="You reclaim"
+          label="You reclaim collateral"
           field={
             <div
               className={css({

--- a/frontend/app/src/screens/LoanScreen/PanelUpdateBorrowPosition.tsx
+++ b/frontend/app/src/screens/LoanScreen/PanelUpdateBorrowPosition.tsx
@@ -198,43 +198,45 @@ export function PanelUpdateBorrowPosition({
                   <HFlex alignItems="center" gap={8}>
                     <Amount
                       format={2}
-                      suffix={` ${collToken.symbol}`}
+                      suffix={` ${collToken.name}`}
                       value={newLoanDetails.deposit}
                     />
                     <InfoTooltip heading="Collateral update">
                       <div>
-                        Current:{" "}
+                        Before:{" "}
                         <Amount
                           format={2}
-                          suffix={` ${collToken.symbol}`}
+                          suffix={` ${collToken.name}`}
                           value={loanDetails.deposit}
                         />
                         {collPrice && (
                           <>
-                            {" / "}
+                            {" ("}
                             <Amount
                               format={2}
                               prefix="$"
                               value={dn.mul(loanDetails.deposit, collPrice)}
                             />
+                            {")"}
                           </>
                         )}
                       </div>
                       <div>
-                        Update:{" "}
+                        After:{" "}
                         <Amount
                           format={2}
-                          suffix={` ${collToken.symbol}`}
+                          suffix={` ${collToken.name}`}
                           value={newLoanDetails.deposit}
                         />
                         {collPrice && (
                           <>
-                            {" / "}
+                            {" ("}
                             <Amount
                               format={2}
                               prefix="$"
                               value={dn.mul(newLoanDetails.deposit, collPrice)}
                             />
+                            {")"}
                           </>
                         )}
                       </div>
@@ -324,7 +326,14 @@ export function PanelUpdateBorrowPosition({
                         suffix=" BOLD"
                       />
                     </div>
-                    <InfoTooltip heading="Debt update" />
+                    <InfoTooltip heading="Debt update">
+                      <div>
+                        Before: <Amount value={loanDetails.debt} suffix=" BOLD" />
+                      </div>
+                      <div>
+                        After: <Amount value={newLoanDetails.debt} suffix=" BOLD" />
+                      </div>
+                    </InfoTooltip>
                   </HFlex>
                 }
               />

--- a/frontend/app/src/screens/LoanScreen/PanelUpdateLeveragePosition.tsx
+++ b/frontend/app/src/screens/LoanScreen/PanelUpdateLeveragePosition.tsx
@@ -162,7 +162,9 @@ export function PanelUpdateLeveragePosition({
       ) || (
         initialLoanDetails.leverageFactor !== newLoanDetails.leverageFactor
       )
-    );
+    )
+    // above the minimum debt
+    && newLoanDetails.debt && dn.gt(newLoanDetails.debt, MIN_DEBT);
 
   return (
     <>
@@ -264,7 +266,17 @@ export function PanelUpdateLeveragePosition({
         />
 
         <Field
-          field={<LeverageField {...leverageField} />}
+          field={
+            <LeverageField
+              drawer={newLoanDetails.debt && dn.lt(newLoanDetails.debt, MIN_DEBT)
+                ? {
+                  mode: "error",
+                  message: `You must borrow at least ${fmtnum(MIN_DEBT, 2)} BOLD.`,
+                }
+                : null}
+              {...leverageField}
+            />
+          }
           footer={[
             {
               start: <Field.FooterInfo label="ETH liquidation price" />,

--- a/frontend/app/src/screens/LoanScreen/PanelUpdateLeveragePosition.tsx
+++ b/frontend/app/src/screens/LoanScreen/PanelUpdateLeveragePosition.tsx
@@ -10,7 +10,7 @@ import { UpdateBox } from "@/src/comps/UpdateBox/UpdateBox";
 import { Value } from "@/src/comps/Value/Value";
 import { ValueUpdate } from "@/src/comps/ValueUpdate/ValueUpdate";
 import { WarningBox } from "@/src/comps/WarningBox/WarningBox";
-import { ETH_MAX_RESERVE } from "@/src/constants";
+import { ETH_MAX_RESERVE, MAX_LTV_RESERVE_RATIO, MIN_DEBT } from "@/src/constants";
 import { dnum18 } from "@/src/dnum-utils";
 import { useInputFieldValue } from "@/src/form-utils";
 import { fmtnum, formatRisk } from "@/src/formatting";
@@ -116,7 +116,7 @@ export function PanelUpdateLeveragePosition({
     collPrice: collPrice ?? dnum18(0),
     collToken,
     depositPreLeverage: newDepositPreLeverage,
-    maxLtvAllowedRatio: 1, // allow up to the max. LTV
+    maxLtvAllowedRatio: 1 - MAX_LTV_RESERVE_RATIO,
   });
 
   const collBalance = useBalance(account.address, collToken.symbol);

--- a/frontend/app/src/screens/LoanScreen/PanelUpdateRate.tsx
+++ b/frontend/app/src/screens/LoanScreen/PanelUpdateRate.tsx
@@ -79,7 +79,8 @@ export function PanelUpdateRate({
     && debt.parsed
     && dn.gt(debt.parsed, 0)
     && interestRate
-    && dn.gt(interestRate, 0);
+    && dn.gt(interestRate, 0)
+    && !dn.eq(interestRate, loan.interestRate);
 
   return (
     <>

--- a/frontend/app/src/screens/StakeScreen/PanelRewards.tsx
+++ b/frontend/app/src/screens/StakeScreen/PanelRewards.tsx
@@ -1,0 +1,190 @@
+import type { TokenSymbol } from "@liquity2/uikit";
+import type { Dnum } from "dnum";
+import type { ReactNode } from "react";
+
+import { Amount } from "@/src/comps/Amount/Amount";
+import { ConnectWarningBox } from "@/src/comps/ConnectWarningBox/ConnectWarningBox";
+import { getProtocolContract } from "@/src/contracts";
+import { useDemoMode } from "@/src/demo-mode";
+import { ACCOUNT_STAKED_LQTY } from "@/src/demo-mode";
+import { dnum18 } from "@/src/dnum-utils";
+import { useStakePosition } from "@/src/liquity-utils";
+import { useAccount } from "@/src/services/Ethereum";
+import { usePrice } from "@/src/services/Prices";
+import { useTransactionFlow } from "@/src/services/TransactionFlow";
+import { css } from "@/styled-system/css";
+import { Button, HFlex, TokenIcon, VFlex } from "@liquity2/uikit";
+import * as dn from "dnum";
+import { encodeFunctionData } from "viem";
+import { useEstimateGas, useGasPrice } from "wagmi";
+
+export function PanelRewards() {
+  const account = useAccount();
+  const txFlow = useTransactionFlow();
+  const demoMode = useDemoMode();
+
+  const ethPrice = usePrice("ETH");
+
+  const stakePosition = useStakePosition(account.address ?? null);
+  const LqtyStaking = getProtocolContract("LqtyStaking");
+
+  const gasEstimate = useEstimateGas({
+    account: account.address,
+    data: encodeFunctionData({
+      abi: LqtyStaking.abi,
+      functionName: "unstake",
+      args: [0n],
+    }),
+    to: LqtyStaking.address,
+  });
+
+  const gasPrice = useGasPrice();
+
+  if (!ethPrice) {
+    return null;
+  }
+
+  const txGasPriceEth = gasEstimate.data && gasPrice.data
+    ? dnum18(gasEstimate.data * gasPrice.data)
+    : null;
+
+  const txGasPriceUsd = txGasPriceEth && dn.mul(txGasPriceEth, ethPrice);
+
+  const rewardsLusd = (
+    demoMode.enabled
+      ? ACCOUNT_STAKED_LQTY.rewardLusd
+      : stakePosition.data?.rewards.lusd
+  ) ?? dn.from(0, 18);
+
+  const rewardsEth = (
+    demoMode.enabled
+      ? ACCOUNT_STAKED_LQTY.rewardEth
+      : stakePosition.data?.rewards.eth
+  ) ?? dn.from(0, 18);
+
+  const totalRewardsUsd = dn.add(
+    rewardsLusd,
+    dn.mul(rewardsEth, ethPrice),
+  );
+
+  const allowSubmit = account.isConnected && dn.gt(totalRewardsUsd, 0);
+
+  return (
+    <VFlex gap={48}>
+      <VFlex gap={0}>
+        <Rewards
+          amount={rewardsLusd}
+          label="Issuance gain"
+          symbol="LUSD"
+        />
+        <Rewards
+          amount={rewardsEth}
+          label="Redemption gain"
+          symbol="ETH"
+        />
+
+        <div
+          className={css({
+            display: "flex",
+            flexDirection: "column",
+            gap: 8,
+            padding: "24px 0",
+            color: "contentAlt",
+          })}
+        >
+          <HFlex justifyContent="space-between" gap={24}>
+            <div>Total in USD</div>
+            <Amount
+              format="2z"
+              prefix="$"
+              value={totalRewardsUsd}
+            />
+          </HFlex>
+          <HFlex justifyContent="space-between" gap={24}>
+            <div>Expected Gas Fee</div>
+            <Amount
+              format="2z"
+              prefix="~$"
+              value={txGasPriceUsd ?? 0}
+            />
+          </HFlex>
+        </div>
+      </VFlex>
+
+      <ConnectWarningBox />
+
+      <Button
+        disabled={!allowSubmit}
+        label="Next: Summary"
+        mode="primary"
+        size="large"
+        wide
+        onClick={() => {
+          if (account.address && stakePosition.data) {
+            txFlow.start({
+              flowId: "stakeClaimRewards",
+              backLink: [
+                `/stake`,
+                "Back to stake position",
+              ],
+              successLink: ["/", "Go to the Dashboard"],
+              successMessage: "The rewards have been claimed successfully.",
+
+              stakePosition: {
+                ...stakePosition.data,
+                rewards: {
+                  eth: dn.from(0, 18),
+                  lusd: dn.from(0, 18),
+                },
+              },
+              prevStakePosition: stakePosition.data,
+            });
+          }
+        }}
+      />
+    </VFlex>
+  );
+}
+
+function Rewards({
+  amount,
+  label,
+  symbol,
+}: {
+  amount: Dnum;
+  label: ReactNode;
+  symbol: TokenSymbol;
+}) {
+  return (
+    <div
+      className={css({
+        display: "grid",
+        gap: 24,
+        gridTemplateColumns: "1.2fr 1fr",
+        alignItems: "start",
+        padding: "24px 0",
+        borderBottom: "1px solid token(colors.separator)",
+      })}
+    >
+      <div
+        className={css({
+          paddingTop: 4,
+        })}
+      >
+        {label}
+      </div>
+      <div
+        className={css({
+          display: "flex",
+          justifyContent: "flex-end",
+          alignItems: "center",
+          gap: 8,
+          fontSize: 28,
+        })}
+      >
+        <Amount value={amount} />
+        <TokenIcon symbol={symbol} size={24} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/src/screens/StakeScreen/PanelVoting.tsx
+++ b/frontend/app/src/screens/StakeScreen/PanelVoting.tsx
@@ -328,7 +328,7 @@ export function PanelVoting() {
 
         <Button
           disabled={!allowSubmit}
-          label="Coming soon: cast votes"
+          label="Coming soon"
           mode="primary"
           size="large"
           wide

--- a/frontend/app/src/screens/StakeScreen/StakeScreen.tsx
+++ b/frontend/app/src/screens/StakeScreen/StakeScreen.tsx
@@ -45,7 +45,7 @@ import { PanelVoting } from "./PanelVoting";
 const TABS = [
   { label: content.stakeScreen.tabs.deposit, id: "deposit" },
   { label: content.stakeScreen.tabs.rewards, id: "rewards" },
-  // { label: content.stakeScreen.tabs.voting, id: "voting" },
+  { label: content.stakeScreen.tabs.voting, id: "voting" },
 ];
 
 export function StakeScreen() {

--- a/frontend/app/src/screens/StakeScreen/StakeScreen.tsx
+++ b/frontend/app/src/screens/StakeScreen/StakeScreen.tsx
@@ -1,20 +1,11 @@
 "use client";
 
-import type { TokenSymbol } from "@liquity2/uikit";
-import type { Dnum } from "dnum";
-import type { ReactNode } from "react";
-
 import { Amount } from "@/src/comps/Amount/Amount";
-import { ConnectWarningBox } from "@/src/comps/ConnectWarningBox/ConnectWarningBox";
 import { Field } from "@/src/comps/Field/Field";
 import { InputTokenBadge } from "@/src/comps/InputTokenBadge/InputTokenBadge";
 import { Screen } from "@/src/comps/Screen/Screen";
 import { StakePositionSummary } from "@/src/comps/StakePositionSummary/StakePositionSummary";
 import content from "@/src/content";
-import { getProtocolContract } from "@/src/contracts";
-import { useDemoMode } from "@/src/demo-mode";
-import { ACCOUNT_STAKED_LQTY } from "@/src/demo-mode";
-import { dnum18 } from "@/src/dnum-utils";
 import { dnumMax } from "@/src/dnum-utils";
 import { parseInputFloat } from "@/src/form-utils";
 import { fmtnum } from "@/src/formatting";
@@ -38,8 +29,7 @@ import {
 import * as dn from "dnum";
 import { useParams, useRouter } from "next/navigation";
 import { useState } from "react";
-import { encodeFunctionData } from "viem";
-import { useEstimateGas, useGasPrice } from "wagmi";
+import { PanelRewards } from "./PanelRewards";
 import { PanelVoting } from "./PanelVoting";
 
 const TABS = [
@@ -51,9 +41,7 @@ const TABS = [
 export function StakeScreen() {
   const router = useRouter();
   const { action = "deposit" } = useParams();
-
   const account = useAccount();
-
   const stakePosition = useStakePosition(account.address ?? null);
 
   return (
@@ -94,7 +82,7 @@ export function StakeScreen() {
         />
 
         {action === "deposit" && <PanelUpdateStake />}
-        {action === "rewards" && <PanelClaimRewards />}
+        {action === "rewards" && <PanelRewards />}
         {action === "voting" && <PanelVoting />}
       </VFlex>
     </Screen>
@@ -326,177 +314,5 @@ function PanelUpdateStake() {
         />
       </div>
     </>
-  );
-}
-
-function PanelClaimRewards() {
-  const account = useAccount();
-  const txFlow = useTransactionFlow();
-  const demoMode = useDemoMode();
-
-  const ethPrice = usePrice("ETH");
-
-  const stakePosition = useStakePosition(account.address ?? null);
-  const LqtyStaking = getProtocolContract("LqtyStaking");
-
-  const gasEstimate = useEstimateGas({
-    account: account.address,
-    data: encodeFunctionData({
-      abi: LqtyStaking.abi,
-      functionName: "unstake",
-      args: [0n],
-    }),
-    to: LqtyStaking.address,
-  });
-
-  const gasPrice = useGasPrice();
-
-  if (!ethPrice) {
-    return null;
-  }
-
-  const txGasPriceEth = gasEstimate.data && gasPrice.data
-    ? dnum18(gasEstimate.data * gasPrice.data)
-    : null;
-
-  const txGasPriceUsd = txGasPriceEth && dn.mul(txGasPriceEth, ethPrice);
-
-  const rewardsLusd = (
-    demoMode.enabled
-      ? ACCOUNT_STAKED_LQTY.rewardLusd
-      : stakePosition.data?.rewards.lusd
-  ) ?? dn.from(0, 18);
-
-  const rewardsEth = (
-    demoMode.enabled
-      ? ACCOUNT_STAKED_LQTY.rewardEth
-      : stakePosition.data?.rewards.eth
-  ) ?? dn.from(0, 18);
-
-  const totalRewardsUsd = dn.add(
-    rewardsLusd,
-    dn.mul(rewardsEth, ethPrice),
-  );
-
-  // const allowSubmit = account.isConnected && dn.gt(totalRewardsUsd, 0);
-  const allowSubmit = account.isConnected;
-
-  return (
-    <VFlex gap={48}>
-      <VFlex gap={0}>
-        <Rewards
-          amount={rewardsLusd}
-          label="Issuance gain"
-          symbol="LUSD"
-        />
-        <Rewards
-          amount={rewardsEth}
-          label="Redemption gain"
-          symbol="ETH"
-        />
-
-        <div
-          className={css({
-            display: "flex",
-            flexDirection: "column",
-            gap: 8,
-            padding: "24px 0",
-            color: "contentAlt",
-          })}
-        >
-          <HFlex justifyContent="space-between" gap={24}>
-            <div>Total in USD</div>
-            <Amount
-              format="2z"
-              prefix="$"
-              value={totalRewardsUsd}
-            />
-          </HFlex>
-          <HFlex justifyContent="space-between" gap={24}>
-            <div>Expected Gas Fee</div>
-            <Amount
-              format="2z"
-              prefix="~$"
-              value={txGasPriceUsd ?? 0}
-            />
-          </HFlex>
-        </div>
-      </VFlex>
-
-      <ConnectWarningBox />
-
-      <Button
-        disabled={!allowSubmit}
-        label="Next: Summary"
-        mode="primary"
-        size="large"
-        wide
-        onClick={() => {
-          if (account.address && stakePosition.data) {
-            txFlow.start({
-              flowId: "stakeClaimRewards",
-              backLink: [
-                `/stake`,
-                "Back to stake position",
-              ],
-              successLink: ["/", "Go to the Dashboard"],
-              successMessage: "The rewards have been claimed successfully.",
-
-              stakePosition: {
-                ...stakePosition.data,
-                rewards: {
-                  eth: dn.from(0, 18),
-                  lusd: dn.from(0, 18),
-                },
-              },
-              prevStakePosition: stakePosition.data,
-            });
-          }
-        }}
-      />
-    </VFlex>
-  );
-}
-
-function Rewards({
-  amount,
-  label,
-  symbol,
-}: {
-  amount: Dnum;
-  label: ReactNode;
-  symbol: TokenSymbol;
-}) {
-  return (
-    <div
-      className={css({
-        display: "grid",
-        gap: 24,
-        gridTemplateColumns: "1.2fr 1fr",
-        alignItems: "start",
-        padding: "24px 0",
-        borderBottom: "1px solid token(colors.separator)",
-      })}
-    >
-      <div
-        className={css({
-          paddingTop: 4,
-        })}
-      >
-        {label}
-      </div>
-      <div
-        className={css({
-          display: "flex",
-          justifyContent: "flex-end",
-          alignItems: "center",
-          gap: 8,
-          fontSize: 28,
-        })}
-      >
-        <Amount value={amount} />
-        <TokenIcon symbol={symbol} size={24} />
-      </div>
-    </div>
   );
 }

--- a/frontend/app/src/screens/TransactionsScreen/LoanCard.tsx
+++ b/frontend/app/src/screens/TransactionsScreen/LoanCard.tsx
@@ -644,7 +644,16 @@ function LoadingCard({
               })}
             >
               {leverage
-                ? <IconLeverage size={16} />
+                ? (
+                  <div
+                    className={css({
+                      display: "flex",
+                      color: "brandGreen",
+                    })}
+                  >
+                    <IconLeverage size={16} />
+                  </div>
+                )
                 : <IconBorrow size={16} />}
             </div>
             {title}

--- a/frontend/app/src/services/Ethereum.tsx
+++ b/frontend/app/src/services/Ethereum.tsx
@@ -34,6 +34,13 @@ import {
   useAccountModal,
   useConnectModal,
 } from "@rainbow-me/rainbowkit";
+import {
+  coinbaseWallet,
+  injectedWallet,
+  metaMaskWallet,
+  safeWallet,
+  walletConnectWallet,
+} from "@rainbow-me/rainbowkit/wallets";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { match } from "ts-pattern";
@@ -157,6 +164,16 @@ export function useWagmiConfig() {
       appName: "Liquity V2",
       projectId: WALLET_CONNECT_PROJECT_ID,
       chains: [chain],
+      wallets: [{
+        groupName: "Suggested",
+        wallets: [
+          injectedWallet,
+          metaMaskWallet,
+          coinbaseWallet,
+          safeWallet,
+          walletConnectWallet,
+        ],
+      }],
       transports: {
         [chain.id]: http(CHAIN_RPC_URL),
       },

--- a/frontend/app/src/tx-flows/closeLoanPosition.tsx
+++ b/frontend/app/src/tx-flows/closeLoanPosition.tsx
@@ -103,7 +103,7 @@ export const closeLoanPosition: FlowDeclaration<Request, Step> = {
           ]}
         />
         <TransactionDetailsRow
-          label="You reclaim"
+          label="You reclaim collateral"
           value={[
             <Amount
               key="start"
@@ -113,7 +113,7 @@ export const closeLoanPosition: FlowDeclaration<Request, Step> = {
           ]}
         />
         <TransactionDetailsRow
-          label="Gas compensation refund"
+          label="You reclaim the gas compensation deposit"
           value={[
             <div
               key="start"

--- a/frontend/app/src/tx-flows/openBorrowPosition.tsx
+++ b/frontend/app/src/tx-flows/openBorrowPosition.tsx
@@ -134,7 +134,7 @@ export const openBorrowPosition: FlowDeclaration<Request, Step> = {
               fallback="…"
               prefix="Incl. "
               value={upfrontFee.data}
-              suffix=" BOLD upfront fee"
+              suffix=" BOLD interest rate adjustment fee"
             />,
           ]}
         />

--- a/frontend/app/src/tx-flows/openLeveragePosition.tsx
+++ b/frontend/app/src/tx-flows/openLeveragePosition.tsx
@@ -109,7 +109,7 @@ export const openLeveragePosition: FlowDeclaration<Request, Step> = {
               fallback="…"
               prefix="Incl. "
               value={upfrontFee.data}
-              suffix=" BOLD upfront fee"
+              suffix=" BOLD interest rate adjustment fee"
             />,
           ]}
         />

--- a/frontend/app/src/tx-flows/updateBorrowPosition.tsx
+++ b/frontend/app/src/tx-flows/updateBorrowPosition.tsx
@@ -200,7 +200,7 @@ export const updateBorrowPosition: FlowDeclaration<Request, Step> = {
                 fallback="…"
                 prefix="Incl. "
                 value={upfrontFeeData.data.upfrontFee}
-                suffix=" BOLD upfront fee"
+                suffix=" BOLD interest rate adjustment fee"
               />
             ),
           ]}

--- a/frontend/app/src/tx-flows/updateLeveragePosition.tsx
+++ b/frontend/app/src/tx-flows/updateLeveragePosition.tsx
@@ -178,7 +178,7 @@ export const updateLeveragePosition: FlowDeclaration<Request, Step> = {
                 fallback="…"
                 prefix="Incl. "
                 value={upfrontFeeData.data.upfrontFee}
-                suffix=" BOLD upfront fee"
+                suffix=" BOLD interest rate adjustment fee"
               />
             ),
           ]}

--- a/frontend/app/src/tx-flows/updateLoanInterestRate.tsx
+++ b/frontend/app/src/tx-flows/updateLoanInterestRate.tsx
@@ -1,6 +1,7 @@
 import type { LoadingState } from "@/src/screens/TransactionsScreen/TransactionsScreen";
 import type { FlowDeclaration } from "@/src/services/TransactionFlow";
 
+import { Amount } from "@/src/comps/Amount/Amount";
 import { MAX_ANNUAL_INTEREST_RATE, MIN_ANNUAL_INTEREST_RATE } from "@/src/constants";
 import { dnum18 } from "@/src/dnum-utils";
 import { fmtnum } from "@/src/formatting";
@@ -90,6 +91,13 @@ export const updateLoanInterestRate: FlowDeclaration<Request, Step> = {
     const { request } = flow;
     const { loan, prevLoan } = request;
 
+    const upfrontFee = usePredictAdjustInterestRateUpfrontFee(
+      loan.collIndex,
+      loan.troveId,
+      loan.batchManager ?? loan.interestRate,
+      prevLoan.batchManager !== null,
+    );
+
     const yearlyBoldInterest = dn.mul(loan.borrowed, loan.interestRate);
 
     return loan.batchManager
@@ -146,6 +154,17 @@ export const updateLoanInterestRate: FlowDeclaration<Request, Step> = {
               ]}
             />
           )}
+          <TransactionDetailsRow
+            label="Interest rate adjustment fee"
+            value={[
+              <Amount
+                key="start"
+                fallback="…"
+                value={upfrontFee.data}
+                suffix=" BOLD"
+              />,
+            ]}
+          />
         </>
       );
   },

--- a/frontend/app/src/tx-flows/updateLoanInterestRate.tsx
+++ b/frontend/app/src/tx-flows/updateLoanInterestRate.tsx
@@ -107,7 +107,7 @@ export const updateLoanInterestRate: FlowDeclaration<Request, Step> = {
       : (
         <>
           <TransactionDetailsRow
-            label="Set interest rate"
+            label="New interest rate"
             value={[
               <div key="start">
                 {fmtnum(loan.interestRate, "full", 100)}%


### PR DESCRIPTION
- [x] Update leverage switch: "Convert to BOLD loan" / "Convert to leverage loan"
- [x] When closing a loan (both on the close panel + tx screen): You reclaim => You reclaim collateral
- [x] Transaction screen when updating a loan: Gas compensation refund => You reclaim the gas compensation deposit
- [x] Transaction screen when opening a loan: use the “interest rate adjustment fee” rather than “upfront fee” (open borrow, update borrow, open leverage, update leverage)
- [x] Earn rewards panel changes:
  - [x] Show the tab content even if the prices haven’t loaded yet
  - [x] Prevent claiming rewards if the amount is 0
- [x] Earn: prevent claiming rewards if the amount is 0 (shouldn’t happen in practice)
- [x] On the borrow update screen, use the collateral names (e.g. wstETH) rather than symbols (e.g. WSTETH).
- [x] RainbowKit: manually defined connectors list + add the Safe connector
- [x] When updating a leveraged loan, limit the max leverage to 5x for LSTs (and 7.9x for ETH)
- [x] Staking: enable the voting tab with a "coming soon" button
- [x] The leverage icon color is now present on the loan screen, and the transaction flow screen. Earn and stake are not impacted by this change since their summary cards don’t show the icon of their position type. The Borrow screen also stays identical on the loan & transaction screens, because its icon is already white.
- [x] Fix home screen layout
- [x] Interest rate update tab: disable the submit button if the rate hasn’t changed
- [x] Loan screen (leverage update panel): add error if borrowing amount is below 2K BOLD
- [x] Leverage screen: add error if borrowing amount is below 2K BOLD
- [x] Update positions order in the dashboard (non-leverage loans first)
- [x] Transaction screen when updating the interest rate (or set a delegate): add adjustment fee
