### PR TITLE
UI kit: explicitly add "use client" to non-RSC components

### DIFF
--- a/frontend/uikit/src/AddressField/AddressField.tsx
+++ b/frontend/uikit/src/AddressField/AddressField.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { ComponentPropsWithoutRef } from "react";
 import type { Address } from "../types";
 

--- a/frontend/uikit/src/Button/AnchorButton.tsx
+++ b/frontend/uikit/src/Button/AnchorButton.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { ComponentPropsWithRef } from "react";
 import type { ButtonProps } from "./Button";
 

--- a/frontend/uikit/src/Button/Button.tsx
+++ b/frontend/uikit/src/Button/Button.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { ComponentPropsWithoutRef, ReactNode } from "react";
 
 import { match, P } from "ts-pattern";

--- a/frontend/uikit/src/Checkbox/Checkbox.tsx
+++ b/frontend/uikit/src/Checkbox/Checkbox.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { ComponentPropsWithoutRef } from "react";
 
 import { Radio } from "../Radio/Radio";

--- a/frontend/uikit/src/Dropdown/Dropdown.tsx
+++ b/frontend/uikit/src/Dropdown/Dropdown.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { ReactElement, ReactNode } from "react";
 import type { CSSProperties } from "react";
 

--- a/frontend/uikit/src/Flex/HFlex.tsx
+++ b/frontend/uikit/src/Flex/HFlex.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { CSSProperties, HTMLAttributes, ReactNode } from "react";
 
 import { css, cx } from "../../styled-system/css";

--- a/frontend/uikit/src/Flex/VFlex.tsx
+++ b/frontend/uikit/src/Flex/VFlex.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { CSSProperties, HTMLAttributes, ReactNode } from "react";
 
 import { css, cx } from "../../styled-system/css";

--- a/frontend/uikit/src/FormField/FormField.tsx
+++ b/frontend/uikit/src/FormField/FormField.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { ReactNode } from "react";
 
 import { css } from "../../styled-system/css";

--- a/frontend/uikit/src/Input/TextInput.tsx
+++ b/frontend/uikit/src/Input/TextInput.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { ComponentPropsWithoutRef } from "react";
 
 import { css, cx } from "../../styled-system/css";

--- a/frontend/uikit/src/InputField/InputField.tsx
+++ b/frontend/uikit/src/InputField/InputField.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { ReactNode } from "react";
 
 import { a, useSpring, useTransition } from "@react-spring/web";

--- a/frontend/uikit/src/LoadingSurface/LoadingSurface.tsx
+++ b/frontend/uikit/src/LoadingSurface/LoadingSurface.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { CSSProperties } from "react";
 
 import { a, useSpring } from "@react-spring/web";

--- a/frontend/uikit/src/Modal/Modal.tsx
+++ b/frontend/uikit/src/Modal/Modal.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { ReactNode } from "react";
 
 import { a, useTransition } from "@react-spring/web";

--- a/frontend/uikit/src/PillButton/PillButton.tsx
+++ b/frontend/uikit/src/PillButton/PillButton.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { ComponentPropsWithoutRef } from "react";
 
 import { match } from "ts-pattern";

--- a/frontend/uikit/src/Radio/Radio.tsx
+++ b/frontend/uikit/src/Radio/Radio.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { CSSProperties } from "react";
 
 import { a, useTransition } from "@react-spring/web";

--- a/frontend/uikit/src/Radio/RadioGroup.tsx
+++ b/frontend/uikit/src/Radio/RadioGroup.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { KeyboardEvent, ReactNode } from "react";
 
 import { createContext, useCallback, useContext, useEffect, useState } from "react";

--- a/frontend/uikit/src/Root/Root.tsx
+++ b/frontend/uikit/src/Root/Root.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { ReactNode } from "react";
 
 import { createContext, useContext, useState } from "react";

--- a/frontend/uikit/src/Slider/Slider.tsx
+++ b/frontend/uikit/src/Slider/Slider.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { SpringValue } from "@react-spring/web";
 import type { CSSProperties } from "react";
 import type { MouseEvent as ReactMouseEvent, TouchEvent as ReactTouchEvent } from "react";

--- a/frontend/uikit/src/StatusDot/StatusDot.tsx
+++ b/frontend/uikit/src/StatusDot/StatusDot.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { StatusMode } from "../types";
 
 import { css } from "../../styled-system/css";

--- a/frontend/uikit/src/Tabs/Tabs.tsx
+++ b/frontend/uikit/src/Tabs/Tabs.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { MouseEvent, MutableRefObject, ReactNode, TouchEvent } from "react";
 
 import { a, useSpring } from "@react-spring/web";

--- a/frontend/uikit/src/TextButton/AnchorTextButton.tsx
+++ b/frontend/uikit/src/TextButton/AnchorTextButton.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { ComponentPropsWithRef } from "react";
 import type { TextButtonProps } from "./TextButton";
 

--- a/frontend/uikit/src/TextButton/TextButton.tsx
+++ b/frontend/uikit/src/TextButton/TextButton.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { ComponentPropsWithoutRef, ReactNode } from "react";
 
 import { forwardRef } from "react";

--- a/frontend/uikit/src/Theme/Theme.tsx
+++ b/frontend/uikit/src/Theme/Theme.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { ReactNode } from "react";
 
 import { createContext, useContext, useState } from "react";

--- a/frontend/uikit/src/TokenIcon/TokenIcon.tsx
+++ b/frontend/uikit/src/TokenIcon/TokenIcon.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { ComponentProps, ReactElement } from "react";
 import type { Token } from "../types";
 

--- a/frontend/uikit/src/Tooltip/InfoTooltip.tsx
+++ b/frontend/uikit/src/Tooltip/InfoTooltip.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { ReactNode } from "react";
 
 import { css } from "../../styled-system/css";

--- a/frontend/uikit/src/Tooltip/Tooltip.tsx
+++ b/frontend/uikit/src/Tooltip/Tooltip.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { ReactNode } from "react";
 
 import { autoUpdate, offset, shift, useFloating } from "@floating-ui/react-dom";

--- a/frontend/uikit/src/UiKit/UiKit.tsx
+++ b/frontend/uikit/src/UiKit/UiKit.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { ReactNode } from "react";
 
 import { RootEntryPoint } from "../Root/Root";

--- a/frontend/uikit/src/react-utils.ts
+++ b/frontend/uikit/src/react-utils.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import type { RefObject } from "react";
 
 import { useEffect, useState } from "react";


### PR DESCRIPTION
This is to be explicit about non-RSC components to increase granularity, even though "use client" is declared in `index.ts` for the entire library. An RSC-compatible import path will be added later.