### PR TITLE
Fix + improve the loan closing flow for redeemed loans

### DIFF
--- a/frontend/app/src/content.tsx
+++ b/frontend/app/src/content.tsx
@@ -165,6 +165,11 @@ export default {
   },
 
   closeLoan: {
+    claimOnly: (
+      <>
+        You are reclaiming your collateral and closing the position. The deposit will be returned to your wallet.
+      </>
+    ),
     repayWithBoldMessage: (
       <>
         You are repaying your debt and closing the position. The deposit will be returned to your wallet.
@@ -176,6 +181,8 @@ export default {
         will be returned to your wallet.
       </>
     ),
+    buttonRepayAndClose: "Repay & close",
+    buttonReclaimAndClose: "Reclaim & close",
   },
 
   // Home screen

--- a/frontend/app/src/screens/LoanScreen/PanelClosePosition.tsx
+++ b/frontend/app/src/screens/LoanScreen/PanelClosePosition.tsx
@@ -83,78 +83,83 @@ export function PanelClosePosition({
     return null;
   }
 
+  // happens in case the loan got redeemed
+  const claimOnly = dn.eq(amountToRepay, 0);
+
   const allowSubmit = error === null;
 
   return (
     <>
       <VFlex gap={48}>
-        <Field
-          label="You repay with"
-          field={
-            <div
-              className={css({
-                display: "flex",
-                alignItems: "center",
-                gap: 16,
-                justifyContent: "space-between",
-              })}
-            >
+        {!claimOnly && (
+          <Field
+            label="You repay with"
+            field={
               <div
                 className={css({
                   display: "flex",
+                  alignItems: "center",
                   gap: 16,
-                  fontSize: 28,
-                  lineHeight: 1,
+                  justifyContent: "space-between",
                 })}
               >
-                {fmtnum(amountToRepay)}
-              </div>
-              <Dropdown
-                buttonDisplay={() => ({
-                  icon: <TokenIcon symbol={repayToken.symbol} />,
-                  label: (
-                    <>
-                      {repayToken.name}
-                      <span
+                <div
+                  className={css({
+                    display: "flex",
+                    gap: 16,
+                    fontSize: 28,
+                    lineHeight: 1,
+                  })}
+                >
+                  {fmtnum(amountToRepay)}
+                </div>
+                <Dropdown
+                  buttonDisplay={() => ({
+                    icon: <TokenIcon symbol={repayToken.symbol} />,
+                    label: (
+                      <>
+                        {repayToken.name}
+                        <span
+                          className={css({
+                            color: "contentAlt",
+                            fontWeight: 400,
+                          })}
+                        >
+                          {repayToken.symbol === "BOLD" ? " account" : " loan"}
+                        </span>
+                      </>
+                    ),
+                  })}
+                  items={(["BOLD", collToken.symbol] as const).map((symbol) => ({
+                    icon: <TokenIcon symbol={symbol} />,
+                    label: (
+                      <div
                         className={css({
-                          color: "contentAlt",
-                          fontWeight: 400,
+                          whiteSpace: "nowrap",
                         })}
                       >
-                        {repayToken.symbol === "BOLD" ? " account" : " loan"}
-                      </span>
-                    </>
-                  ),
-                })}
-                items={(["BOLD", collToken.symbol] as const).map((symbol) => ({
-                  icon: <TokenIcon symbol={symbol} />,
-                  label: (
-                    <div
-                      className={css({
-                        whiteSpace: "nowrap",
-                      })}
-                    >
-                      {TOKENS_BY_SYMBOL[symbol].name} {symbol === "BOLD" ? "(account)" : "(loan collateral)"}
-                    </div>
-                  ),
-                  value: symbol === "BOLD" ? fmtnum(boldBalance.data) : null,
-                }))}
-                menuWidth={300}
-                menuPlacement="end"
-                onSelect={setRepayDropdownIndex}
-                selected={repayDropdownIndex}
-              />
-            </div>
-          }
-          footer={{
-            start: (
-              <Field.FooterInfo
-                label={`$${fmtnum(amountToRepayUsd)}`}
-                value={null}
-              />
-            ),
-          }}
-        />
+                        {TOKENS_BY_SYMBOL[symbol].name} {symbol === "BOLD" ? "(account)" : "(loan collateral)"}
+                      </div>
+                    ),
+                    value: symbol === "BOLD" ? fmtnum(boldBalance.data) : null,
+                  }))}
+                  menuWidth={300}
+                  menuPlacement="end"
+                  onSelect={setRepayDropdownIndex}
+                  selected={repayDropdownIndex}
+                />
+              </div>
+            }
+            footer={{
+              start: (
+                <Field.FooterInfo
+                  label={`$${fmtnum(amountToRepayUsd)}`}
+                  value={null}
+                />
+              ),
+            }}
+          />
+        )}
         <Field
           label="You reclaim collateral"
           field={
@@ -220,7 +225,9 @@ export function PanelClosePosition({
           borderRadius: 8,
         })}
       >
-        {repayToken.symbol === "BOLD"
+        {claimOnly
+          ? content.closeLoan.claimOnly
+          : repayToken.symbol === "BOLD"
           ? content.closeLoan.repayWithBoldMessage
           : content.closeLoan.repayWithCollateralMessage}
       </div>
@@ -245,7 +252,9 @@ export function PanelClosePosition({
 
         <Button
           disabled={!allowSubmit}
-          label="Repay & close"
+          label={claimOnly
+            ? content.closeLoan.buttonReclaimAndClose
+            : content.closeLoan.buttonRepayAndClose}
           mode="primary"
           size="large"
           wide
@@ -261,7 +270,7 @@ export function PanelClosePosition({
                 successMessage: "The loan position has been closed successfully.",
 
                 loan: { ...loan },
-                repayWithCollateral: repayToken.symbol !== "BOLD",
+                repayWithCollateral: claimOnly ? false : repayToken.symbol !== "BOLD",
               });
             }
           }}

--- a/frontend/app/src/tx-flows/closeLoanPosition.tsx
+++ b/frontend/app/src/tx-flows/closeLoanPosition.tsx
@@ -92,16 +92,18 @@ export const closeLoanPosition: FlowDeclaration<Request, Step> = {
 
     return (
       <>
-        <TransactionDetailsRow
-          label={repayWithCollateral ? "You repay (from collateral)" : "You repay"}
-          value={[
-            <Amount
-              key="start"
-              value={amountToRepay}
-              suffix={` ${repayWithCollateral ? collateral.symbol : "BOLD"}`}
-            />,
-          ]}
-        />
+        {dn.gt(amountToRepay, 0) && (
+          <TransactionDetailsRow
+            label={repayWithCollateral ? "You repay (from collateral)" : "You repay"}
+            value={[
+              <Amount
+                key="start"
+                value={amountToRepay}
+                suffix={` ${repayWithCollateral ? collateral.symbol : "BOLD"}`}
+              />,
+            ]}
+          />
+        )}
         <TransactionDetailsRow
           label="You reclaim collateral"
           value={[
@@ -213,8 +215,8 @@ export const closeLoanPosition: FlowDeclaration<Request, Step> = {
     if (stepId === "closeLoanPositionFromCollateral") {
       const closeFlashLoanAmount = await getCloseFlashLoanAmount(loan.collIndex, loan.troveId, wagmiConfig);
 
-      if (!closeFlashLoanAmount) {
-        throw new Error("Could not calculate closeFlashLoanAmount");
+      if (closeFlashLoanAmount === null) {
+        throw new Error("The flash loan amount could not be calculated.");
       }
 
       const closeParams = {


### PR DESCRIPTION
- The closing panel doesn’t show “you repay with” anymore in this situation.
- The content of the info message and the submit button are now based on being in `claimOnly` mode or not.
- Moved the submit button label into `content.tsx`.
- On the tx flow, “you repay” doesn’t appear if `0`.
- `writeContractParams()` only fails if `closeLoanPosition` === null (was `!closeLoanPosition` before, which was including `0n`).