### PR TITLE
Leverage: improve slippage calculation

### DIFF
--- a/frontend/app/src/liquity-leverage.ts
+++ b/frontend/app/src/liquity-leverage.ts
@@ -1,8 +1,14 @@
-import type { CollIndex, TroveId } from "@/src/types";
+import type { CollIndex, Dnum, TroveId } from "@/src/types";
 import type { Config as WagmiConfig } from "wagmi";
 
-import { CLOSE_FROM_COLLATERAL_SLIPPAGE } from "@/src/constants";
+import { CLOSE_FROM_COLLATERAL_SLIPPAGE, DATA_REFRESH_INTERVAL } from "@/src/constants";
+import { getProtocolContract } from "@/src/contracts";
 import { getCollateralContracts } from "@/src/contracts";
+import { dnum18 } from "@/src/dnum-utils";
+import { useDebouncedQueryKey } from "@/src/react-utils";
+import { useWagmiConfig } from "@/src/services/Ethereum";
+import { useQuery } from "@tanstack/react-query";
+import * as dn from "dnum";
 import { readContract, readContracts } from "wagmi/actions";
 
 const DECIMAL_PRECISION = 10n ** 18n;
@@ -207,4 +213,63 @@ export async function getCloseFlashLoanAmount(
 
 function leverageRatioToCollateralRatio(inputRatio: bigint) {
   return inputRatio * DECIMAL_PRECISION / (inputRatio - DECIMAL_PRECISION);
+}
+
+export function useCheckLeverageSlippage({
+  collIndex,
+  initialDeposit,
+  leverageFactor,
+  ownerIndex,
+}: {
+  collIndex: CollIndex;
+  initialDeposit: Dnum | null;
+  leverageFactor: number;
+  ownerIndex: number | null;
+}) {
+  const wagmiConfig = useWagmiConfig();
+  const WethContract = getProtocolContract("WETH");
+  const ExchangeHelpersContract = getProtocolContract("ExchangeHelpers");
+
+  const debouncedQueryKey = useDebouncedQueryKey([
+    "openLeveragedTroveParams",
+    collIndex,
+    String(!initialDeposit || initialDeposit[0]),
+    leverageFactor,
+    ownerIndex,
+  ], 100);
+
+  return useQuery({
+    queryKey: debouncedQueryKey,
+    queryFn: async () => {
+      const params = initialDeposit && await getOpenLeveragedTroveParams(
+        collIndex,
+        initialDeposit[0],
+        leverageFactor,
+        wagmiConfig,
+      );
+
+      if (params === null) {
+        return null;
+      }
+
+      const [_, slippage] = await readContract(wagmiConfig, {
+        abi: ExchangeHelpersContract.abi,
+        address: ExchangeHelpersContract.address,
+        functionName: "getCollFromBold",
+        args: [
+          params.expectedBoldAmount,
+          WethContract.address,
+          params.flashLoanAmount,
+        ],
+      });
+
+      return dnum18(slippage);
+    },
+    enabled: Boolean(
+      initialDeposit
+        && dn.gt(initialDeposit, 0)
+        && ownerIndex !== null,
+    ),
+    refetchInterval: DATA_REFRESH_INTERVAL,
+  });
 }

--- a/frontend/app/src/screens/LeverageScreen/LeverageScreen.tsx
+++ b/frontend/app/src/screens/LeverageScreen/LeverageScreen.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { DelegateMode } from "@/src/comps/InterestRateField/InterestRateField";
-import type { Address, Dnum, PositionLoanUncommitted } from "@/src/types";
+import type { Address, PositionLoanUncommitted } from "@/src/types";
 import type { ComponentPropsWithoutRef, ReactNode } from "react";
 
 import { Amount } from "@/src/comps/Amount/Amount";
@@ -12,7 +12,6 @@ import { LeverageField, useLeverageField } from "@/src/comps/LeverageField/Lever
 import { RedemptionInfo } from "@/src/comps/RedemptionInfo/RedemptionInfo";
 import { Screen } from "@/src/comps/Screen/Screen";
 import {
-  DATA_REFRESH_INTERVAL,
   ETH_MAX_RESERVE,
   INTEREST_RATE_DEFAULT,
   LEVERAGE_MAX_SLIPPAGE,
@@ -20,15 +19,14 @@ import {
   MIN_DEBT,
 } from "@/src/constants";
 import content from "@/src/content";
-import { getContracts, getProtocolContract } from "@/src/contracts";
+import { getContracts } from "@/src/contracts";
 import { dnum18, dnumMax } from "@/src/dnum-utils";
 import { useInputFieldValue } from "@/src/form-utils";
 import { fmtnum } from "@/src/formatting";
-import { getOpenLeveragedTroveParams } from "@/src/liquity-leverage";
+import { useCheckLeverageSlippage } from "@/src/liquity-leverage";
 import { getRedemptionRisk } from "@/src/liquity-math";
 import { getCollIndexFromSymbol } from "@/src/liquity-utils";
-import { useDebouncedQueryKey } from "@/src/react-utils";
-import { useAccount, useBalance, useWagmiConfig } from "@/src/services/Ethereum";
+import { useAccount, useBalance } from "@/src/services/Ethereum";
 import { usePrice } from "@/src/services/Prices";
 import { useTransactionFlow } from "@/src/services/TransactionFlow";
 import { useTrovesCount } from "@/src/subgraph-hooks";
@@ -48,11 +46,9 @@ import {
   TokenIcon,
   VFlex,
 } from "@liquity2/uikit";
-import { useQuery } from "@tanstack/react-query";
 import * as dn from "dnum";
 import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
-import { useReadContract } from "wagmi";
 
 export function LeverageScreen() {
   const router = useRouter();
@@ -145,13 +141,16 @@ export function LeverageScreen() {
   const hasDeposit = Boolean(depositPreLeverage.parsed && dn.gt(depositPreLeverage.parsed, 0));
 
   const leverageSlippage = useCheckLeverageSlippage({
+    collIndex,
     initialDeposit: depositPreLeverage.parsed,
     leverageFactor: leverageField.leverageFactor,
     ownerIndex: troveCount.data ?? null,
-    loan: newLoan,
   });
 
-  const leverageSlippageElements = useSlippageElements(leverageSlippage, hasDeposit && account.isConnected);
+  const leverageSlippageElements = useSlippageElements(
+    leverageSlippage,
+    hasDeposit && account.isConnected,
+  );
 
   const hasAllowedSlippage = leverageSlippage.data
     && dn.lte(leverageSlippage.data, LEVERAGE_MAX_SLIPPAGE);
@@ -404,63 +403,6 @@ export function LeverageScreen() {
   );
 }
 
-export function useCheckLeverageSlippage({
-  initialDeposit,
-  leverageFactor,
-  loan,
-  ownerIndex,
-}: {
-  initialDeposit: Dnum | null;
-  leverageFactor: number;
-  loan: PositionLoanUncommitted;
-  ownerIndex: number | null;
-}) {
-  const { collIndex } = loan;
-  const wagmiConfig = useWagmiConfig();
-  const WethContract = getProtocolContract("WETH");
-  const ExchangeHelpersContract = getProtocolContract("ExchangeHelpers");
-
-  const debouncedQueryKey = useDebouncedQueryKey([
-    "openLeveragedTroveParams",
-    collIndex,
-    String(!initialDeposit || initialDeposit[0]),
-    leverageFactor,
-    ownerIndex,
-  ], 100);
-
-  const openLeveragedTroveParams = useQuery({
-    queryKey: debouncedQueryKey,
-    queryFn: () => (
-      initialDeposit && getOpenLeveragedTroveParams(
-        collIndex,
-        initialDeposit[0],
-        leverageFactor,
-        wagmiConfig,
-      )
-    ),
-    enabled: Boolean(
-      initialDeposit
-        && dn.gt(initialDeposit, 0)
-        && ownerIndex !== null,
-    ),
-    refetchInterval: DATA_REFRESH_INTERVAL,
-  });
-
-  const boldAmount = openLeveragedTroveParams.data?.expectedBoldAmount ?? 0n;
-  const flashLoanAmount = openLeveragedTroveParams.data?.flashLoanAmount ?? 0n;
-
-  return useReadContract({
-    abi: ExchangeHelpersContract.abi,
-    address: ExchangeHelpersContract.address,
-    functionName: "getCollFromBold",
-    args: [boldAmount, WethContract.address, flashLoanAmount],
-    query: {
-      enabled: Boolean(openLeveragedTroveParams.data),
-      select: (result) => dnum18(result[1]),
-    },
-  });
-}
-
 function useSlippageElements(
   leverageSlippage: ReturnType<typeof useCheckLeverageSlippage>,
   ready: boolean,
@@ -523,7 +465,6 @@ function useSlippageElements(
     const message = "Calculating slippage…";
     return {
       drawer: null,
-      // drawer: { mode: "loading", message },
       message,
       mode: "loading",
       onClose,
@@ -550,11 +491,6 @@ function useSlippageElements(
 
   return {
     drawer: null,
-    // drawer: {
-    //   mode: "success",
-    //   message: `Slippage below threshold (${fmtnum(LEVERAGE_MAX_SLIPPAGE, 2, 100)}%)`,
-    //   autoClose: 700,
-    // },
     onClose,
     mode: "success",
   };


### PR DESCRIPTION
- Use a single `useQuery()` for the two requests
- `useCheckLeverageSlippage()` now takes `collIndex` a parameter rather than a loan object
- Move `useCheckLeverageSlippage()` to `liquity-leverage.ts
`