### PR TITLE
deployment-manifest-to-app-env: remove interestRouter from the contracts

### DIFF
--- a/contracts/utils/deployment-manifest-to-app-env.ts
+++ b/contracts/utils/deployment-manifest-to-app-env.ts
@@ -46,7 +46,6 @@ const ZDeploymentManifest = z.object({
       collToken: ZAddress,
       defaultPool: ZAddress,
       gasPool: ZAddress,
-      interestRouter: ZAddress,
       leverageZapper: ZAddress,
       metadataNFT: ZAddress,
       priceFeed: ZAddress,


### PR DESCRIPTION
This has been removed from recent versions of the manifest and is not needed by the app.