### PR TITLE
Safe account detection

### DIFF
--- a/frontend/app/src/demo-mode/index.tsx
+++ b/frontend/app/src/demo-mode/index.tsx
@@ -66,6 +66,7 @@ type DemoModeContext = DemoModeState & {
   account: DemoModeState["account"] & {
     connect: () => void;
     disconnect: () => void;
+    safeStatus: null;
   };
   clearDemoMode: () => void;
   enabled: boolean;
@@ -95,6 +96,7 @@ const DemoContext = createContext<DemoModeContext>({
     ...demoModeStateDefault.account,
     connect: noop,
     disconnect: noop,
+    safeStatus: null,
   },
   clearDemoMode: noop,
   enabled: DEMO_MODE,
@@ -203,6 +205,7 @@ export function DemoMode({
           ...state.account,
           connect,
           disconnect,
+          safeStatus: null,
         },
         clearDemoMode,
         enabled: DEMO_MODE,

--- a/frontend/app/src/safe-utils.ts
+++ b/frontend/app/src/safe-utils.ts
@@ -1,0 +1,77 @@
+import type { Address } from "@/src/types";
+
+import { SAFE_API_URL } from "@/src/env";
+import { sleep } from "@/src/utils";
+import { vAddress } from "@/src/valibot-utils";
+import * as v from "valibot";
+
+async function safeApiCall(path: string) {
+  if (!SAFE_API_URL) {
+    throw new Error("SAFE_API_URL is not set");
+  }
+  return fetch(`${SAFE_API_URL}/v1${path}`, {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+  });
+}
+
+export const SafeTransactionSchema = v.object({
+  confirmations: v.array(v.object({ owner: vAddress() })),
+  confirmationsRequired: v.number(),
+  isExecuted: v.union([v.null(), v.boolean()]),
+  isSuccessful: v.union([v.null(), v.boolean()]),
+  transactionHash: v.union([v.null(), v.string()]),
+});
+
+export async function getSafeTransaction(safeTxHash: string): Promise<
+  v.InferOutput<typeof SafeTransactionSchema>
+> {
+  const response = await safeApiCall(`/multisig-transactions/${safeTxHash}`);
+  if (!response.ok) {
+    throw new Error(response.statusText);
+  }
+  return v.parse(SafeTransactionSchema, await response.json());
+}
+
+export const SafeStatusSchema = v.object({
+  address: vAddress(),
+  nonce: v.number(),
+  threshold: v.number(),
+  owners: v.array(vAddress()),
+  masterCopy: vAddress(),
+  modules: v.array(vAddress()),
+  fallbackHandler: vAddress(),
+  guard: vAddress(),
+  version: v.string(),
+});
+
+export async function getSafeStatus(safeAddress: Address): Promise<
+  v.InferOutput<typeof SafeStatusSchema> | null
+> {
+  const response = await safeApiCall(`/safes/${safeAddress}`);
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error(response.statusText);
+  }
+
+  return v.parse(SafeStatusSchema, await response.json());
+}
+
+export async function waitForSafeTransaction(safeTxHash: string): Promise<`0x${string}`> {
+  while (true) {
+    try {
+      const safeTransaction = await getSafeTransaction(safeTxHash);
+      if (safeTransaction.transactionHash !== null) {
+        return safeTransaction.transactionHash as `0x${string}`;
+      }
+    } catch (_) {}
+    await sleep(2000);
+  }
+}

--- a/frontend/app/src/tx-flows/allocateVotingPower.tsx
+++ b/frontend/app/src/tx-flows/allocateVotingPower.tsx
@@ -208,8 +208,8 @@ export const allocateVotingPower: FlowDeclaration<AllocateVotingPowerRequest> = 
         });
       },
 
-      async verify({ wagmiConfig }, hash) {
-        await verifyTransaction(wagmiConfig, hash);
+      async verify({ wagmiConfig, isSafe }, hash) {
+        await verifyTransaction(wagmiConfig, hash, isSafe);
       },
     },
   },

--- a/frontend/app/src/tx-flows/claimCollateralSurplus.tsx
+++ b/frontend/app/src/tx-flows/claimCollateralSurplus.tsx
@@ -190,8 +190,8 @@ export const claimCollateralSurplus: FlowDeclaration<ClaimCollateralSurplusReque
         });
       },
 
-      async verify({ wagmiConfig }, hash) {
-        await verifyTransaction(wagmiConfig, hash);
+      async verify({ wagmiConfig, isSafe }, hash) {
+        await verifyTransaction(wagmiConfig, hash, isSafe);
       },
     },
   },

--- a/frontend/app/src/tx-flows/closeLoanPosition.tsx
+++ b/frontend/app/src/tx-flows/closeLoanPosition.tsx
@@ -137,8 +137,8 @@ export const closeLoanPosition: FlowDeclaration<CloseLoanPositionRequest> = {
         });
       },
 
-      async verify({ wagmiConfig }, hash) {
-        await verifyTransaction(wagmiConfig, hash);
+      async verify({ wagmiConfig, isSafe }, hash) {
+        await verifyTransaction(wagmiConfig, hash, isSafe);
       },
     },
 
@@ -207,8 +207,8 @@ export const closeLoanPosition: FlowDeclaration<CloseLoanPositionRequest> = {
         });
       },
 
-      async verify({ request, wagmiConfig }, hash) {
-        await verifyTransaction(wagmiConfig, hash);
+      async verify({ request, wagmiConfig, isSafe }, hash) {
+        await verifyTransaction(wagmiConfig, hash, isSafe);
 
         const prefixedTroveId = getPrefixedTroveId(
           request.loan.collIndex,

--- a/frontend/app/src/tx-flows/earnClaimRewards.tsx
+++ b/frontend/app/src/tx-flows/earnClaimRewards.tsx
@@ -105,8 +105,8 @@ export const earnClaimRewards: FlowDeclaration<EarnClaimRewardsRequest> = {
         });
       },
 
-      async verify({ wagmiConfig }, hash) {
-        await verifyTransaction(wagmiConfig, hash);
+      async verify({ wagmiConfig, isSafe }, hash) {
+        await verifyTransaction(wagmiConfig, hash, isSafe);
       },
     },
   },

--- a/frontend/app/src/tx-flows/earnDeposit.tsx
+++ b/frontend/app/src/tx-flows/earnDeposit.tsx
@@ -92,8 +92,8 @@ export const earnDeposit: FlowDeclaration<EarnDepositRequest> = {
         });
       },
 
-      async verify({ wagmiConfig }, hash) {
-        await verifyTransaction(wagmiConfig, hash);
+      async verify({ wagmiConfig, isSafe }, hash) {
+        await verifyTransaction(wagmiConfig, hash, isSafe);
       },
     },
   },

--- a/frontend/app/src/tx-flows/earnWithdraw.tsx
+++ b/frontend/app/src/tx-flows/earnWithdraw.tsx
@@ -88,8 +88,8 @@ export const earnWithdraw: FlowDeclaration<EarnWithdrawRequest> = {
         });
       },
 
-      async verify({ wagmiConfig }, hash) {
-        await verifyTransaction(wagmiConfig, hash);
+      async verify({ wagmiConfig, isSafe }, hash) {
+        await verifyTransaction(wagmiConfig, hash, isSafe);
       },
     },
   },

--- a/frontend/app/src/tx-flows/openBorrowPosition.tsx
+++ b/frontend/app/src/tx-flows/openBorrowPosition.tsx
@@ -198,8 +198,8 @@ export const openBorrowPosition: FlowDeclaration<OpenBorrowPositionRequest> = {
         });
       },
 
-      async verify({ wagmiConfig }, hash) {
-        await verifyTransaction(wagmiConfig, hash);
+      async verify({ wagmiConfig, isSafe }, hash) {
+        await verifyTransaction(wagmiConfig, hash, isSafe);
       },
     },
 
@@ -239,8 +239,8 @@ export const openBorrowPosition: FlowDeclaration<OpenBorrowPositionRequest> = {
         });
       },
 
-      async verify({ contracts, request, wagmiConfig }, hash) {
-        const receipt = await verifyTransaction(wagmiConfig, hash);
+      async verify({ contracts, request, wagmiConfig, isSafe }, hash) {
+        const receipt = await verifyTransaction(wagmiConfig, hash, isSafe);
 
         // extract trove ID from logs
         const collateral = contracts.collaterals[request.collIndex];

--- a/frontend/app/src/tx-flows/openLeveragePosition.tsx
+++ b/frontend/app/src/tx-flows/openLeveragePosition.tsx
@@ -151,8 +151,8 @@ export const openLeveragePosition: FlowDeclaration<OpenLeveragePositionRequest> 
         });
       },
 
-      async verify({ wagmiConfig }, hash) {
-        await verifyTransaction(wagmiConfig, hash);
+      async verify({ wagmiConfig, isSafe }, hash) {
+        await verifyTransaction(wagmiConfig, hash, isSafe);
       },
     },
 
@@ -211,8 +211,8 @@ export const openLeveragePosition: FlowDeclaration<OpenLeveragePositionRequest> 
         });
       },
 
-      async verify({ contracts, request, wagmiConfig }, hash) {
-        const receipt = await verifyTransaction(wagmiConfig, hash);
+      async verify({ contracts, request, wagmiConfig, isSafe }, hash) {
+        const receipt = await verifyTransaction(wagmiConfig, hash, isSafe);
 
         // Extract trove ID from logs
         const collToken = getCollToken(request.loan.collIndex);

--- a/frontend/app/src/tx-flows/shared.ts
+++ b/frontend/app/src/tx-flows/shared.ts
@@ -1,11 +1,10 @@
 import type { CollIndex } from "@/src/types";
 import type { Config as WagmiConfig } from "wagmi";
 
-import { SAFE_API_URL } from "@/src/env";
 import { getPrefixedTroveId } from "@/src/liquity-utils";
+import { waitForSafeTransaction } from "@/src/safe-utils";
 import { graphQuery, TroveByIdQuery } from "@/src/subgraph-queries";
 import { sleep } from "@/src/utils";
-import { vAddress } from "@/src/valibot-utils";
 import * as v from "valibot";
 import { waitForTransactionReceipt } from "wagmi/actions";
 
@@ -31,68 +30,25 @@ export function createRequestSchema<
   });
 }
 
-const SafeTransactionSchema = v.object({
-  confirmations: v.array(v.object({ owner: vAddress() })),
-  confirmationsRequired: v.number(),
-  isExecuted: v.union([v.null(), v.boolean()]),
-  isSuccessful: v.union([v.null(), v.boolean()]),
-  transactionHash: v.union([v.null(), v.string()]),
-});
-
-async function getSafeTransaction(safeTxHash: string): Promise<
-  v.InferOutput<typeof SafeTransactionSchema>
-> {
-  if (!SAFE_API_URL) {
-    throw new Error("SAFE_API_URL is not set");
-  }
-
-  const response = await fetch(
-    `${SAFE_API_URL}/v1/multisig-transactions/${safeTxHash}/`,
-    {
-      method: "GET",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json",
-      },
-    },
-  );
-
-  if (!response.ok) {
-    throw new Error(response.statusText);
-  }
-
-  return v.parse(SafeTransactionSchema, await response.json());
-}
-
-async function waitForSafeTransaction(safeTxHash: string): Promise<`0x${string}`> {
-  while (true) {
-    try {
-      const safeTransaction = await getSafeTransaction(safeTxHash);
-      if (safeTransaction.transactionHash !== null) {
-        return safeTransaction.transactionHash as `0x${string}`;
-      }
-    } catch (_) {}
-    await sleep(2000);
-  }
-}
-
 export async function verifyTransaction(
   wagmiConfig: WagmiConfig,
   hash: string,
+  isSafe: boolean,
 ) {
-  return Promise.race([
-    // safe tx
-    waitForSafeTransaction(hash).then((txHash) => (
+  // safe tx
+  if (isSafe) {
+    return waitForSafeTransaction(hash).then((txHash) => (
       // still get the receipt to return the same thing
       waitForTransactionReceipt(wagmiConfig, {
         hash: txHash as `0x${string}`,
       })
-    )),
-    // normal tx
-    waitForTransactionReceipt(wagmiConfig, {
-      hash: hash as `0x${string}`,
-    }),
-  ]);
+    ));
+  }
+
+  // normal tx
+  return waitForTransactionReceipt(wagmiConfig, {
+    hash: hash as `0x${string}`,
+  });
 }
 
 export async function verifyTroveUpdate(

--- a/frontend/app/src/tx-flows/stakeClaimRewards.tsx
+++ b/frontend/app/src/tx-flows/stakeClaimRewards.tsx
@@ -93,8 +93,8 @@ export const stakeClaimRewards: FlowDeclaration<StakeClaimRewardsRequest> = {
         });
       },
 
-      async verify({ wagmiConfig }, hash) {
-        await verifyTransaction(wagmiConfig, hash);
+      async verify({ wagmiConfig, isSafe }, hash) {
+        await verifyTransaction(wagmiConfig, hash, isSafe);
       },
     },
   },

--- a/frontend/app/src/tx-flows/stakeDeposit.tsx
+++ b/frontend/app/src/tx-flows/stakeDeposit.tsx
@@ -79,8 +79,8 @@ export const stakeDeposit: FlowDeclaration<StakeDepositRequest> = {
         });
       },
 
-      async verify({ wagmiConfig }, hash) {
-        await verifyTransaction(wagmiConfig, hash);
+      async verify({ wagmiConfig, isSafe }, hash) {
+        await verifyTransaction(wagmiConfig, hash, isSafe);
       },
     },
 
@@ -106,8 +106,8 @@ export const stakeDeposit: FlowDeclaration<StakeDepositRequest> = {
         });
       },
 
-      async verify({ wagmiConfig }, hash) {
-        await verifyTransaction(wagmiConfig, hash);
+      async verify({ wagmiConfig, isSafe }, hash) {
+        await verifyTransaction(wagmiConfig, hash, isSafe);
       },
     },
 
@@ -174,8 +174,8 @@ export const stakeDeposit: FlowDeclaration<StakeDepositRequest> = {
         });
       },
 
-      async verify({ wagmiConfig }, hash) {
-        await verifyTransaction(wagmiConfig, hash);
+      async verify({ wagmiConfig, isSafe }, hash) {
+        await verifyTransaction(wagmiConfig, hash, isSafe);
       },
     },
 
@@ -219,8 +219,8 @@ export const stakeDeposit: FlowDeclaration<StakeDepositRequest> = {
         });
       },
 
-      async verify({ wagmiConfig }, hash) {
-        await verifyTransaction(wagmiConfig, hash);
+      async verify({ wagmiConfig, isSafe }, hash) {
+        await verifyTransaction(wagmiConfig, hash, isSafe);
       },
     },
   },

--- a/frontend/app/src/tx-flows/unstakeDeposit.tsx
+++ b/frontend/app/src/tx-flows/unstakeDeposit.tsx
@@ -80,8 +80,8 @@ export const unstakeDeposit: FlowDeclaration<UnstakeDepositRequest> = {
         });
       },
 
-      async verify({ wagmiConfig }, hash) {
-        await verifyTransaction(wagmiConfig, hash);
+      async verify({ wagmiConfig, isSafe }, hash) {
+        await verifyTransaction(wagmiConfig, hash, isSafe);
       },
     },
 
@@ -98,8 +98,8 @@ export const unstakeDeposit: FlowDeclaration<UnstakeDepositRequest> = {
         });
       },
 
-      async verify({ wagmiConfig }, hash) {
-        await verifyTransaction(wagmiConfig, hash);
+      async verify({ wagmiConfig, isSafe }, hash) {
+        await verifyTransaction(wagmiConfig, hash, isSafe);
       },
     },
   },

--- a/frontend/app/src/tx-flows/unstakeDeposit.tsx
+++ b/frontend/app/src/tx-flows/unstakeDeposit.tsx
@@ -1,4 +1,5 @@
 import type { FlowDeclaration } from "@/src/services/TransactionFlow";
+import type { Address } from "@/src/types";
 
 import { Amount } from "@/src/comps/Amount/Amount";
 import { StakePositionSummary } from "@/src/comps/StakePositionSummary/StakePositionSummary";

--- a/frontend/app/src/tx-flows/updateBorrowPosition.tsx
+++ b/frontend/app/src/tx-flows/updateBorrowPosition.tsx
@@ -153,8 +153,8 @@ export const updateBorrowPosition: FlowDeclaration<UpdateBorrowPositionRequest> 
         });
       },
 
-      async verify({ wagmiConfig }, hash) {
-        await verifyTransaction(wagmiConfig, hash);
+      async verify({ wagmiConfig, isSafe }, hash) {
+        await verifyTransaction(wagmiConfig, hash, isSafe);
       },
     },
 
@@ -185,8 +185,8 @@ export const updateBorrowPosition: FlowDeclaration<UpdateBorrowPositionRequest> 
         });
       },
 
-      async verify({ wagmiConfig }, hash) {
-        await verifyTransaction(wagmiConfig, hash);
+      async verify({ wagmiConfig, isSafe }, hash) {
+        await verifyTransaction(wagmiConfig, hash, isSafe);
       },
     },
 

--- a/frontend/app/src/tx-flows/updateLeveragePosition.tsx
+++ b/frontend/app/src/tx-flows/updateLeveragePosition.tsx
@@ -211,8 +211,8 @@ export const updateLeveragePosition: FlowDeclaration<UpdateLeveragePositionReque
         });
       },
 
-      async verify({ wagmiConfig }, hash) {
-        await verifyTransaction(wagmiConfig, hash);
+      async verify({ wagmiConfig, isSafe }, hash) {
+        await verifyTransaction(wagmiConfig, hash, isSafe);
       },
     },
 


### PR DESCRIPTION
The account object returned by `useAccount()` now has a `safeStatus` property, which allows to avoid querying the Safe API for non-Safe accounts.