### PR TITLE
Ensure the trove ID always increments (subgraph + app)

### DIFF
--- a/frontend/app/src/graphql/gql.ts
+++ b/frontend/app/src/graphql/gql.ts
@@ -15,7 +15,7 @@ import * as types from './graphql';
  * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
  */
 const documents = {
-    "\n  query TrovesCount($id: ID!) {\n    borrowerInfo(id: $id) {\n      troves\n      trovesByCollateral\n    }\n  }\n": types.TrovesCountDocument,
+    "\n  query BorrowerInfo($id: ID!) {\n    borrowerInfo(id: $id) {\n      nextOwnerIndexes\n      troves\n      trovesByCollateral\n    }\n  }\n": types.BorrowerInfoDocument,
     "\n  fragment FullTroveFragment on Trove {\n    id\n    borrower\n    closedAt\n    createdAt\n    debt\n    deposit\n    interestRate\n    mightBeLeveraged\n    stake\n    status\n    troveId\n    updatedAt\n    collateral {\n      id\n      token {\n        symbol\n        name\n      }\n      minCollRatio\n      collIndex\n    }\n    interestBatch {\n      id\n      annualInterestRate\n      annualManagementFee\n      batchManager\n    }\n  }\n": types.FullTroveFragmentFragmentDoc,
     "\n  query TrovesByAccount($account: Bytes!) {\n    troves(\n      where: {\n        borrower: $account,\n        status_in: [active,redeemed,liquidated],\n      }\n      orderBy: updatedAt\n      orderDirection: desc\n    ) {\n      id\n      borrower\n      closedAt\n      createdAt\n      debt\n      deposit\n      interestRate\n      mightBeLeveraged\n      stake\n      status\n      troveId\n      updatedAt\n      collateral {\n        id\n        token {\n          symbol\n          name\n        }\n        minCollRatio\n        collIndex\n      }\n      interestBatch {\n        id\n        annualInterestRate\n        annualManagementFee\n        batchManager\n      }\n    }\n  }\n": types.TrovesByAccountDocument,
     "\n  query TroveById($id: ID!) {\n    trove(id: $id) {\n      id\n      borrower\n      closedAt\n      createdAt\n      debt\n      deposit\n      interestRate\n      mightBeLeveraged\n      stake\n      status\n      troveId\n      updatedAt\n      collateral {\n        id\n        token {\n          symbol\n          name\n        }\n        minCollRatio\n        collIndex\n      }\n      interestBatch {\n        id\n        annualInterestRate\n        annualManagementFee\n        batchManager\n      }\n    }\n  }\n": types.TroveByIdDocument,
@@ -35,7 +35,7 @@ const documents = {
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
-export function graphql(source: "\n  query TrovesCount($id: ID!) {\n    borrowerInfo(id: $id) {\n      troves\n      trovesByCollateral\n    }\n  }\n"): typeof import('./graphql').TrovesCountDocument;
+export function graphql(source: "\n  query BorrowerInfo($id: ID!) {\n    borrowerInfo(id: $id) {\n      nextOwnerIndexes\n      troves\n      trovesByCollateral\n    }\n  }\n"): typeof import('./graphql').BorrowerInfoDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/frontend/app/src/graphql/graphql.ts
+++ b/frontend/app/src/graphql/graphql.ts
@@ -47,6 +47,7 @@ export type Block_Height = {
 export type BorrowerInfo = {
   __typename?: 'BorrowerInfo';
   id: Scalars['ID']['output'];
+  nextOwnerIndexes: Array<Scalars['Int']['output']>;
   troves: Scalars['Int']['output'];
   trovesByCollateral: Array<Scalars['Int']['output']>;
 };
@@ -63,6 +64,12 @@ export type BorrowerInfo_Filter = {
   id_lte?: InputMaybe<Scalars['ID']['input']>;
   id_not?: InputMaybe<Scalars['ID']['input']>;
   id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  nextOwnerIndexes?: InputMaybe<Array<Scalars['Int']['input']>>;
+  nextOwnerIndexes_contains?: InputMaybe<Array<Scalars['Int']['input']>>;
+  nextOwnerIndexes_contains_nocase?: InputMaybe<Array<Scalars['Int']['input']>>;
+  nextOwnerIndexes_not?: InputMaybe<Array<Scalars['Int']['input']>>;
+  nextOwnerIndexes_not_contains?: InputMaybe<Array<Scalars['Int']['input']>>;
+  nextOwnerIndexes_not_contains_nocase?: InputMaybe<Array<Scalars['Int']['input']>>;
   or?: InputMaybe<Array<InputMaybe<BorrowerInfo_Filter>>>;
   troves?: InputMaybe<Scalars['Int']['input']>;
   trovesByCollateral?: InputMaybe<Array<Scalars['Int']['input']>>;
@@ -82,6 +89,7 @@ export type BorrowerInfo_Filter = {
 
 export enum BorrowerInfo_OrderBy {
   Id = 'id',
+  NextOwnerIndexes = 'nextOwnerIndexes',
   Troves = 'troves',
   TrovesByCollateral = 'trovesByCollateral'
 }
@@ -138,11 +146,8 @@ export type Collateral = {
   collIndex: Scalars['Int']['output'];
   id: Scalars['ID']['output'];
   minCollRatio: Scalars['BigInt']['output'];
-  price: Scalars['BigInt']['output'];
   stabilityPoolDeposits: Array<StabilityPoolDeposit>;
   token: Token;
-  totalDebt: Scalars['BigInt']['output'];
-  totalDeposited: Scalars['BigInt']['output'];
   troves: Array<Trove>;
 };
 
@@ -278,9 +283,6 @@ export enum CollateralAddresses_OrderBy {
   CollateralCollIndex = 'collateral__collIndex',
   CollateralId = 'collateral__id',
   CollateralMinCollRatio = 'collateral__minCollRatio',
-  CollateralPrice = 'collateral__price',
-  CollateralTotalDebt = 'collateral__totalDebt',
-  CollateralTotalDeposited = 'collateral__totalDeposited',
   Id = 'id',
   SortedTroves = 'sortedTroves',
   StabilityPool = 'stabilityPool',
@@ -319,14 +321,6 @@ export type Collateral_Filter = {
   minCollRatio_not?: InputMaybe<Scalars['BigInt']['input']>;
   minCollRatio_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   or?: InputMaybe<Array<InputMaybe<Collateral_Filter>>>;
-  price?: InputMaybe<Scalars['BigInt']['input']>;
-  price_gt?: InputMaybe<Scalars['BigInt']['input']>;
-  price_gte?: InputMaybe<Scalars['BigInt']['input']>;
-  price_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
-  price_lt?: InputMaybe<Scalars['BigInt']['input']>;
-  price_lte?: InputMaybe<Scalars['BigInt']['input']>;
-  price_not?: InputMaybe<Scalars['BigInt']['input']>;
-  price_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   stabilityPoolDeposits_?: InputMaybe<StabilityPoolDeposit_Filter>;
   token?: InputMaybe<Scalars['String']['input']>;
   token_?: InputMaybe<Token_Filter>;
@@ -349,22 +343,6 @@ export type Collateral_Filter = {
   token_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
   token_starts_with?: InputMaybe<Scalars['String']['input']>;
   token_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
-  totalDebt?: InputMaybe<Scalars['BigInt']['input']>;
-  totalDebt_gt?: InputMaybe<Scalars['BigInt']['input']>;
-  totalDebt_gte?: InputMaybe<Scalars['BigInt']['input']>;
-  totalDebt_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
-  totalDebt_lt?: InputMaybe<Scalars['BigInt']['input']>;
-  totalDebt_lte?: InputMaybe<Scalars['BigInt']['input']>;
-  totalDebt_not?: InputMaybe<Scalars['BigInt']['input']>;
-  totalDebt_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
-  totalDeposited?: InputMaybe<Scalars['BigInt']['input']>;
-  totalDeposited_gt?: InputMaybe<Scalars['BigInt']['input']>;
-  totalDeposited_gte?: InputMaybe<Scalars['BigInt']['input']>;
-  totalDeposited_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
-  totalDeposited_lt?: InputMaybe<Scalars['BigInt']['input']>;
-  totalDeposited_lte?: InputMaybe<Scalars['BigInt']['input']>;
-  totalDeposited_not?: InputMaybe<Scalars['BigInt']['input']>;
-  totalDeposited_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   troves_?: InputMaybe<Trove_Filter>;
 };
 
@@ -380,15 +358,12 @@ export enum Collateral_OrderBy {
   CollIndex = 'collIndex',
   Id = 'id',
   MinCollRatio = 'minCollRatio',
-  Price = 'price',
   StabilityPoolDeposits = 'stabilityPoolDeposits',
   Token = 'token',
   TokenDecimals = 'token__decimals',
   TokenId = 'token__id',
   TokenName = 'token__name',
   TokenSymbol = 'token__symbol',
-  TotalDebt = 'totalDebt',
-  TotalDeposited = 'totalDeposited',
   Troves = 'troves'
 }
 
@@ -848,9 +823,6 @@ export enum InterestBatch_OrderBy {
   CollateralCollIndex = 'collateral__collIndex',
   CollateralId = 'collateral__id',
   CollateralMinCollRatio = 'collateral__minCollRatio',
-  CollateralPrice = 'collateral__price',
-  CollateralTotalDebt = 'collateral__totalDebt',
-  CollateralTotalDeposited = 'collateral__totalDeposited',
   Debt = 'debt',
   Id = 'id',
   Troves = 'troves'
@@ -921,9 +893,6 @@ export enum InterestRateBracket_OrderBy {
   CollateralCollIndex = 'collateral__collIndex',
   CollateralId = 'collateral__id',
   CollateralMinCollRatio = 'collateral__minCollRatio',
-  CollateralPrice = 'collateral__price',
-  CollateralTotalDebt = 'collateral__totalDebt',
-  CollateralTotalDeposited = 'collateral__totalDeposited',
   Id = 'id',
   Rate = 'rate',
   TotalDebt = 'totalDebt'
@@ -1441,9 +1410,6 @@ export enum StabilityPoolDeposit_OrderBy {
   CollateralCollIndex = 'collateral__collIndex',
   CollateralId = 'collateral__id',
   CollateralMinCollRatio = 'collateral__minCollRatio',
-  CollateralPrice = 'collateral__price',
-  CollateralTotalDebt = 'collateral__totalDebt',
-  CollateralTotalDeposited = 'collateral__totalDeposited',
   Deposit = 'deposit',
   Depositor = 'depositor',
   Id = 'id',
@@ -1957,9 +1923,6 @@ export enum Token_OrderBy {
   CollateralCollIndex = 'collateral__collIndex',
   CollateralId = 'collateral__id',
   CollateralMinCollRatio = 'collateral__minCollRatio',
-  CollateralPrice = 'collateral__price',
-  CollateralTotalDebt = 'collateral__totalDebt',
-  CollateralTotalDeposited = 'collateral__totalDeposited',
   Decimals = 'decimals',
   Id = 'id',
   Name = 'name',
@@ -2149,9 +2112,6 @@ export enum Trove_OrderBy {
   CollateralCollIndex = 'collateral__collIndex',
   CollateralId = 'collateral__id',
   CollateralMinCollRatio = 'collateral__minCollRatio',
-  CollateralPrice = 'collateral__price',
-  CollateralTotalDebt = 'collateral__totalDebt',
-  CollateralTotalDeposited = 'collateral__totalDeposited',
   CreatedAt = 'createdAt',
   Debt = 'debt',
   Deposit = 'deposit',
@@ -2207,12 +2167,12 @@ export enum _SubgraphErrorPolicy_ {
   Deny = 'deny'
 }
 
-export type TrovesCountQueryVariables = Exact<{
+export type BorrowerInfoQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
 
 
-export type TrovesCountQuery = { __typename?: 'Query', borrowerInfo?: { __typename?: 'BorrowerInfo', troves: number, trovesByCollateral: Array<number> } | null };
+export type BorrowerInfoQuery = { __typename?: 'Query', borrowerInfo?: { __typename?: 'BorrowerInfo', nextOwnerIndexes: Array<number>, troves: number, trovesByCollateral: Array<number> } | null };
 
 export type FullTroveFragmentFragment = { __typename?: 'Trove', id: string, borrower: string, closedAt?: bigint | null, createdAt: bigint, debt: bigint, deposit: bigint, interestRate: bigint, mightBeLeveraged: boolean, stake: bigint, status: TroveStatus, troveId: string, updatedAt: bigint, collateral: { __typename?: 'Collateral', id: string, minCollRatio: bigint, collIndex: number, token: { __typename?: 'Token', symbol: string, name: string } }, interestBatch?: { __typename?: 'InterestBatch', id: string, annualInterestRate: bigint, annualManagementFee: bigint, batchManager: string } | null } & { ' $fragmentName'?: 'FullTroveFragmentFragment' };
 
@@ -2360,14 +2320,15 @@ export const StabilityPoolDepositFragmentFragmentDoc = new TypedDocumentString(`
   }
 }
     `, {"fragmentName":"StabilityPoolDepositFragment"}) as unknown as TypedDocumentString<StabilityPoolDepositFragmentFragment, unknown>;
-export const TrovesCountDocument = new TypedDocumentString(`
-    query TrovesCount($id: ID!) {
+export const BorrowerInfoDocument = new TypedDocumentString(`
+    query BorrowerInfo($id: ID!) {
   borrowerInfo(id: $id) {
+    nextOwnerIndexes
     troves
     trovesByCollateral
   }
 }
-    `) as unknown as TypedDocumentString<TrovesCountQuery, TrovesCountQueryVariables>;
+    `) as unknown as TypedDocumentString<BorrowerInfoQuery, BorrowerInfoQueryVariables>;
 export const TrovesByAccountDocument = new TypedDocumentString(`
     query TrovesByAccount($account: Bytes!) {
   troves(

--- a/frontend/app/src/screens/BorrowScreen/BorrowScreen.tsx
+++ b/frontend/app/src/screens/BorrowScreen/BorrowScreen.tsx
@@ -26,7 +26,7 @@ import { getLiquidationRisk, getLoanDetails, getLtv } from "@/src/liquity-math";
 import { useAccount, useBalance } from "@/src/services/Ethereum";
 import { usePrice } from "@/src/services/Prices";
 import { useTransactionFlow } from "@/src/services/TransactionFlow";
-import { useTrovesCount } from "@/src/subgraph-hooks";
+import { useNextOwnerIndex } from "@/src/subgraph-hooks";
 import { isCollIndex } from "@/src/types";
 import { infoTooltipProps } from "@/src/uikit-utils";
 import { css } from "@/styled-system/css";
@@ -113,7 +113,7 @@ export function BorrowScreen() {
     throw new Error(`Unknown collateral symbol: ${collateral.symbol}`);
   }
 
-  const troveCount = useTrovesCount(account.address ?? null, collIndex);
+  const nextOwnerIndex = useNextOwnerIndex(account.address ?? null, collIndex);
 
   const loanDetails = getLoanDetails(
     deposit.isEmpty ? null : deposit.parsed,
@@ -396,7 +396,12 @@ export function BorrowScreen() {
             size="large"
             wide
             onClick={() => {
-              if (deposit.parsed && debt.parsed && account.address) {
+              if (
+                deposit.parsed
+                && debt.parsed
+                && account.address
+                && typeof nextOwnerIndex.data === "number"
+              ) {
                 txFlow.start({
                   flowId: "openBorrowPosition",
                   backLink: ["/borrow", "Back to editing"],
@@ -405,7 +410,7 @@ export function BorrowScreen() {
 
                   collIndex,
                   owner: account.address,
-                  ownerIndex: troveCount.data ?? 0,
+                  ownerIndex: nextOwnerIndex.data,
                   collAmount: deposit.parsed,
                   boldAmount: debt.parsed,
                   upperHint: dnum18(0),

--- a/frontend/app/src/screens/LeverageScreen/LeverageScreen.tsx
+++ b/frontend/app/src/screens/LeverageScreen/LeverageScreen.tsx
@@ -29,7 +29,7 @@ import { getCollIndexFromSymbol } from "@/src/liquity-utils";
 import { useAccount, useBalance } from "@/src/services/Ethereum";
 import { usePrice } from "@/src/services/Prices";
 import { useTransactionFlow } from "@/src/services/TransactionFlow";
-import { useTrovesCount } from "@/src/subgraph-hooks";
+import { useNextOwnerIndex } from "@/src/subgraph-hooks";
 import { infoTooltipProps } from "@/src/uikit-utils";
 import { css } from "@/styled-system/css";
 import {
@@ -85,7 +85,8 @@ export function LeverageScreen() {
     [symbol, useBalance(account.address, symbol)] as const
   )));
 
-  const troveCount = useTrovesCount(account.address ?? null, collIndex);
+  const nextOwnerIndex = useNextOwnerIndex(account.address ?? null, collIndex);
+
   const collPrice = usePrice(collToken.symbol);
 
   const maxCollDeposit = MAX_COLLATERAL_DEPOSITS[collSymbol] ?? null;
@@ -147,7 +148,7 @@ export function LeverageScreen() {
     collIndex,
     initialDeposit: depositPreLeverage.parsed,
     leverageFactor: leverageField.leverageFactor,
-    ownerIndex: troveCount.data ?? null,
+    ownerIndex: nextOwnerIndex.data ?? null,
   });
 
   const leverageSlippageElements = useSlippageElements(
@@ -373,14 +374,19 @@ export function LeverageScreen() {
               size="large"
               wide
               onClick={() => {
-                if (depositPreLeverage.parsed && leverageField.debt && account.address) {
+                if (
+                  depositPreLeverage.parsed
+                  && leverageField.debt
+                  && account.address
+                  && typeof nextOwnerIndex.data === "number"
+                ) {
                   txFlow.start({
                     flowId: "openLeveragePosition",
                     backLink: ["/multiply", "Back to editing"],
                     successLink: ["/", "Go to the Dashboard"],
                     successMessage: "The leveraged position has been created successfully.",
 
-                    ownerIndex: troveCount.data ?? 0,
+                    ownerIndex: nextOwnerIndex.data,
                     leverageFactor: leverageField.leverageFactor,
                     loan: newLoan,
                   });

--- a/frontend/app/src/subgraph-hooks.ts
+++ b/frontend/app/src/subgraph-hooks.ts
@@ -15,6 +15,7 @@ import { isAddress, shortenAddress } from "@liquity2/uikit";
 import { useQuery } from "@tanstack/react-query";
 import * as dn from "dnum";
 import {
+  BorrowerInfoQuery,
   GovernanceInitiatives,
   GovernanceStats,
   GovernanceUser,
@@ -27,7 +28,6 @@ import {
   StabilityPoolQuery,
   TroveByIdQuery,
   TrovesByAccountQuery,
-  TrovesCountQuery,
 } from "./subgraph-queries";
 
 type Options = {
@@ -41,22 +41,23 @@ function prepareOptions(options?: Options) {
   };
 }
 
-export function useTrovesCount(
+export function useNextOwnerIndex(
   borrower: null | Address,
-  collIndex?: CollIndex,
+  collIndex: null | CollIndex,
   options?: Options,
 ) {
   let queryFn = async () => {
-    if (!borrower) {
+    if (!borrower || collIndex === null) {
       return null;
     }
+
     const { borrowerInfo } = await graphQuery(
-      TrovesCountQuery,
+      BorrowerInfoQuery,
       { id: borrower.toLowerCase() },
     );
-    return collIndex === undefined
-      ? borrowerInfo?.troves ?? 0
-      : borrowerInfo?.trovesByCollateral[collIndex] ?? null;
+
+    // if borrowerInfo doesn’t exist, start at 0
+    return borrowerInfo?.nextOwnerIndexes[collIndex] ?? 0;
   };
 
   if (DEMO_MODE) {
@@ -70,7 +71,7 @@ export function useTrovesCount(
   }
 
   return useQuery({
-    queryKey: ["TrovesCount", borrower, collIndex],
+    queryKey: ["NextTroveId", borrower, collIndex],
     queryFn,
     ...prepareOptions(options),
   });

--- a/frontend/app/src/subgraph-queries.ts
+++ b/frontend/app/src/subgraph-queries.ts
@@ -32,9 +32,10 @@ export async function graphQuery<TResult, TVariables>(
   return result.data as TResult;
 }
 
-export const TrovesCountQuery = graphql(`
-  query TrovesCount($id: ID!) {
+export const BorrowerInfoQuery = graphql(`
+  query BorrowerInfo($id: ID!) {
     borrowerInfo(id: $id) {
+      nextOwnerIndexes
       troves
       trovesByCollateral
     }

--- a/subgraph/networks.json
+++ b/subgraph/networks.json
@@ -19,12 +19,12 @@
   },
   "sepolia": {
     "BoldToken": {
-      "address": "0x6ecf96d1f30cd98c0b58d6b12ea8ae014c52464d",
-      "startBlock": 7279144
+      "address": "0x0a69fa2a565bd6fa9c3890ecaa30b149aaf99136",
+      "startBlock": 7314166
     },
     "Governance": {
-      "address": "0xd7eae81178b97e49e6471f398f0486a7c2e43721",
-      "startBlock": 7279317
+      "address": "0x7eedda08119826757c98a4680e94f3b5e1f33af6",
+      "startBlock": 7314318
     }
   }
 }

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -68,6 +68,7 @@ type BorrowerInfo @entity {
   id: ID! # "borrowerAddress", e.g. "0x0000000000000000000000000000000000000000"
   troves: Int!
   trovesByCollateral: [Int!]!
+  nextOwnerIndexes: [Int!]!
 }
 
 type StabilityPool @entity {

--- a/subgraph/src/TroveNFT.mapping.ts
+++ b/subgraph/src/TroveNFT.mapping.ts
@@ -1,46 +1,7 @@
-import { Address, BigInt, dataSource } from "@graphprotocol/graph-ts";
-import { BorrowerInfo, Trove } from "../generated/schema";
+import { Address, dataSource } from "@graphprotocol/graph-ts";
+import { Trove } from "../generated/schema";
 import { Transfer as TransferEvent } from "../generated/templates/TroveNFT/TroveNFT";
-
-enum BorrowerInfoUpdate {
-  add,
-  remove,
-}
-
-function updateBorrowerInfo(
-  borrowerAddress: Address,
-  troveFullId: string,
-  update: BorrowerInfoUpdate,
-): void {
-  let trove = Trove.load(troveFullId);
-  if (!trove) {
-    throw new Error("Trove does not exist: " + troveFullId);
-  }
-
-  let borrowerInfo = BorrowerInfo.load(borrowerAddress.toHexString());
-
-  if (!borrowerInfo && update == BorrowerInfoUpdate.add) {
-    borrowerInfo = new BorrowerInfo(borrowerAddress.toHexString());
-    borrowerInfo.troves = 0;
-
-    let totalCollaterals = dataSource.context().getI32("totalCollaterals");
-    borrowerInfo.trovesByCollateral = (new Array<i32>(totalCollaterals)).fill(0);
-  }
-
-  if (!borrowerInfo) {
-    throw new Error("BorrowerInfo does not exist: " + borrowerAddress.toHexString());
-  }
-
-  let diff = update == BorrowerInfoUpdate.add ? 1 : -1;
-
-  let trovesByColl = borrowerInfo.trovesByCollateral;
-  let collIndex = <i32> parseInt(trove.collateral);
-  trovesByColl[collIndex] += diff;
-
-  borrowerInfo.trovesByCollateral = trovesByColl;
-  borrowerInfo.troves += diff;
-  borrowerInfo.save();
-}
+import { BorrowerTrovesCountUpdate, updateBorrowerTrovesCount } from "./shared";
 
 export function handleTransfer(event: TransferEvent): void {
   // Minting doesn’t need to be handled as we are already
@@ -53,16 +14,28 @@ export function handleTransfer(event: TransferEvent): void {
   let collId = dataSource.context().getString("collId");
   let troveFullId = collId + ":" + event.params.tokenId.toHexString();
 
-  // update BorrowerInfo for the previous owner
-  updateBorrowerInfo(event.params.from, troveFullId, BorrowerInfoUpdate.remove);
+  let trove = Trove.load(troveFullId);
+  if (!trove) {
+    throw new Error("Trove does not exist: " + troveFullId);
+  }
 
-  // update BorrowerInfo for the new owner (including zero address)
-  updateBorrowerInfo(event.params.to, troveFullId, BorrowerInfoUpdate.add);
+  let collIndex = <i32> parseInt(trove.collateral);
+
+  // update troves count & ownerIndex for the previous owner
+  updateBorrowerTrovesCount(
+    BorrowerTrovesCountUpdate.remove,
+    event.params.from,
+    collIndex,
+  );
+
+  // update troves count & ownerIndex for the current owner (including zero address)
+  updateBorrowerTrovesCount(
+    BorrowerTrovesCountUpdate.add,
+    event.params.to,
+    collIndex,
+  );
 
   // update the trove borrower
-  let trove = Trove.load(troveFullId);
-  if (trove) {
-    trove.borrower = event.params.to;
-    trove.save();
-  }
+  trove.borrower = event.params.to;
+  trove.save();
 }

--- a/subgraph/src/shared.ts
+++ b/subgraph/src/shared.ts
@@ -1,0 +1,44 @@
+import { Address, dataSource } from "@graphprotocol/graph-ts";
+import { BorrowerInfo } from "../generated/schema";
+
+export enum BorrowerTrovesCountUpdate {
+  add,
+  remove,
+}
+
+export function updateBorrowerTrovesCount(
+  update: BorrowerTrovesCountUpdate,
+  borrower: Address,
+  collIndex: i32,
+): BorrowerInfo {
+  let borrowerId = borrower.toHexString();
+  let borrowerInfo = BorrowerInfo.load(borrowerId);
+
+  let collateralsCount = dataSource.context().getI32("totalCollaterals");
+
+  if (!borrowerInfo) {
+    borrowerInfo = new BorrowerInfo(borrowerId);
+    borrowerInfo.troves = 0;
+    borrowerInfo.trovesByCollateral = (new Array<i32>(collateralsCount)).fill(0);
+    borrowerInfo.nextOwnerIndexes = (new Array<i32>(collateralsCount)).fill(0);
+  }
+
+  // track the amount of troves per collateral
+  let trovesByCollateral = borrowerInfo.trovesByCollateral;
+  trovesByCollateral[collIndex] += update === BorrowerTrovesCountUpdate.add ? 1 : -1;
+  borrowerInfo.trovesByCollateral = trovesByCollateral;
+
+  // track the total amount of troves
+  borrowerInfo.troves += update === BorrowerTrovesCountUpdate.add ? 1 : -1;
+
+  // nextOwnerIndexes only ever goes up
+  if (update === BorrowerTrovesCountUpdate.add) {
+    let nextOwnerIndexes = borrowerInfo.nextOwnerIndexes;
+    nextOwnerIndexes[collIndex] += 1;
+    borrowerInfo.nextOwnerIndexes = nextOwnerIndexes;
+  }
+
+  borrowerInfo.save();
+
+  return borrowerInfo;
+}

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -6,8 +6,8 @@ dataSources:
     name: BoldToken
     source:
       abi: BoldToken
-      address: "0x6ecf96d1f30cd98c0b58d6b12ea8ae014c52464d"
-      startBlock: 7279144
+      address: "0x0a69fa2a565bd6fa9c3890ecaa30b149aaf99136"
+      startBlock: 7314166
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.9
@@ -38,8 +38,8 @@ dataSources:
     name: Governance
     source:
       abi: Governance
-      address: "0xd7eae81178b97e49e6471f398f0486a7c2e43721"
-      startBlock: 7279317
+      address: "0x7eedda08119826757c98a4680e94f3b5e1f33af6"
+      startBlock: 7314318
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.9


### PR DESCRIPTION
1. The troves count now decrements when a trove gets closed.
2. The nextOwnerIndexes field is now used to determine the next ownerIndex to use, rather than the troves count.

Also:

- Troves count is now updated from a shared updateBorrowerTrovesCount().
- In the app, replace useTrovesCount() by useNextOwnerIndex().
- Update sepolia addresses.