### PR TITLE
Preferred approval method

### DIFF
--- a/frontend/app/src/screens/TransactionsScreen/TransactionStatus.tsx
+++ b/frontend/app/src/screens/TransactionsScreen/TransactionStatus.tsx
@@ -2,23 +2,95 @@ import type { FlowStepDeclaration } from "@/src/services/TransactionFlow";
 import type { ComponentPropsWithoutRef } from "react";
 
 import { CHAIN_BLOCK_EXPLORER } from "@/src/env";
-import { AnchorTextButton, TextButton } from "@liquity2/uikit";
+import { useAccount } from "@/src/services/Ethereum";
+import { useStoredState } from "@/src/services/StoredState";
+import { useTransactionFlow } from "@/src/services/TransactionFlow";
+import { css, cx } from "@/styled-system/css";
+import { AnchorTextButton, Dropdown, IconChevronDown, TextButton } from "@liquity2/uikit";
 import { match } from "ts-pattern";
 
 export function TransactionStatus(
-  props: ComponentPropsWithoutRef<FlowStepDeclaration["Status"]>,
+  props: ComponentPropsWithoutRef<FlowStepDeclaration["Status"]> & {
+    approval?: "all" | "approve-only" | null;
+  },
 ) {
+  const { preferredApproveMethod } = useStoredState();
   return (
-    <>
+    <div
+      className={cx(
+        "tx-status",
+        css({
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: 8,
+        }),
+      )}
+    >
+      {props.approval
+        && (props.status === "idle" || props.status === "error")
+        && <PreferredApproveMethodSelector selector={props.approval} />}
+      <StatusText
+        {...props}
+        type={props.approval === "all" && preferredApproveMethod === "permit"
+          ? "permission"
+          : "transaction"}
+      />
+    </div>
+  );
+}
+
+function TxLink({ txHash }: { txHash: string }) {
+  const account = useAccount();
+  return (
+    <AnchorTextButton
+      label="transaction"
+      href={account.safeStatus === null
+        ? `${CHAIN_BLOCK_EXPLORER?.url}tx/${txHash}`
+        : `https://app.safe.global/transactions/tx?id=multisig_${account.address}_${txHash}&safe=sep:${account.address}`}
+      external
+    />
+  );
+}
+
+function StatusText(
+  props: ComponentPropsWithoutRef<FlowStepDeclaration["Status"]> & {
+    type: "transaction" | "permission";
+  },
+) {
+  if (props.type === "permission") {
+    return (
+      <div>
+        {match(props)
+          .with({ status: "idle" }, () => (
+            "This action will open your wallet to sign a permission."
+          ))
+          .with({ status: "awaiting-commit" }, () => (
+            "Please sign the permission in your wallet."
+          ))
+          .with({ status: "confirmed" }, () => (
+            "The permission has been signed."
+          ))
+          .with({ status: "error" }, () => (
+            "An error occurred. Please try again."
+          ))
+          .otherwise(() => null)}
+      </div>
+    );
+  }
+  return (
+    <div>
       {match(props)
         .with({ status: "idle" }, () => (
-          <>
-            This action will open your wallet to sign the transaction.
-          </>
+          "This action will open your wallet to sign the transaction."
         ))
         .with({ status: "awaiting-commit" }, ({ onRetry }) => (
           <>
-            Please sign the transaction in your wallet. <TextButton label="Retry" onClick={onRetry} />
+            Please sign the transaction in your wallet.{" "}
+            <TextButton
+              label="Retry"
+              onClick={onRetry}
+            />
           </>
         ))
         .with({ status: "awaiting-verify" }, ({ artifact: txHash }) => (
@@ -32,21 +104,114 @@ export function TransactionStatus(
           </>
         ))
         .with({ status: "error" }, () => (
-          <>
-            An error occurred. Please try again.
-          </>
+          "An error occurred. Please try again."
         ))
         .exhaustive()}
-    </>
+    </div>
   );
 }
 
-function TxLink({ txHash }: { txHash: string }) {
+const approveMethodOptions = [{
+  method: "permit",
+  label: "Signature",
+  secondary: "You will be asked to sign a message. Instant and no gas fees. Recommended.",
+}, {
+  method: "approve-amount",
+  label: "Transaction",
+  secondary: "You will be asked to approve the desired amount in your wallet via a transaction.",
+}, {
+  method: "approve-infinite",
+  label: "Transaction (infinite)",
+  secondary: "You will be asked to approve an infinite amount in your wallet via a transaction.",
+}] as const;
+
+function PreferredApproveMethodSelector({
+  selector,
+}: {
+  selector: "all" | "approve-only";
+}) {
+  const { preferredApproveMethod, setState } = useStoredState();
+
+  const options = approveMethodOptions.slice(
+    selector === "approve-only" ? 1 : 0,
+  );
+
+  const currentOption = options.find(({ method }) => (
+    method === preferredApproveMethod
+  )) ?? (options[0] as typeof options[0]);
+
+  const { clearError } = useTransactionFlow();
+
   return (
-    <AnchorTextButton
-      label="transaction"
-      href={`${CHAIN_BLOCK_EXPLORER?.url}tx/${txHash}`}
-      external
-    />
+    <div
+      className={css({
+        display: "flex",
+        gap: 4,
+      })}
+    >
+      <div>Approve via</div>
+      <Dropdown
+        customButton={({ menuVisible }) => (
+          <div
+            className={css({
+              display: "flex",
+              gap: 4,
+              color: "accent",
+              borderRadius: 4,
+              _groupFocusVisible: {
+                outline: "2px solid token(colors.focused)",
+                outlineOffset: 2,
+              },
+            })}
+          >
+            <div>{currentOption.label}</div>
+            <div
+              className={css({
+                display: "flex",
+                alignItems: "center",
+                transformOrigin: "50% 50%",
+                transition: "transform 80ms",
+              })}
+              style={{
+                transform: menuVisible ? "rotate(180deg)" : "rotate(0)",
+              }}
+            >
+              <IconChevronDown size={16} />
+            </div>
+          </div>
+        )}
+        menuWidth={300}
+        menuPlacement="top-end"
+        items={options}
+        selected={options.indexOf(currentOption)}
+        floatingUpdater={({ computePosition, referenceElement, floatingElement }) => {
+          return async () => {
+            const container = referenceElement.closest(".tx-status");
+            if (!container) {
+              return;
+            }
+
+            const position = await computePosition(referenceElement, floatingElement);
+            const containerRect = container.getBoundingClientRect();
+            const x = containerRect.left + containerRect.width / 2
+              - floatingElement.offsetWidth / 2;
+            const y = position.y - floatingElement.offsetHeight - 32;
+
+            floatingElement.style.left = `${x}px`;
+            floatingElement.style.top = `${y}px`;
+          };
+        }}
+        onSelect={(index) => {
+          const method = options[index]?.method;
+          if (method) {
+            setState((state) => ({
+              ...state,
+              preferredApproveMethod: method,
+            }));
+            clearError();
+          }
+        }}
+      />
+    </div>
   );
 }

--- a/frontend/app/src/services/StoredState.tsx
+++ b/frontend/app/src/services/StoredState.tsx
@@ -17,12 +17,18 @@ export const StoredStateSchema = v.object({
       v.literal("multiply"),
     ]),
   ),
+  preferredApproveMethod: v.union([
+    v.literal("permit"),
+    v.literal("approve-amount"),
+    v.literal("approve-infinite"),
+  ]),
 });
 
 type StoredStateType = v.InferOutput<typeof StoredStateSchema>;
 
 const defaultState: StoredStateType = {
   loanModes: {},
+  preferredApproveMethod: "permit",
 };
 
 type StoredStateContext = StoredStateType & {

--- a/frontend/app/src/tx-flows/stakeDeposit.tsx
+++ b/frontend/app/src/tx-flows/stakeDeposit.tsx
@@ -5,14 +5,15 @@ import { Amount } from "@/src/comps/Amount/Amount";
 import { StakePositionSummary } from "@/src/comps/StakePositionSummary/StakePositionSummary";
 import { dnum18 } from "@/src/dnum-utils";
 import { signPermit } from "@/src/permit";
-import { PermissionStatus } from "@/src/screens/TransactionsScreen/PermissionStatus";
 import { TransactionDetailsRow } from "@/src/screens/TransactionsScreen/TransactionsScreen";
 import { TransactionStatus } from "@/src/screens/TransactionsScreen/TransactionStatus";
+import { useAccount } from "@/src/services/Ethereum";
 import { usePrice } from "@/src/services/Prices";
 import { GovernanceUserAllocated, graphQuery } from "@/src/subgraph-queries";
 import { vDnum, vPositionStake } from "@/src/valibot-utils";
 import * as dn from "dnum";
 import * as v from "valibot";
+import { maxUint256 } from "viem";
 import { getBytecode, readContract, writeContract } from "wagmi/actions";
 import { createRequestSchema, verifyTransaction } from "./shared";
 
@@ -26,8 +27,6 @@ const RequestSchema = createRequestSchema(
 );
 
 export type StakeDepositRequest = v.InferOutput<typeof RequestSchema>;
-
-const USE_PERMIT = true;
 
 export const stakeDeposit: FlowDeclaration<StakeDepositRequest> = {
   title: "Review & Send Transaction",
@@ -67,115 +66,105 @@ export const stakeDeposit: FlowDeclaration<StakeDepositRequest> = {
     deployUserProxy: {
       name: () => "Initialize Staking",
       Status: TransactionStatus,
-
       async commit({ account, contracts, wagmiConfig }) {
         if (!account) {
           throw new Error("Account address is required");
         }
-
         return writeContract(wagmiConfig, {
           ...contracts.Governance,
           functionName: "deployUserProxy",
         });
       },
-
       async verify({ wagmiConfig, isSafe }, hash) {
         await verifyTransaction(wagmiConfig, hash, isSafe);
       },
     },
 
-    // reset allocations
     resetAllocations: {
       name: () => "Reset Allocations",
       Status: TransactionStatus,
-
       async commit({ account, contracts, wagmiConfig }) {
         if (!account) {
           throw new Error("Account address is required");
         }
-
         const allocated = await graphQuery(
           GovernanceUserAllocated,
           { id: account.toLowerCase() },
         );
-
         return writeContract(wagmiConfig, {
           ...contracts.Governance,
           functionName: "resetAllocations",
           args: [(allocated.governanceUser?.allocated ?? []) as Address[], true],
         });
       },
-
       async verify({ wagmiConfig, isSafe }, hash) {
         await verifyTransaction(wagmiConfig, hash, isSafe);
       },
     },
 
-    // approve via permit
-    permitLqty: {
+    approve: {
       name: () => "Approve LQTY",
-      Status: PermissionStatus,
-
-      async commit({ account, contracts, request, wagmiConfig }) {
+      Status: (props) => {
+        const account = useAccount();
+        return (
+          <TransactionStatus
+            {...props}
+            // don’t use permit for safe transactions
+            approval={account.safeStatus === null ? "all" : "approve-only"}
+          />
+        );
+      },
+      async commit({
+        account,
+        contracts,
+        request,
+        wagmiConfig,
+        preferredApproveMethod,
+        isSafe,
+      }) {
         if (!account) {
           throw new Error("Account address is required");
         }
 
-        const { LqtyToken, Governance } = contracts;
-
         const userProxyAddress = await readContract(wagmiConfig, {
-          ...Governance,
+          ...contracts.Governance,
           functionName: "deriveUserProxyAddress",
           args: [account],
         });
 
-        const { deadline, ...permit } = await signPermit({
-          token: LqtyToken.address,
-          spender: userProxyAddress,
-          value: request.lqtyAmount[0],
-          account,
-          wagmiConfig,
-        });
+        // permit
+        if (preferredApproveMethod === "permit" && !isSafe) {
+          const { deadline, ...permit } = await signPermit({
+            token: contracts.LqtyToken.address,
+            spender: userProxyAddress,
+            value: request.lqtyAmount[0],
+            account,
+            wagmiConfig,
+          });
 
-        return JSON.stringify({
-          ...permit,
-          deadline: Number(deadline),
-          userProxyAddress,
-        });
-      },
-
-      async verify() {
-        // nothing to do
-      },
-    },
-
-    // approve tx
-    approveLqty: {
-      name: () => "Approve LQTY",
-      Status: TransactionStatus,
-
-      async commit({ account, contracts, request, wagmiConfig }) {
-        if (!account) {
-          throw new Error("Account address is required");
+          return "permit:" + JSON.stringify({
+            ...permit,
+            deadline: Number(deadline),
+            userProxyAddress,
+          });
         }
 
-        const { LqtyToken, Governance } = contracts;
-
-        const userProxyAddress = await readContract(wagmiConfig, {
-          ...Governance,
-          functionName: "deriveUserProxyAddress",
-          args: [account],
-        });
-
+        // approve()
         return writeContract(wagmiConfig, {
-          ...LqtyToken,
+          ...contracts.LqtyToken,
           functionName: "approve",
-          args: [userProxyAddress, request.lqtyAmount[0]],
+          args: [
+            userProxyAddress,
+            preferredApproveMethod === "approve-amount"
+              ? request.lqtyAmount[0] // exact amount
+              : maxUint256, // infinite approval
+          ],
         });
       },
-
       async verify({ wagmiConfig, isSafe }, hash) {
-        await verifyTransaction(wagmiConfig, hash, isSafe);
+        if (!hash.startsWith("permit:")) {
+          await verifyTransaction(wagmiConfig, hash, isSafe);
+        }
       },
     },
 
@@ -188,8 +177,11 @@ export const stakeDeposit: FlowDeclaration<StakeDepositRequest> = {
           throw new Error("Account address is required");
         }
 
+        const approveStep = steps?.find((step) => step.id === "approve");
+        const isPermit = approveStep?.artifact?.startsWith("permit:") === true;
+
         // deposit approved LQTY
-        if (!USE_PERMIT) {
+        if (!isPermit) {
           return writeContract(wagmiConfig, {
             ...contracts.Governance,
             functionName: "depositLQTY",
@@ -198,8 +190,9 @@ export const stakeDeposit: FlowDeclaration<StakeDepositRequest> = {
         }
 
         // deposit LQTY via permit
-        const permitStep = steps?.find((step) => step.id === "permitLqty");
-        const { userProxyAddress, ...permit } = JSON.parse(permitStep?.artifact ?? "");
+        const { userProxyAddress, ...permit } = JSON.parse(
+          approveStep?.artifact?.replace(/^permit:/, "") ?? "{}",
+        );
 
         return writeContract(wagmiConfig, {
           ...contracts.Governance,
@@ -262,15 +255,6 @@ export const stakeDeposit: FlowDeclaration<StakeDepositRequest> = {
       steps.push("deployUserProxy");
     }
 
-    // approve via permit
-    if (USE_PERMIT) {
-      return [
-        ...steps,
-        "permitLqty",
-        "stakeDeposit",
-      ];
-    }
-
     // check for allowance
     const lqtyAllowance = await readContract(wagmiConfig, {
       ...contracts.LqtyToken,
@@ -280,7 +264,7 @@ export const stakeDeposit: FlowDeclaration<StakeDepositRequest> = {
 
     // approve
     if (dn.gt(request.lqtyAmount, dnum18(lqtyAllowance))) {
-      steps.push("approveLqty");
+      steps.push("approve");
     }
 
     // stake


### PR DESCRIPTION


- Add `preferredApproveMethod` to the stored state (`"permit"`, `"approve-amount"` or `"approve-infinite"`).
- Add `clearError()` to the object returned by `useTransactionFlow()` (this is used to clear the error when users change their preferred approve method).
- `TransactionStatus` now supports an option to show the preferred approve method selector, which can include the permit or not. This option allows `TransactionStatus` to provide a permission mode, replacing `PermissionStatus`.
- The tx link is now fixed for Safe accounts and point to the Safe app.
- Add preferred approval method to stakeDeposit:
  - Group the different approve steps into one, handling all the approval methods (including infinite which is new).
  - Allow users to change their preferred approval method.
  - When a Safe account is detected, only allow tx-based approvals.
- Dropdown: fully customizable button + popup position.