### PR TITLE
Loan update tweaks

### DIFF
--- a/frontend/app/src/screens/LoanScreen/PanelUpdateBorrowPosition.tsx
+++ b/frontend/app/src/screens/LoanScreen/PanelUpdateBorrowPosition.tsx
@@ -214,11 +214,20 @@ export function PanelUpdateBorrowPosition({
                 }
                 value={
                   <HFlex alignItems="center" gap={8}>
-                    <Amount
-                      format={2}
-                      suffix={` ${collToken.name}`}
-                      value={newLoanDetails.deposit}
-                    />
+                    <div
+                      className={css({
+                        "--color-error": "token(colors.negativeStrong)",
+                      })}
+                      style={{
+                        color: dn.lt(newLoanDetails.deposit, 0) ? "var(--color-error)" : "inherit",
+                      }}
+                    >
+                      <Amount
+                        format={2}
+                        suffix={` ${collToken.name}`}
+                        value={newLoanDetails.deposit}
+                      />
+                    </div>
                     <InfoTooltip heading="Collateral update">
                       <div>
                         Before:{" "}

--- a/frontend/app/src/screens/LoanScreen/PanelUpdateBorrowPosition.tsx
+++ b/frontend/app/src/screens/LoanScreen/PanelUpdateBorrowPosition.tsx
@@ -395,8 +395,10 @@ export function PanelUpdateBorrowPosition({
               },
               {
                 label: "Liquidation price",
-                before: <Amount value={loanDetails.liquidationPrice} />,
-                after: <Amount value={newLoanDetails.liquidationPrice} />,
+                before: <Amount prefix="$" value={loanDetails.liquidationPrice} />,
+                after: newLoanDetails.liquidationPrice
+                  ? <Amount prefix="$" value={newLoanDetails.liquidationPrice} />
+                  : "N/A",
               },
             ]}
           />

--- a/frontend/app/src/screens/LoanScreen/PanelUpdateBorrowPosition.tsx
+++ b/frontend/app/src/screens/LoanScreen/PanelUpdateBorrowPosition.tsx
@@ -389,7 +389,9 @@ export function PanelUpdateBorrowPosition({
               {
                 label: <abbr title="Loan-to-value ratio">LTV</abbr>,
                 before: <Amount value={loanDetails.ltv} percentage />,
-                after: <Amount value={newLoanDetails.ltv} percentage />,
+                after: newLoanDetails.ltv && dn.gt(newLoanDetails.ltv, 0)
+                  ? <Amount value={newLoanDetails.ltv} percentage />
+                  : "N/A",
               },
               {
                 label: "Liquidation price",


### PR DESCRIPTION

- Require sufficient balance to submit (see screenshot).
- Show negative deposit in red.
- Show negative LTV as N/A.
- Show liquidation prices with a $ prefix + show N/A when absent.


![image](https://github.com/user-attachments/assets/1828859c-cd16-4035-bd8a-20cb038be16c)
