### PR TITLE
Transactions & gas strategy improvements

### DIFF
--- a/frontend/app/src/constants.ts
+++ b/frontend/app/src/constants.ts
@@ -5,6 +5,10 @@ import type { CollateralSymbol, RiskLevel } from "@/src/types";
 import { norm } from "@liquity2/uikit";
 import * as dn from "dnum";
 
+export const GAS_MIN_HEADROOM = 100_000;
+export const GAS_RELATIVE_HEADROOM = 0.25;
+export const GAS_ALLOCATE_LQTY_MIN_HEADROOM = 350_000;
+
 export const LOCAL_STORAGE_PREFIX = "liquity2:";
 
 export const LEVERAGE_FACTOR_MIN = 1.1;

--- a/frontend/app/src/tx-flows/claimCollateralSurplus.tsx
+++ b/frontend/app/src/tx-flows/claimCollateralSurplus.tsx
@@ -11,7 +11,6 @@ import { shortenAddress, TokenIcon } from "@liquity2/uikit";
 import { blo } from "blo";
 import Image from "next/image";
 import * as v from "valibot";
-import { writeContract } from "wagmi/actions";
 import { createRequestSchema, verifyTransaction } from "./shared";
 
 const RequestSchema = createRequestSchema(
@@ -176,22 +175,22 @@ export const claimCollateralSurplus: FlowDeclaration<ClaimCollateralSurplusReque
       name: () => "Claim remaining collateral",
       Status: TransactionStatus,
 
-      async commit({ contracts, request, wagmiConfig }) {
-        const { collIndex } = request;
-        const collateral = contracts.collaterals[collIndex];
+      async commit(ctx) {
+        const { collIndex } = ctx.request;
+        const collateral = ctx.contracts.collaterals[collIndex];
         if (!collateral) {
           throw new Error("Invalid collateral index: " + collIndex);
         }
         const { BorrowerOperations } = collateral.contracts;
-        return writeContract(wagmiConfig, {
+        return ctx.writeContract({
           ...BorrowerOperations,
           functionName: "claimCollateral",
           args: [],
         });
       },
 
-      async verify({ wagmiConfig, isSafe }, hash) {
-        await verifyTransaction(wagmiConfig, hash, isSafe);
+      async verify(ctx, hash) {
+        await verifyTransaction(ctx.wagmiConfig, hash, ctx.isSafe);
       },
     },
   },

--- a/frontend/app/src/tx-flows/earnClaimRewards.tsx
+++ b/frontend/app/src/tx-flows/earnClaimRewards.tsx
@@ -9,7 +9,6 @@ import { usePrice } from "@/src/services/Prices";
 import { vPositionEarn } from "@/src/valibot-utils";
 import * as dn from "dnum";
 import * as v from "valibot";
-import { writeContract } from "wagmi/actions";
 import { createRequestSchema, verifyTransaction } from "./shared";
 
 const RequestSchema = createRequestSchema(
@@ -90,23 +89,23 @@ export const earnClaimRewards: FlowDeclaration<EarnClaimRewardsRequest> = {
       name: () => "Claim rewards",
       Status: TransactionStatus,
 
-      async commit({ contracts, request, wagmiConfig }) {
-        const { collIndex } = request.earnPosition;
-        const collateral = contracts.collaterals[collIndex];
+      async commit(ctx) {
+        const { collIndex } = ctx.request.earnPosition;
+        const collateral = ctx.contracts.collaterals[collIndex];
         if (!collateral) {
           throw new Error("Invalid collateral index: " + collIndex);
         }
 
         const { StabilityPool } = collateral.contracts;
-        return writeContract(wagmiConfig, {
+        return ctx.writeContract({
           ...StabilityPool,
           functionName: "withdrawFromSP",
           args: [0n, true],
         });
       },
 
-      async verify({ wagmiConfig, isSafe }, hash) {
-        await verifyTransaction(wagmiConfig, hash, isSafe);
+      async verify(ctx, hash) {
+        await verifyTransaction(ctx.wagmiConfig, hash, ctx.isSafe);
       },
     },
   },

--- a/frontend/app/src/tx-flows/earnDeposit.tsx
+++ b/frontend/app/src/tx-flows/earnDeposit.tsx
@@ -8,7 +8,6 @@ import { usePrice } from "@/src/services/Prices";
 import { vCollIndex, vPositionEarn } from "@/src/valibot-utils";
 import * as dn from "dnum";
 import * as v from "valibot";
-import { writeContract } from "wagmi/actions";
 import { createRequestSchema, verifyTransaction } from "./shared";
 
 const RequestSchema = createRequestSchema(
@@ -72,28 +71,28 @@ export const earnDeposit: FlowDeclaration<EarnDepositRequest> = {
       name: () => "Add deposit",
       Status: TransactionStatus,
 
-      async commit({ contracts, request, wagmiConfig }) {
-        const collateral = contracts.collaterals[request.collIndex];
+      async commit(ctx) {
+        const collateral = ctx.contracts.collaterals[ctx.request.collIndex];
         if (!collateral) {
-          throw new Error("Invalid collateral index: " + request.collIndex);
+          throw new Error("Invalid collateral index: " + ctx.request.collIndex);
         }
         const boldAmount = dn.sub(
-          request.earnPosition.deposit,
-          request.prevEarnPosition?.deposit ?? dn.from(0, 18),
+          ctx.request.earnPosition.deposit,
+          ctx.request.prevEarnPosition?.deposit ?? dn.from(0, 18),
         );
 
-        return writeContract(wagmiConfig, {
+        return ctx.writeContract({
           ...collateral.contracts.StabilityPool,
           functionName: "provideToSP",
           args: [
             boldAmount[0],
-            request.claim,
+            ctx.request.claim,
           ],
         });
       },
 
-      async verify({ wagmiConfig, isSafe }, hash) {
-        await verifyTransaction(wagmiConfig, hash, isSafe);
+      async verify(ctx, hash) {
+        await verifyTransaction(ctx.wagmiConfig, hash, ctx.isSafe);
       },
     },
   },

--- a/frontend/app/src/tx-flows/openBorrowPosition.tsx
+++ b/frontend/app/src/tx-flows/openBorrowPosition.tsx
@@ -22,7 +22,7 @@ import { ADDRESS_ZERO, InfoTooltip, shortenAddress } from "@liquity2/uikit";
 import * as dn from "dnum";
 import * as v from "valibot";
 import { maxUint256, parseEventLogs } from "viem";
-import { readContract, writeContract } from "wagmi/actions";
+import { readContract } from "wagmi/actions";
 import { createRequestSchema, verifyTransaction } from "./shared";
 
 const RequestSchema = createRequestSchema(
@@ -188,10 +188,10 @@ export const openBorrowPosition: FlowDeclaration<OpenBorrowPositionRequest> = {
   steps: {
     // Approve LST
     approveLst: {
-      name: ({ contracts, request }) => {
-        const collateral = contracts.collaterals[request.collIndex];
+      name: (ctx) => {
+        const collateral = ctx.contracts.collaterals[ctx.request.collIndex];
         if (!collateral) {
-          throw new Error(`Invalid collateral index: ${request.collIndex}`);
+          throw new Error(`Invalid collateral index: ${ctx.request.collIndex}`);
         }
         return `Approve ${collateral.symbol}`;
       },
@@ -201,31 +201,26 @@ export const openBorrowPosition: FlowDeclaration<OpenBorrowPositionRequest> = {
           approval="approve-only"
         />
       ),
-      async commit({
-        contracts,
-        request,
-        wagmiConfig,
-        preferredApproveMethod,
-      }) {
-        const collateral = contracts.collaterals[request.collIndex];
+      async commit(ctx) {
+        const collateral = ctx.contracts.collaterals[ctx.request.collIndex];
         if (!collateral) {
-          throw new Error(`Invalid collateral index: ${request.collIndex}`);
+          throw new Error(`Invalid collateral index: ${ctx.request.collIndex}`);
         }
         const { LeverageLSTZapper, CollToken } = collateral.contracts;
 
-        return writeContract(wagmiConfig, {
+        return ctx.writeContract({
           ...CollToken,
           functionName: "approve",
           args: [
             LeverageLSTZapper.address,
-            preferredApproveMethod === "approve-infinite"
+            ctx.preferredApproveMethod === "approve-infinite"
               ? maxUint256 // infinite approval
-              : request.collAmount[0], // exact amount
+              : ctx.request.collAmount[0], // exact amount
           ],
         });
       },
-      async verify({ wagmiConfig, isSafe }, hash) {
-        await verifyTransaction(wagmiConfig, hash, isSafe);
+      async verify(ctx, hash) {
+        await verifyTransaction(ctx.wagmiConfig, hash, ctx.isSafe);
       },
     },
 
@@ -234,36 +229,36 @@ export const openBorrowPosition: FlowDeclaration<OpenBorrowPositionRequest> = {
       name: () => "Open Position",
       Status: TransactionStatus,
 
-      async commit({ contracts, request, wagmiConfig }) {
-        const collateral = contracts.collaterals[request.collIndex];
+      async commit(ctx) {
+        const collateral = ctx.contracts.collaterals[ctx.request.collIndex];
         if (!collateral) {
-          throw new Error(`Invalid collateral index: ${request.collIndex}`);
+          throw new Error(`Invalid collateral index: ${ctx.request.collIndex}`);
         }
 
         const { upperHint, lowerHint } = await getTroveOperationHints({
-          wagmiConfig,
-          contracts,
-          collIndex: request.collIndex,
-          interestRate: request.annualInterestRate[0],
+          wagmiConfig: ctx.wagmiConfig,
+          contracts: ctx.contracts,
+          collIndex: ctx.request.collIndex,
+          interestRate: ctx.request.annualInterestRate[0],
         });
 
-        return writeContract(wagmiConfig, {
+        return ctx.writeContract({
           ...collateral.contracts.LeverageLSTZapper,
           functionName: "openTroveWithRawETH" as const,
           args: [{
-            owner: request.owner,
-            ownerIndex: BigInt(request.ownerIndex),
-            collAmount: request.collAmount[0],
-            boldAmount: request.boldAmount[0],
+            owner: ctx.request.owner,
+            ownerIndex: BigInt(ctx.request.ownerIndex),
+            collAmount: ctx.request.collAmount[0],
+            boldAmount: ctx.request.boldAmount[0],
             upperHint,
             lowerHint,
-            annualInterestRate: request.interestRateDelegate
+            annualInterestRate: ctx.request.interestRateDelegate
               ? 0n
-              : request.annualInterestRate[0],
-            batchManager: request.interestRateDelegate
-              ? request.interestRateDelegate[0]
+              : ctx.request.annualInterestRate[0],
+            batchManager: ctx.request.interestRateDelegate
+              ? ctx.request.interestRateDelegate[0]
               : ADDRESS_ZERO,
-            maxUpfrontFee: request.maxUpfrontFee[0],
+            maxUpfrontFee: ctx.request.maxUpfrontFee[0],
             addManager: ADDRESS_ZERO,
             removeManager: ADDRESS_ZERO,
             receiver: ADDRESS_ZERO,
@@ -272,13 +267,13 @@ export const openBorrowPosition: FlowDeclaration<OpenBorrowPositionRequest> = {
         });
       },
 
-      async verify({ contracts, request, wagmiConfig, isSafe }, hash) {
-        const receipt = await verifyTransaction(wagmiConfig, hash, isSafe);
+      async verify(ctx, hash) {
+        const receipt = await verifyTransaction(ctx.wagmiConfig, hash, ctx.isSafe);
 
         // extract trove ID from logs
-        const collateral = contracts.collaterals[request.collIndex];
+        const collateral = ctx.contracts.collaterals[ctx.request.collIndex];
         if (!collateral) {
-          throw new Error(`Invalid collateral index: ${request.collIndex}`);
+          throw new Error(`Invalid collateral index: ${ctx.request.collIndex}`);
         }
         const [troveOperation] = parseEventLogs({
           abi: collateral.contracts.TroveManager.abi,
@@ -291,7 +286,7 @@ export const openBorrowPosition: FlowDeclaration<OpenBorrowPositionRequest> = {
         }
 
         const prefixedTroveId = getPrefixedTroveId(
-          request.collIndex,
+          ctx.request.collIndex,
           `0x${troveOperation.args._troveId.toString(16)}`,
         );
 
@@ -313,41 +308,41 @@ export const openBorrowPosition: FlowDeclaration<OpenBorrowPositionRequest> = {
       name: () => "Open Position",
       Status: TransactionStatus,
 
-      async commit({ contracts, request, wagmiConfig }) {
-        const collateral = contracts.collaterals[request.collIndex];
+      async commit(ctx) {
+        const collateral = ctx.contracts.collaterals[ctx.request.collIndex];
         if (!collateral) {
-          throw new Error(`Invalid collateral index: ${request.collIndex}`);
+          throw new Error(`Invalid collateral index: ${ctx.request.collIndex}`);
         }
 
         const { upperHint, lowerHint } = await getTroveOperationHints({
-          wagmiConfig,
-          contracts,
-          collIndex: request.collIndex,
-          interestRate: request.annualInterestRate[0],
+          wagmiConfig: ctx.wagmiConfig,
+          contracts: ctx.contracts,
+          collIndex: ctx.request.collIndex,
+          interestRate: ctx.request.annualInterestRate[0],
         });
 
-        return writeContract(wagmiConfig, {
+        return ctx.writeContract({
           ...collateral.contracts.LeverageWETHZapper,
           functionName: "openTroveWithRawETH",
           args: [{
-            owner: request.owner,
-            ownerIndex: BigInt(request.ownerIndex),
+            owner: ctx.request.owner,
+            ownerIndex: BigInt(ctx.request.ownerIndex),
             collAmount: 0n,
-            boldAmount: request.boldAmount[0],
+            boldAmount: ctx.request.boldAmount[0],
             upperHint,
             lowerHint,
-            annualInterestRate: request.interestRateDelegate
+            annualInterestRate: ctx.request.interestRateDelegate
               ? 0n
-              : request.annualInterestRate[0],
-            batchManager: request.interestRateDelegate
-              ? request.interestRateDelegate[0]
+              : ctx.request.annualInterestRate[0],
+            batchManager: ctx.request.interestRateDelegate
+              ? ctx.request.interestRateDelegate[0]
               : ADDRESS_ZERO,
-            maxUpfrontFee: request.maxUpfrontFee[0],
+            maxUpfrontFee: ctx.request.maxUpfrontFee[0],
             addManager: ADDRESS_ZERO,
             removeManager: ADDRESS_ZERO,
             receiver: ADDRESS_ZERO,
           }],
-          value: request.collAmount[0] + ETH_GAS_COMPENSATION[0],
+          value: ctx.request.collAmount[0] + ETH_GAS_COMPENSATION[0],
         });
       },
 
@@ -358,14 +353,14 @@ export const openBorrowPosition: FlowDeclaration<OpenBorrowPositionRequest> = {
     },
   },
 
-  async getSteps({ account, contracts, request, wagmiConfig }) {
-    if (!account) {
+  async getSteps(ctx) {
+    if (!ctx.account) {
       throw new Error("Account address is required");
     }
 
-    const collateral = contracts.collaterals[request.collIndex];
+    const collateral = ctx.contracts.collaterals[ctx.request.collIndex];
     if (!collateral) {
-      throw new Error(`Invalid collateral index: ${request.collIndex}`);
+      throw new Error(`Invalid collateral index: ${ctx.request.collIndex}`);
     }
     const { LeverageLSTZapper, CollToken } = collateral.contracts;
 
@@ -375,15 +370,15 @@ export const openBorrowPosition: FlowDeclaration<OpenBorrowPositionRequest> = {
     }
 
     // Check if approval is needed
-    const allowance = await readContract(wagmiConfig, {
+    const allowance = await readContract(ctx.wagmiConfig, {
       ...CollToken,
       functionName: "allowance",
-      args: [account, LeverageLSTZapper.address],
+      args: [ctx.account, LeverageLSTZapper.address],
     });
 
     const steps: string[] = [];
 
-    if (allowance < request.collAmount[0]) {
+    if (allowance < ctx.request.collAmount[0]) {
       steps.push("approveLst");
     }
 

--- a/frontend/app/src/tx-flows/openLeveragePosition.tsx
+++ b/frontend/app/src/tx-flows/openLeveragePosition.tsx
@@ -24,7 +24,7 @@ import { ADDRESS_ZERO, InfoTooltip } from "@liquity2/uikit";
 import * as dn from "dnum";
 import * as v from "valibot";
 import { maxUint256, parseEventLogs } from "viem";
-import { readContract, writeContract } from "wagmi/actions";
+import { readContract } from "wagmi/actions";
 import { createRequestSchema, verifyTransaction } from "./shared";
 
 const RequestSchema = createRequestSchema(
@@ -154,33 +154,28 @@ export const openLeveragePosition: FlowDeclaration<OpenLeveragePositionRequest> 
           approval="approve-only"
         />
       ),
-      async commit({
-        contracts,
-        request,
-        wagmiConfig,
-        preferredApproveMethod,
-      }) {
-        const { loan } = request;
-        const initialDeposit = dn.div(loan.deposit, request.leverageFactor);
-        const collateral = contracts.collaterals[loan.collIndex];
+      async commit(ctx) {
+        const { loan } = ctx.request;
+        const initialDeposit = dn.div(loan.deposit, ctx.request.leverageFactor);
+        const collateral = ctx.contracts.collaterals[loan.collIndex];
         if (!collateral) {
           throw new Error("Invalid collateral index: " + loan.collIndex);
         }
         const { LeverageLSTZapper, CollToken } = collateral.contracts;
 
-        return writeContract(wagmiConfig, {
+        return ctx.writeContract({
           ...CollToken,
           functionName: "approve",
           args: [
             LeverageLSTZapper.address,
-            preferredApproveMethod === "approve-infinite"
+            ctx.preferredApproveMethod === "approve-infinite"
               ? maxUint256 // infinite approval
               : initialDeposit[0], // exact amount
           ],
         });
       },
-      async verify({ wagmiConfig, isSafe }, hash) {
-        await verifyTransaction(wagmiConfig, hash, isSafe);
+      async verify(ctx, hash) {
+        await verifyTransaction(ctx.wagmiConfig, hash, ctx.isSafe);
       },
     },
 
@@ -188,10 +183,10 @@ export const openLeveragePosition: FlowDeclaration<OpenLeveragePositionRequest> 
       name: () => "Open Multiply Position",
       Status: TransactionStatus,
 
-      async commit({ contracts, request, wagmiConfig }) {
-        const { loan } = request;
-        const initialDeposit = dn.div(loan.deposit, request.leverageFactor);
-        const collateral = contracts.collaterals[loan.collIndex];
+      async commit(ctx) {
+        const { loan } = ctx.request;
+        const initialDeposit = dn.div(loan.deposit, ctx.request.leverageFactor);
+        const collateral = ctx.contracts.collaterals[loan.collIndex];
         if (!collateral) {
           throw new Error("Invalid collateral index: " + loan.collIndex);
         }
@@ -200,20 +195,20 @@ export const openLeveragePosition: FlowDeclaration<OpenLeveragePositionRequest> 
         const openLeveragedParams = await getOpenLeveragedTroveParams(
           loan.collIndex,
           initialDeposit[0],
-          request.leverageFactor,
-          wagmiConfig,
+          ctx.request.leverageFactor,
+          ctx.wagmiConfig,
         );
 
         const { upperHint, lowerHint } = await getTroveOperationHints({
-          wagmiConfig,
-          contracts,
+          wagmiConfig: ctx.wagmiConfig,
+          contracts: ctx.contracts,
           collIndex: loan.collIndex,
           interestRate: loan.interestRate[0],
         });
 
         const txParams = {
           owner: loan.borrower,
-          ownerIndex: BigInt(request.ownerIndex),
+          ownerIndex: BigInt(ctx.request.ownerIndex),
           collAmount: initialDeposit[0],
           flashLoanAmount: openLeveragedParams.flashLoanAmount,
           boldAmount: openLeveragedParams.effectiveBoldAmount,
@@ -229,7 +224,7 @@ export const openLeveragePosition: FlowDeclaration<OpenLeveragePositionRequest> 
 
         // ETH collateral case
         if (collateral.symbol === "ETH") {
-          return writeContract(wagmiConfig, {
+          return ctx.writeContract({
             ...LeverageWETHZapper,
             functionName: "openLeveragedTroveWithRawETH",
             args: [txParams],
@@ -238,7 +233,7 @@ export const openLeveragePosition: FlowDeclaration<OpenLeveragePositionRequest> 
         }
 
         // LST collateral case
-        return writeContract(wagmiConfig, {
+        return ctx.writeContract({
           ...LeverageLSTZapper,
           functionName: "openLeveragedTroveWithRawETH",
           args: [txParams],
@@ -246,16 +241,16 @@ export const openLeveragePosition: FlowDeclaration<OpenLeveragePositionRequest> 
         });
       },
 
-      async verify({ contracts, request, wagmiConfig, isSafe }, hash) {
-        const receipt = await verifyTransaction(wagmiConfig, hash, isSafe);
+      async verify(ctx, hash) {
+        const receipt = await verifyTransaction(ctx.wagmiConfig, hash, ctx.isSafe);
 
         // Extract trove ID from logs
-        const collToken = getCollToken(request.loan.collIndex);
+        const collToken = getCollToken(ctx.request.loan.collIndex);
         if (!collToken) throw new Error("Invalid collateral index");
 
-        const collateral = contracts.collaterals[request.loan.collIndex];
+        const collateral = ctx.contracts.collaterals[ctx.request.loan.collIndex];
         if (!collateral) {
-          throw new Error("Invalid collateral index: " + request.loan.collIndex);
+          throw new Error("Invalid collateral index: " + ctx.request.loan.collIndex);
         }
 
         const [troveOperation] = parseEventLogs({
@@ -270,7 +265,7 @@ export const openLeveragePosition: FlowDeclaration<OpenLeveragePositionRequest> 
 
         // Wait for trove to appear in subgraph
         const prefixedTroveId = getPrefixedTroveId(
-          request.loan.collIndex,
+          ctx.request.loan.collIndex,
           `0x${troveOperation.args._troveId.toString(16)}`,
         );
 
@@ -285,17 +280,12 @@ export const openLeveragePosition: FlowDeclaration<OpenLeveragePositionRequest> 
     },
   },
 
-  async getSteps({
-    account,
-    contracts,
-    request,
-    wagmiConfig,
-  }) {
-    if (!account) {
+  async getSteps(ctx) {
+    if (!ctx.account) {
       throw new Error("Account address is required");
     }
 
-    const { loan } = request;
+    const { loan } = ctx.request;
     const collToken = getCollToken(loan.collIndex);
     if (!collToken) {
       throw new Error("Invalid collateral index: " + loan.collIndex);
@@ -306,7 +296,7 @@ export const openLeveragePosition: FlowDeclaration<OpenLeveragePositionRequest> 
       return ["openLeveragedTrove"];
     }
 
-    const { collaterals } = contracts;
+    const { collaterals } = ctx.contracts;
     const collateral = collaterals[loan.collIndex];
     if (!collateral) {
       throw new Error("Invalid collateral index: " + loan.collIndex);
@@ -314,16 +304,16 @@ export const openLeveragePosition: FlowDeclaration<OpenLeveragePositionRequest> 
     const { LeverageLSTZapper, CollToken } = collateral.contracts;
 
     const allowance = dnum18(
-      await readContract(wagmiConfig, {
+      await readContract(ctx.wagmiConfig, {
         ...CollToken,
         functionName: "allowance",
-        args: [account, LeverageLSTZapper.address],
+        args: [ctx.account, LeverageLSTZapper.address],
       }),
     );
 
     const steps: string[] = [];
 
-    const initialDeposit = dn.div(loan.deposit, request.leverageFactor);
+    const initialDeposit = dn.div(loan.deposit, ctx.request.leverageFactor);
     if (dn.lt(allowance, initialDeposit)) {
       steps.push("approveLst");
     }

--- a/frontend/app/src/tx-flows/stakeClaimRewards.tsx
+++ b/frontend/app/src/tx-flows/stakeClaimRewards.tsx
@@ -8,7 +8,6 @@ import { usePrice } from "@/src/services/Prices";
 import { vPositionStake } from "@/src/valibot-utils";
 import * as dn from "dnum";
 import * as v from "valibot";
-import { writeContract } from "wagmi/actions";
 import { createRequestSchema, verifyTransaction } from "./shared";
 
 const RequestSchema = createRequestSchema(
@@ -85,16 +84,16 @@ export const stakeClaimRewards: FlowDeclaration<StakeClaimRewardsRequest> = {
       name: () => "Claim rewards",
       Status: TransactionStatus,
 
-      async commit({ contracts, wagmiConfig, request }) {
-        return writeContract(wagmiConfig, {
-          ...contracts.Governance,
+      async commit(ctx) {
+        return ctx.writeContract({
+          ...ctx.contracts.Governance,
           functionName: "claimFromStakingV1",
-          args: [request.stakePosition.owner], // address to receive the payout
+          args: [ctx.request.stakePosition.owner], // address to receive the payout
         });
       },
 
-      async verify({ wagmiConfig, isSafe }, hash) {
-        await verifyTransaction(wagmiConfig, hash, isSafe);
+      async verify(ctx, hash) {
+        await verifyTransaction(ctx.wagmiConfig, hash, ctx.isSafe);
       },
     },
   },

--- a/frontend/app/src/tx-flows/updateBorrowPosition.tsx
+++ b/frontend/app/src/tx-flows/updateBorrowPosition.tsx
@@ -13,7 +13,6 @@ import * as dn from "dnum";
 import { match, P } from "ts-pattern";
 import * as v from "valibot";
 import { maxUint256 } from "viem";
-import { readContract, writeContract } from "wagmi/actions";
 import { createRequestSchema, verifyTransaction, verifyTroveUpdate } from "./shared";
 
 const RequestSchema = createRequestSchema(
@@ -141,34 +140,29 @@ export const updateBorrowPosition: FlowDeclaration<UpdateBorrowPositionRequest> 
           approval="approve-only"
         />
       ),
-      async commit({
-        contracts,
-        request,
-        wagmiConfig,
-        preferredApproveMethod,
-      }) {
-        const debtChange = getDebtChange(request.loan, request.prevLoan);
-        const collateral = contracts.collaterals[request.loan.collIndex];
+      async commit(ctx) {
+        const debtChange = getDebtChange(ctx.request.loan, ctx.request.prevLoan);
+        const collateral = ctx.contracts.collaterals[ctx.request.loan.collIndex];
         if (!collateral) {
-          throw new Error("Invalid collateral index: " + request.loan.collIndex);
+          throw new Error("Invalid collateral index: " + ctx.request.loan.collIndex);
         }
         const Controller = collateral.symbol === "ETH"
           ? collateral.contracts.LeverageWETHZapper
           : collateral.contracts.LeverageLSTZapper;
 
-        return writeContract(wagmiConfig, {
-          ...contracts.BoldToken,
+        return ctx.writeContract({
+          ...ctx.contracts.BoldToken,
           functionName: "approve",
           args: [
             Controller.address,
-            preferredApproveMethod === "approve-infinite"
+            ctx.preferredApproveMethod === "approve-infinite"
               ? maxUint256 // infinite approval
               : dn.abs(debtChange)[0], // exact amount
           ],
         });
       },
-      async verify({ wagmiConfig, isSafe }, hash) {
-        await verifyTransaction(wagmiConfig, hash, isSafe);
+      async verify(ctx, hash) {
+        await verifyTransaction(ctx.wagmiConfig, hash, ctx.isSafe);
       },
     },
 
@@ -186,34 +180,29 @@ export const updateBorrowPosition: FlowDeclaration<UpdateBorrowPositionRequest> 
           approval="approve-only"
         />
       ),
-      async commit({
-        contracts,
-        request,
-        wagmiConfig,
-        preferredApproveMethod,
-      }) {
-        const collChange = getCollChange(request.loan, request.prevLoan);
+      async commit(ctx) {
+        const collChange = getCollChange(ctx.request.loan, ctx.request.prevLoan);
 
-        const collateral = contracts.collaterals[request.loan.collIndex];
+        const collateral = ctx.contracts.collaterals[ctx.request.loan.collIndex];
         if (!collateral) {
-          throw new Error("Invalid collateral index: " + request.loan.collIndex);
+          throw new Error("Invalid collateral index: " + ctx.request.loan.collIndex);
         }
 
         const Controller = collateral.contracts.LeverageLSTZapper;
 
-        return writeContract(wagmiConfig, {
+        return ctx.writeContract({
           ...collateral.contracts.CollToken,
           functionName: "approve",
           args: [
             Controller.address,
-            preferredApproveMethod === "approve-infinite"
+            ctx.preferredApproveMethod === "approve-infinite"
               ? maxUint256 // infinite approval
               : dn.abs(collChange)[0], // exact amount
           ],
         });
       },
-      async verify({ wagmiConfig, isSafe }, hash) {
-        await verifyTransaction(wagmiConfig, hash, isSafe);
+      async verify(ctx, hash) {
+        await verifyTransaction(ctx.wagmiConfig, hash, ctx.isSafe);
       },
     },
 
@@ -222,32 +211,19 @@ export const updateBorrowPosition: FlowDeclaration<UpdateBorrowPositionRequest> 
       name: () => "Update Position",
       Status: TransactionStatus,
 
-      async commit({ contracts, request, wagmiConfig }) {
-        const { loan, maxUpfrontFee } = request;
-        const collChange = getCollChange(loan, request.prevLoan);
-        const debtChange = getDebtChange(loan, request.prevLoan);
-        const collateral = contracts.collaterals[loan.collIndex];
+      async commit(ctx) {
+        const { loan, maxUpfrontFee } = ctx.request;
+        const collChange = getCollChange(loan, ctx.request.prevLoan);
+        const debtChange = getDebtChange(loan, ctx.request.prevLoan);
+        const collateral = ctx.contracts.collaterals[loan.collIndex];
         if (!collateral) {
           throw new Error("Invalid collateral index: " + loan.collIndex);
         }
-
         if (collateral.symbol === "ETH") {
-          return writeContract(wagmiConfig, {
-            ...collateral.contracts.LeverageWETHZapper,
-            functionName: "adjustTroveWithRawETH",
-            args: [
-              BigInt(loan.troveId),
-              dn.abs(collChange)[0],
-              !dn.lt(collChange, 0n),
-              dn.abs(debtChange)[0],
-              !dn.lt(debtChange, 0n),
-              maxUpfrontFee[0],
-            ],
-            value: dn.gt(collChange, 0n) ? collChange[0] : 0n,
-          });
+          throw new Error("ETH collateral not supported for adjustTrove");
         }
 
-        return writeContract(wagmiConfig, {
+        return ctx.writeContract({
           ...collateral.contracts.LeverageLSTZapper,
           functionName: "adjustTrove",
           args: [
@@ -261,57 +237,57 @@ export const updateBorrowPosition: FlowDeclaration<UpdateBorrowPositionRequest> 
         });
       },
 
-      async verify({ request, wagmiConfig }, hash) {
-        await verifyTroveUpdate(wagmiConfig, hash, request.loan);
+      async verify(ctx, hash) {
+        await verifyTroveUpdate(ctx.wagmiConfig, hash, ctx.request.loan);
       },
     },
 
     depositBold: {
-      name: () => "Update Position",
+      name: () => "Repay BOLD",
       Status: TransactionStatus,
 
-      async commit({ contracts, request, wagmiConfig }) {
-        const { loan } = request;
-        const debtChange = getDebtChange(loan, request.prevLoan);
-        const collateral = contracts.collaterals[loan.collIndex];
+      async commit(ctx) {
+        const { loan } = ctx.request;
+        const debtChange = getDebtChange(loan, ctx.request.prevLoan);
+        const collateral = ctx.contracts.collaterals[loan.collIndex];
         if (!collateral) {
           throw new Error("Invalid collateral index: " + loan.collIndex);
         }
 
         if (collateral.symbol === "ETH") {
-          return writeContract(wagmiConfig, {
+          return ctx.writeContract({
             ...collateral.contracts.LeverageWETHZapper,
             functionName: "repayBold",
             args: [BigInt(loan.troveId), dn.abs(debtChange)[0]],
           });
         }
 
-        return writeContract(wagmiConfig, {
+        return ctx.writeContract({
           ...collateral.contracts.LeverageLSTZapper,
           functionName: "repayBold",
           args: [BigInt(loan.troveId), dn.abs(debtChange)[0]],
         });
       },
 
-      async verify({ request, wagmiConfig }, hash) {
-        await verifyTroveUpdate(wagmiConfig, hash, request.loan);
+      async verify(ctx, hash) {
+        await verifyTroveUpdate(ctx.wagmiConfig, hash, ctx.request.loan);
       },
     },
 
     depositColl: {
-      name: () => "Update Position",
+      name: () => "Deposit Collateral",
       Status: TransactionStatus,
 
-      async commit({ contracts, request, wagmiConfig }) {
-        const { loan } = request;
-        const collChange = getCollChange(loan, request.prevLoan);
-        const collateral = contracts.collaterals[loan.collIndex];
+      async commit(ctx) {
+        const { loan } = ctx.request;
+        const collChange = getCollChange(loan, ctx.request.prevLoan);
+        const collateral = ctx.contracts.collaterals[loan.collIndex];
         if (!collateral) {
           throw new Error("Invalid collateral index: " + loan.collIndex);
         }
 
         if (collateral.symbol === "ETH") {
-          return writeContract(wagmiConfig, {
+          return ctx.writeContract({
             ...collateral.contracts.LeverageWETHZapper,
             functionName: "addCollWithRawETH",
             args: [BigInt(loan.troveId)],
@@ -319,114 +295,117 @@ export const updateBorrowPosition: FlowDeclaration<UpdateBorrowPositionRequest> 
           });
         }
 
-        return writeContract(wagmiConfig, {
+        return ctx.writeContract({
           ...collateral.contracts.LeverageLSTZapper,
           functionName: "addColl",
           args: [BigInt(loan.troveId), dn.abs(collChange)[0]],
         });
       },
 
-      async verify({ request, wagmiConfig }, hash) {
-        await verifyTroveUpdate(wagmiConfig, hash, request.loan);
+      async verify(ctx, hash) {
+        await verifyTroveUpdate(ctx.wagmiConfig, hash, ctx.request.loan);
       },
     },
 
     withdrawBold: {
-      name: () => "Update Position",
+      name: () => "Borrow BOLD",
       Status: TransactionStatus,
 
-      async commit({ contracts, request, wagmiConfig }) {
-        const { loan, maxUpfrontFee } = request;
-        const debtChange = getDebtChange(loan, request.prevLoan);
-        const collateral = contracts.collaterals[loan.collIndex];
+      async commit(ctx) {
+        const { loan, maxUpfrontFee } = ctx.request;
+        const debtChange = getDebtChange(loan, ctx.request.prevLoan);
+        const collateral = ctx.contracts.collaterals[loan.collIndex];
         if (!collateral) {
           throw new Error("Invalid collateral index: " + loan.collIndex);
         }
 
         if (collateral.symbol === "ETH") {
-          return writeContract(wagmiConfig, {
+          return ctx.writeContract({
             ...collateral.contracts.LeverageWETHZapper,
             functionName: "withdrawBold",
             args: [BigInt(loan.troveId), dn.abs(debtChange)[0], maxUpfrontFee[0]],
           });
         }
 
-        return writeContract(wagmiConfig, {
+        return ctx.writeContract({
           ...collateral.contracts.LeverageLSTZapper,
           functionName: "withdrawBold",
           args: [BigInt(loan.troveId), dn.abs(debtChange)[0], maxUpfrontFee[0]],
         });
       },
 
-      async verify({ request, wagmiConfig }, hash) {
-        await verifyTroveUpdate(wagmiConfig, hash, request.loan);
+      async verify(ctx, hash) {
+        await verifyTroveUpdate(ctx.wagmiConfig, hash, ctx.request.loan);
       },
     },
 
     withdrawColl: {
-      name: () => "Update Position",
+      name: () => "Withdraw Collateral",
       Status: TransactionStatus,
 
-      async commit({ contracts, request, wagmiConfig }) {
-        const { loan } = request;
-        const collChange = getCollChange(loan, request.prevLoan);
-        const collateral = contracts.collaterals[loan.collIndex];
+      async commit(ctx) {
+        const { loan } = ctx.request;
+        const collChange = getCollChange(loan, ctx.request.prevLoan);
+        const collateral = ctx.contracts.collaterals[loan.collIndex];
         if (!collateral) {
           throw new Error("Invalid collateral index: " + loan.collIndex);
         }
 
         if (collateral.symbol === "ETH") {
-          return writeContract(wagmiConfig, {
+          return ctx.writeContract({
             ...collateral.contracts.LeverageWETHZapper,
             functionName: "withdrawCollToRawETH",
             args: [BigInt(loan.troveId), dn.abs(collChange)[0]],
           });
         }
 
-        return writeContract(wagmiConfig, {
+        return ctx.writeContract({
           ...collateral.contracts.LeverageLSTZapper,
           functionName: "withdrawColl",
           args: [BigInt(loan.troveId), dn.abs(collChange)[0]],
         });
       },
 
-      async verify({ request, wagmiConfig }, hash) {
-        await verifyTroveUpdate(wagmiConfig, hash, request.loan);
+      async verify(ctx, hash) {
+        await verifyTroveUpdate(ctx.wagmiConfig, hash, ctx.request.loan);
       },
     },
   },
 
-  async getSteps({ account, contracts, request, wagmiConfig }) {
-    const debtChange = getDebtChange(request.loan, request.prevLoan);
-    const collChange = getCollChange(request.loan, request.prevLoan);
-    const coll = contracts.collaterals[request.loan.collIndex];
+  async getSteps(ctx) {
+    if (!ctx.account) {
+      throw new Error("Account address is required");
+    }
+
+    const debtChange = getDebtChange(ctx.request.loan, ctx.request.prevLoan);
+    const collChange = getCollChange(ctx.request.loan, ctx.request.prevLoan);
+    const coll = ctx.contracts.collaterals[ctx.request.loan.collIndex];
     if (!coll) {
-      throw new Error("Invalid collateral index: " + request.loan.collIndex);
+      throw new Error("Invalid collateral index: " + ctx.request.loan.collIndex);
     }
 
     const Controller = coll.symbol === "ETH"
       ? coll.contracts.LeverageWETHZapper
       : coll.contracts.LeverageLSTZapper;
 
-    if (!account) {
-      throw new Error("Account address is required");
-    }
-
-    const isBoldApproved = !dn.lt(debtChange, 0) || !dn.gt(dn.abs(debtChange), [
-      await readContract(wagmiConfig, {
-        ...contracts.BoldToken,
-        functionName: "allowance",
-        args: [account, Controller.address],
-      }) ?? 0n,
-      18,
-    ]);
+    const isBoldApproved = !dn.lt(debtChange, 0) || !dn.gt(
+      dn.abs(debtChange),
+      [
+        await ctx.readContract({
+          ...ctx.contracts.BoldToken,
+          functionName: "allowance",
+          args: [ctx.account, Controller.address],
+        }) ?? 0n,
+        18,
+      ],
+    );
 
     // Collateral token needs to be approved if collChange > 0 and collToken != "ETH" (no LeverageWETHZapper)
     const isCollApproved = coll.symbol === "ETH" || !dn.gt(collChange, 0) || !dn.gt(collChange, [
-      await readContract(wagmiConfig, {
+      await ctx.readContract({
         ...coll.contracts.CollToken,
         functionName: "allowance",
-        args: [account, Controller.address],
+        args: [ctx.account, Controller.address],
       }) ?? 0n,
       18,
     ]);
@@ -436,9 +415,7 @@ export const updateBorrowPosition: FlowDeclaration<UpdateBorrowPositionRequest> 
     if (!isBoldApproved) steps.push("approveBold");
     if (!isCollApproved) steps.push("approveColl");
 
-    steps.push(getFinalStep(request));
-
-    return steps;
+    return steps.concat(getFinalSteps(ctx.request, coll.symbol));
   },
 
   parseRequest(request) {
@@ -460,26 +437,34 @@ function getCollChange(
   return dn.sub(loan.deposit, prevLoan.deposit);
 }
 
-function getFinalStep(
+function getFinalSteps(
   request: UpdateBorrowPositionRequest,
-): "adjustTrove" | "depositBold" | "depositColl" | "withdrawBold" | "withdrawColl" {
+  collSymbol: string,
+): ("adjustTrove" | "depositBold" | "depositColl" | "withdrawBold" | "withdrawColl")[] {
   const collChange = getCollChange(request.loan, request.prevLoan);
   const debtChange = getDebtChange(request.loan, request.prevLoan);
 
   // both coll and debt change => adjust trove
-  if (!dn.eq(collChange, 0) && !dn.eq(debtChange, 0)) return "adjustTrove";
+  if (!dn.eq(collChange, 0) && !dn.eq(debtChange, 0)) {
+    if (collSymbol === "ETH") {
+      return dn.gt(collChange, 0)
+        ? ["depositColl", dn.gt(debtChange, 0) ? "withdrawBold" : "depositBold"]
+        : [dn.gt(debtChange, 0) ? "withdrawBold" : "depositBold", "withdrawColl"];
+    }
+    return ["adjustTrove"];
+  }
 
   // coll increases => deposit
-  if (dn.gt(collChange, 0)) return "depositColl";
+  if (dn.gt(collChange, 0)) return ["depositColl"];
 
   // coll decreases => withdraw
-  if (dn.lt(collChange, 0)) return "withdrawColl";
+  if (dn.lt(collChange, 0)) return ["withdrawColl"];
 
   // debt increases => withdraw BOLD (borrow)
-  if (dn.gt(debtChange, 0)) return "withdrawBold";
+  if (dn.gt(debtChange, 0)) return ["withdrawBold"];
 
   // debt decreases => deposit BOLD (repay)
-  if (dn.lt(debtChange, 0)) return "depositBold";
+  if (dn.lt(debtChange, 0)) return ["depositBold"];
 
   throw new Error("Invalid request");
 }


### PR DESCRIPTION
The gas limit is now increased based on the following:

estimatedGas + max(minGasHeadroom, estimatedGas * relativeGasHeadroom)

Additionally, writeContract() and readContract are now passed via the TransactionFlow context, to take care of passing the wagmi config object and applying the gas strategy automatically. minGasHeadroom can be set per-transaction.