### PR TITLE
Improved env vars

### DIFF
--- a/frontend/app/.env
+++ b/frontend/app/.env
@@ -19,18 +19,18 @@ NEXT_PUBLIC_COINGECKO_API_KEY=
 # NEXT_PUBLIC_BLOCKING_VPNAPI=
 
 # Uncomment to change the app commit URL (see “About” modal):
-NEXT_PUBLIC_APP_COMMIT_URL=https://github.com/liquity/bold/tree/{commit}
-# Disable the app commit URL (will still show the commit hash, but not link to it):
+# NEXT_PUBLIC_APP_COMMIT_URL=https://github.com/liquity/bold/tree/{commit}
+# Or disable it:
 # NEXT_PUBLIC_APP_COMMIT_URL=false
 #
 # Uncomment to change the contracts commit URL (see “About” modal):
-NEXT_PUBLIC_CONTRACTS_COMMIT_URL=https://github.com/liquity/bold/tree/{commit}
-# Disable the contracts commit URL (will still show the commit hash, but not link to it):
+# NEXT_PUBLIC_CONTRACTS_COMMIT_URL=https://github.com/liquity/bold/tree/{commit}
+# Or disable it:
 # NEXT_PUBLIC_CONTRACTS_COMMIT_URL=false
 #
 # Uncomment to change the version URL:
-NEXT_PUBLIC_APP_VERSION_URL=https://github.com/liquity/bold/releases/tag/%40liquity2%2Fapp-v{version}
-# Disable the version URL (will still show the version, but not link to it):
+# NEXT_PUBLIC_APP_VERSION_URL=https://github.com/liquity/bold/releases/tag/%40liquity2%2Fapp-v{version}
+# Or disable it:
 # NEXT_PUBLIC_APP_VERSION_URL=false
 
 ######################

--- a/frontend/app/.env
+++ b/frontend/app/.env
@@ -1,7 +1,12 @@
 NEXT_PUBLIC_ACCOUNT_SCREEN=false
 NEXT_PUBLIC_DEMO_MODE=false
 NEXT_PUBLIC_VERCEL_ANALYTICS=false
-NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=1
+
+# Get a WalletConnect project ID at https://cloud.reown.com/app
+NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=
+
+# Use this to indicate a specific variant (e.g. "preview").
+# This will be displayed in the app header.
 # NEXT_PUBLIC_DEPLOYMENT_FLAVOR=
 
 # use demo|API_KEY (demo API) or pro|API_KEY (pro API)
@@ -12,6 +17,21 @@ NEXT_PUBLIC_COINGECKO_API_KEY=
 
 # format: {vpnapi.io key}|{comma separated country codes} e.g. 1234|US,CA
 # NEXT_PUBLIC_BLOCKING_VPNAPI=
+
+# Uncomment to change the app commit URL (see “About” modal):
+NEXT_PUBLIC_APP_COMMIT_URL=https://github.com/liquity/bold/tree/{commit}
+# Disable the app commit URL (will still show the commit hash, but not link to it):
+# NEXT_PUBLIC_APP_COMMIT_URL=false
+#
+# Uncomment to change the contracts commit URL (see “About” modal):
+NEXT_PUBLIC_CONTRACTS_COMMIT_URL=https://github.com/liquity/bold/tree/{commit}
+# Disable the contracts commit URL (will still show the commit hash, but not link to it):
+# NEXT_PUBLIC_CONTRACTS_COMMIT_URL=false
+#
+# Uncomment to change the version URL:
+NEXT_PUBLIC_APP_VERSION_URL=https://github.com/liquity/bold/releases/tag/%40liquity2%2Fapp-v{version}
+# Disable the version URL (will still show the version, but not link to it):
+# NEXT_PUBLIC_APP_VERSION_URL=false
 
 ######################
 # Ethereum (mainnet) #

--- a/frontend/app/README.md
+++ b/frontend/app/README.md
@@ -65,6 +65,51 @@ See [./src/env.ts](./src/env.ts) for details about how the environment variables
 <details>
 <summary>Supported Variables</summary>
 
+### `NEXT_PUBLIC_ACCOUNT_SCREEN`
+
+Enable or disable the account screen (meant for testing purposes).
+
+```dosini
+# Example
+NEXT_PUBLIC_ACCOUNT_SCREEN=false
+```
+
+### `NEXT_PUBLIC_APP_COMMIT_URL`
+
+The URL template for linking to specific app commits in the repository. Set to `false` to disable.
+
+```dosini
+# Format
+NEXT_PUBLIC_APP_COMMIT_URL=https://url_template_with_{commit}
+
+# Example (default)
+NEXT_PUBLIC_APP_COMMIT_URL=https://github.com/liquity/bold/tree/{commit}
+```
+
+### `NEXT_PUBLIC_APP_VERSION_URL`
+
+The URL template for linking to specific app version releases. Set to `false` to disable.
+
+```dosini
+# Format
+NEXT_PUBLIC_APP_VERSION_URL=https://url_template_with_{version}
+
+# Example (default)
+NEXT_PUBLIC_APP_VERSION_URL=https://github.com/liquity/bold/releases/tag/%40liquity2%2Fapp-v{version}
+```
+
+### `NEXT_PUBLIC_CONTRACTS_COMMIT_URL`
+
+The URL template for linking to specific contract commits in the repository. Set to `false` to disable.
+
+```dosini
+# Format
+NEXT_PUBLIC_CONTRACTS_COMMIT_URL=https://url_template_with_{commit}
+
+# Example (default)
+NEXT_PUBLIC_CONTRACTS_COMMIT_URL=https://github.com/liquity/bold/tree/{commit}
+```
+
 ### `NEXT_PUBLIC_CHAIN_ID`
 
 The Ethereum network to connect to.
@@ -192,6 +237,24 @@ Enable or disable demo mode for testing purposes.
 ```dosini
 # Example
 NEXT_PUBLIC_DEMO_MODE=false
+```
+
+### `NEXT_PUBLIC_DELEGATE_AUTO`
+
+The default delegate address to use for the interest rate automated strategy.
+
+```dosini
+# Example
+NEXT_PUBLIC_DELEGATE_AUTO=0x0000000000000000000000000000000000000000
+```
+
+### `NEXT_PUBLIC_DEPLOYMENT_FLAVOR`
+
+Indicates a specific deployment variant (e.g., "preview"). This will be displayed in the app header.
+
+```dosini
+# Example
+NEXT_PUBLIC_DEPLOYMENT_FLAVOR=preview
 ```
 
 ### `NEXT_PUBLIC_KNOWN_INITIATIVES_URL`

--- a/frontend/app/src/comps/TopBar/TopBar.tsx
+++ b/frontend/app/src/comps/TopBar/TopBar.tsx
@@ -80,7 +80,7 @@ export function TopBar() {
             })}
           >
             {content.appName}
-            {DEPLOYMENT_FLAVOR !== "" && (
+            {DEPLOYMENT_FLAVOR && (
               <div
                 className={css({
                   display: "flex",

--- a/frontend/app/src/valibot-utils.ts
+++ b/frontend/app/src/valibot-utils.ts
@@ -59,6 +59,31 @@ export function vPrefixedTroveId() {
   );
 }
 
+// accepts a URL or a vEnvFlag to use the default or disable
+export function vEnvUrlOrDefault(defaultValue: `https://${string}`) {
+  return v.pipe(
+    // true = use default
+    // false = disable
+    // string = custom URL
+    v.optional(
+      v.union([
+        v.pipe(v.string(), v.url()),
+        vEnvFlag(),
+      ]),
+      "true",
+    ),
+    v.transform((value) => {
+      if (typeof value === "string") {
+        if (value.startsWith("https://")) {
+          return value;
+        }
+        throw new Error(`URL must start with "https://", got "${value}"`);
+      }
+      return value ? defaultValue : null;
+    }),
+  );
+}
+
 // Env var link, e.g. Etherscan|https://etherscan.io
 export function vEnvLink(addFinalSlash = false) {
   return v.pipe(


### PR DESCRIPTION
- Add `APP_COMMIT_URL`, `CONTRACTS_COMMIT_URL` and `APP_VERSION_URL`, all three optional and pointing to [liquity/bold](https://github.com/liquity/bold) by default. When turned off, the version & commits get displayed without a link in the About modal.
- `NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID` is not set by default rather than using a placeholder, making sure that an error is triggered when not set (it is not optional because RainbowKit requires it).

Also:

- Improved some other env var defaults (eg. `DELEGATE_AUTO` is now null rather than an empty string when not set).
- Add the `vEnvUrlOrDefault()` utility.
- On the About modal, non-set values are shown as such.