### PR TITLE
Add a build flag to build routes in separate directories

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -63,6 +63,12 @@ pnpm build
 
 The app will be built in the `out/` directory which can be deployed to any static hosting service.
 
+Note: your server must be configured to serve .html files by default. If you are using Vercel, this is done automatically. If your server does not support this, you can build the app with a separate directory for each route:
+
+```bash
+NEXT_TRAILING_SLASH=1 pnpm build
+```
+
 ## Local development setup
 
 Follow these steps to set up your local development environment:

--- a/frontend/app/next.config.js
+++ b/frontend/app/next.config.js
@@ -23,6 +23,7 @@ export default withBundleAnalyzer({
   output: "export",
   reactStrictMode: false,
   images: { unoptimized: true },
+  trailingSlash: flag(process.env.NEXT_TRAILING_SLASH),
   env: {
     APP_VERSION_FROM_BUILD,
     APP_COMMIT_HASH_FROM_BUILD,
@@ -50,3 +51,11 @@ export default withBundleAnalyzer({
     ];
   },
 });
+
+function flag(value) {
+  if (typeof value !== "string") {
+    return false;
+  }
+  value = value.trim();
+  return value === "true" || value === "1" || value === "yes";
+}


### PR DESCRIPTION
This builds routes in separate directories rather than in .html files. The is useful for servers that can’t serve .html files by default. The downside is that routes get a final slash.