### PR TITLE
App layout fixes

### DIFF
--- a/frontend/app/panda.config.ts
+++ b/frontend/app/panda.config.ts
@@ -30,11 +30,17 @@ export default defineConfig({
   ],
   globalCss: defineGlobalStyles({
     "html, body": {
+      height: "100%",
+      minWidth: 960,
       lineHeight: 1.5,
       fontSize: 16,
       fontWeight: 500,
       color: "content",
       background: "background",
+    },
+    html: {
+      overflowX: "auto",
+      overflowY: "scroll",
     },
   }),
 });

--- a/frontend/app/src/app/layout.tsx
+++ b/frontend/app/src/app/layout.tsx
@@ -1,7 +1,7 @@
 // All global styles should be imported here for easier maintenance
 import "@liquity2/uikit/index.css";
 
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import type { ReactNode } from "react";
 
 import { About } from "@/src/comps/About/About";
@@ -21,6 +21,13 @@ import { GeistSans } from "geist/font/sans";
 export const metadata: Metadata = {
   title: content.appName,
   icons: "/favicon.svg",
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
 };
 
 export default function Layout({

--- a/frontend/app/src/comps/AppLayout/AppLayout.tsx
+++ b/frontend/app/src/comps/AppLayout/AppLayout.tsx
@@ -19,13 +19,18 @@ export function AppLayout({
   children: ReactNode;
 }) {
   return (
-    <>
+    <div
+      className={css({
+        display: "grid",
+        gridTemplateRows: "auto 1fr",
+        minHeight: "100vh",
+        height: "100%",
+        background: "background",
+      })}
+    >
       <div
         className={css({
-          display: "flex",
-          flexDirection: "column",
           width: "100%",
-          gap: 1,
         })}
       >
         <Banner />
@@ -33,24 +38,17 @@ export function AppLayout({
       </div>
       <div
         className={css({
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "flex-start",
-          width: "100%",
-          minHeight: "100vh",
+          display: "grid",
+          gridTemplateRows: "auto 1fr auto",
+          minWidth: 960,
+          maxWidth: 1092,
           margin: "0 auto",
-          background: "background",
+          width: "100%",
         })}
-        style={{
-          minWidth: `${MIN_WIDTH}px`,
-          maxWidth: `${LAYOUT_WIDTH + 24 * 2}px`,
-        }}
       >
         <div
           className={css({
             width: "100%",
-            flexGrow: 0,
-            flexShrink: 0,
             paddingBottom: 48,
           })}
         >
@@ -58,37 +56,25 @@ export function AppLayout({
         </div>
         <div
           className={css({
-            flexGrow: 1,
-            display: "flex",
             flexDirection: "column",
+            width: "100%",
+            minHeight: 0,
+            padding: "0 24px",
           })}
-          style={{
-            width: `${LAYOUT_WIDTH + 24 * 2}px`,
-          }}
         >
-          <div
-            className={css({
-              flexGrow: 1,
-              display: "flex",
-              flexDirection: "column",
-              width: "100%",
-              padding: "0 24px",
-            })}
-          >
-            {children}
-          </div>
-          <div
-            className={css({
-              width: "100%",
-              padding: "48px 24px 0",
-            })}
-          >
-            <BuildInfo />
-            <ProtocolStats />
-          </div>
+          {children}
+        </div>
+        <div
+          className={css({
+            width: "100%",
+            padding: "48px 24px 0",
+          })}
+        >
+          <BuildInfo />
+          <ProtocolStats />
         </div>
       </div>
-    </>
+    </div>
   );
 }
 

--- a/frontend/app/src/comps/InterestRateField/IcStrategiesModal.tsx
+++ b/frontend/app/src/comps/InterestRateField/IcStrategiesModal.tsx
@@ -68,8 +68,6 @@ export function IcStrategiesModal({
           alignItems: "center",
           gap: 8,
           paddingTop: 32,
-          paddingBottom: 24,
-          minHeight: 312,
         })}
       >
         {icpDelegates?.slice(0, displayedDelegates).map((delegate) => {

--- a/frontend/uikit/src/Modal/Modal.tsx
+++ b/frontend/uikit/src/Modal/Modal.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from "react";
 
 import { a, useTransition } from "@react-spring/web";
 import FocusTrap from "focus-trap-react";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { css } from "../../styled-system/css";
 import { IconCross } from "../icons";
 import { Root } from "../Root/Root";
@@ -47,8 +47,18 @@ export function Modal({
   });
 
   useEffect(() => {
-    if ("document" in globalThis) {
-      document.body.style.overflow = visible ? "hidden" : "auto";
+    if (!("document" in globalThis)) {
+      return;
+    }
+    if (visible) {
+      const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+      document.documentElement.style.overflow = "hidden";
+      document.body.style.position = "relative";
+      document.body.style.left = `-${scrollbarWidth / 2}px`;
+    } else {
+      document.documentElement.style.overflow = "visible";
+      document.body.style.removeProperty("position");
+      document.body.style.removeProperty("left");
     }
   }, [visible]);
 
@@ -61,27 +71,32 @@ export function Modal({
       }, item) => (
         item && (
           <a.section
-            style={{
-              opacity: overlayOpacity,
-              pointerEvents: visible ? "auto" : "none",
+            onMouseDown={({ target, currentTarget }) => {
+              if (target === currentTarget) {
+                onClose();
+              }
             }}
             className={css({
               position: "fixed",
               inset: 0,
               zIndex: 2,
-              overflow: "auto",
+              display: "grid",
+              placeItems: "center",
+              overflowX: "auto",
               background: "rgba(18, 27, 68, 0.7)",
             })}
+            style={{
+              overflowY: visible ? "scroll" : "hidden",
+              opacity: overlayOpacity,
+              pointerEvents: visible ? "auto" : "none",
+            }}
           >
             <div
-              onMouseDown={({ target, currentTarget }) => {
-                if (target === currentTarget) {
-                  onClose();
-                }
-              }}
               className={css({
                 display: "flex",
                 justifyContent: "center",
+                // this is to let the overlay handle the onMouseDown event
+                pointerEvents: "none",
               })}
             >
               <FocusTrap
@@ -99,6 +114,8 @@ export function Modal({
                   }}
                   className={css({
                     padding: 64,
+                    // and this is to re-enable the onMouseDown event
+                    pointerEvents: "auto",
                   })}
                 >
                   <a.div


### PR DESCRIPTION
- Simplify / improve the app layout (the banner is now always full width, even with a scroll).
- Prevent resizing on smaller screens and show a scrollbar instead (viewport: device-width).
- Prevent horizontal jumps:
  - Always show the vertical scrollbar.
  - Modal: when opened, ensure the app scroll + position are corrected to account for the applied overflow: hidden.
- Modal fixes: center vertically, close when clicking on the bottom part of the overlay, layout tweaks.