### PR TITLE
Account button tweaks

### DIFF
--- a/frontend/app/src/comps/TopBar/MenuItem.tsx
+++ b/frontend/app/src/comps/TopBar/MenuItem.tsx
@@ -9,7 +9,7 @@ export function MenuItem({
   selected,
 }: {
   icon: ReactNode;
-  label: string;
+  label: ReactNode;
   selected?: boolean;
 }) {
   return (
@@ -19,10 +19,13 @@ export function MenuItem({
         display: "flex",
         alignItems: "center",
         gap: 12,
+        width: "100%",
         height: "100%",
         color: "content",
         cursor: "pointer",
         userSelect: "none",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
       })}
       style={{
         color: token(`colors.${selected ? "selected" : "interactive"}`),
@@ -38,7 +41,26 @@ export function MenuItem({
       >
         {icon}
       </div>
-      {label}
+      <div
+        className={css({
+          flexShrink: 1,
+          flexGrow: 1,
+          overflow: "hidden",
+          display: "flex",
+          alignItems: "center",
+          height: "100%",
+        })}
+      >
+        <div
+          className={css({
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          })}
+        >
+          {label}
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/app/src/comps/TopBar/TopBar.tsx
+++ b/frontend/app/src/comps/TopBar/TopBar.tsx
@@ -102,7 +102,16 @@ export function TopBar() {
           </div>
         </Link>
         <Menu menuItems={menuItems} />
-        <AccountButton />
+        <div
+          className={css({
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "flex-end",
+            width: 140,
+          })}
+        >
+          <AccountButton />
+        </div>
       </div>
     </div>
   );

--- a/frontend/app/src/services/Ethereum.tsx
+++ b/frontend/app/src/services/Ethereum.tsx
@@ -196,17 +196,7 @@ export function useWagmiConfig() {
       },
       ssr: true,
     });
-  }, [
-    CHAIN_BLOCK_EXPLORER,
-    CHAIN_CONTRACT_ENS_REGISTRY,
-    CHAIN_CONTRACT_ENS_RESOLVER,
-    CHAIN_CONTRACT_MULTICALL,
-    CHAIN_CURRENCY,
-    CHAIN_ID,
-    CHAIN_NAME,
-    CHAIN_RPC_URL,
-    WALLET_CONNECT_PROJECT_ID,
-  ]);
+  }, []);
 }
 
 function createChain({

--- a/frontend/uikit/src/ShowAfter/ShowAfter.tsx
+++ b/frontend/uikit/src/ShowAfter/ShowAfter.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+
+import { useEffect, useState } from "react";
+
+export function ShowAfter({
+  children,
+  delay,
+}: {
+  children: ReactNode;
+  delay: number;
+}) {
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setShow(true);
+    }, delay);
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [delay]);
+
+  return show ? children : null;
+}

--- a/frontend/uikit/src/index.ts
+++ b/frontend/uikit/src/index.ts
@@ -27,6 +27,7 @@ export { PillButton } from "./PillButton/PillButton";
 export { Radio } from "./Radio/Radio";
 export { RadioGroup, useRadioGroup } from "./Radio/RadioGroup";
 export { Root, RootEntryPoint } from "./Root/Root";
+export { ShowAfter } from "./ShowAfter/ShowAfter";
 export { Slider } from "./Slider/Slider";
 export { StatusDot } from "./StatusDot/StatusDot";
 export { Tabs } from "./Tabs/Tabs";


### PR DESCRIPTION
- Fixed width (prevents jumps).
- Add a new “connecting” status, which only shows after a 500ms delay (making it invisible in most cases).
- UI kit: add a new ShowAfter component.
- Cut the text when too wide (ENS name resolution).

Also:

- Remove unnecessary hook dependencies in services/Ethereum.tsx.