### PR TITLE
tx flows: use the block number to check if a tx has been indexed by the subgraph

### DIFF
--- a/frontend/app/src/graphql/gql.ts
+++ b/frontend/app/src/graphql/gql.ts
@@ -30,6 +30,7 @@ const documents = {
     "\n  query GovernanceUser($id: ID!) {\n    governanceUser(id: $id) {\n      id\n      allocatedLQTY\n      stakedLQTY\n      stakedOffset\n      allocations {\n        id\n        atEpoch\n        vetoLQTY\n        voteLQTY\n        initiative {\n          id\n        }\n      }\n    }\n  }\n": types.GovernanceUserDocument,
     "\n  query GovernanceStats {\n    governanceStats(id: \"stats\") {\n      id\n      totalLQTYStaked\n      totalOffset\n      totalInitiatives\n    }\n  }\n": types.GovernanceStatsDocument,
     "\n  query GovernanceUserAllocations($id: ID!) {\n    governanceUser(id: $id) {\n      allocated\n    }\n  }\n": types.GovernanceUserAllocationsDocument,
+    "\n  query BlockNumber {\n    _meta {\n      block {\n        number\n      }\n    }\n  }\n": types.BlockNumberDocument,
 };
 
 /**
@@ -92,6 +93,10 @@ export function graphql(source: "\n  query GovernanceStats {\n    governanceStat
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(source: "\n  query GovernanceUserAllocations($id: ID!) {\n    governanceUser(id: $id) {\n      allocated\n    }\n  }\n"): typeof import('./graphql').GovernanceUserAllocationsDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  query BlockNumber {\n    _meta {\n      block {\n        number\n      }\n    }\n  }\n"): typeof import('./graphql').BlockNumberDocument;
 
 
 export function graphql(source: string) {

--- a/frontend/app/src/graphql/graphql.ts
+++ b/frontend/app/src/graphql/graphql.ts
@@ -2254,6 +2254,11 @@ export type GovernanceUserAllocationsQueryVariables = Exact<{
 
 export type GovernanceUserAllocationsQuery = { __typename?: 'Query', governanceUser?: { __typename?: 'GovernanceUser', allocated: Array<string> } | null };
 
+export type BlockNumberQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type BlockNumberQuery = { __typename?: 'Query', _meta?: { __typename?: '_Meta_', block: { __typename?: '_Block_', number: number } } | null };
+
 export class TypedDocumentString<TResult, TVariables>
   extends String
   implements DocumentTypeDecoration<TResult, TVariables>
@@ -2518,3 +2523,12 @@ export const GovernanceUserAllocationsDocument = new TypedDocumentString(`
   }
 }
     `) as unknown as TypedDocumentString<GovernanceUserAllocationsQuery, GovernanceUserAllocationsQueryVariables>;
+export const BlockNumberDocument = new TypedDocumentString(`
+    query BlockNumber {
+  _meta {
+    block {
+      number
+    }
+  }
+}
+    `) as unknown as TypedDocumentString<BlockNumberQuery, BlockNumberQueryVariables>;

--- a/frontend/app/src/services/TransactionFlow.tsx
+++ b/frontend/app/src/services/TransactionFlow.tsx
@@ -489,6 +489,11 @@ function useFlowManager(account: Address | null, isSafe: boolean = false) {
     const verifyingStep = flow.steps.find((step) => step.status === "awaiting-verify" && step.artifact);
     if (!verifyingStep) return;
 
+    // if runningStepRef is set, no need to resume
+    if (runningStepRef.current !== null) {
+      return;
+    }
+
     const stepIndex = flow.steps.indexOf(verifyingStep);
     const flowDeclaration = getFlowDeclaration(flow.request.flowId);
     if (!flowDeclaration) return;

--- a/frontend/app/src/subgraph-queries.ts
+++ b/frontend/app/src/subgraph-queries.ts
@@ -299,3 +299,13 @@ export const GovernanceUserAllocated = graphql(`
     }
   }
 `);
+
+export const BlockNumberQuery = graphql(`
+  query BlockNumber {
+    _meta {
+      block {
+        number
+      }
+    }
+  }
+`);

--- a/frontend/app/src/tx-flows/shared.ts
+++ b/frontend/app/src/tx-flows/shared.ts
@@ -1,9 +1,7 @@
-import type { BranchId, TroveId } from "@/src/types";
 import type { Config as WagmiConfig } from "wagmi";
 
-import { getPrefixedTroveId } from "@/src/liquity-utils";
 import { waitForSafeTransaction } from "@/src/safe-utils";
-import { BlockNumberQuery, graphQuery, TroveByIdQuery } from "@/src/subgraph-queries";
+import { BlockNumberQuery, graphQuery } from "@/src/subgraph-queries";
 import { sleep } from "@/src/utils";
 import * as v from "valibot";
 import { waitForTransactionReceipt } from "wagmi/actions";

--- a/frontend/app/src/tx-flows/updateBorrowPosition.tsx
+++ b/frontend/app/src/tx-flows/updateBorrowPosition.tsx
@@ -13,7 +13,7 @@ import * as dn from "dnum";
 import { match, P } from "ts-pattern";
 import * as v from "valibot";
 import { maxUint256 } from "viem";
-import { createRequestSchema, verifyTransaction, verifyTroveUpdate } from "./shared";
+import { createRequestSchema, verifyTransaction } from "./shared";
 
 const RequestSchema = createRequestSchema(
   "updateBorrowPosition",
@@ -226,7 +226,7 @@ export const updateBorrowPosition: FlowDeclaration<UpdateBorrowPositionRequest> 
       },
 
       async verify(ctx, hash) {
-        await verifyTroveUpdate(ctx.wagmiConfig, hash, ctx.request.loan);
+        await verifyTransaction(ctx.wagmiConfig, hash, ctx.isSafe);
       },
     },
 
@@ -256,7 +256,7 @@ export const updateBorrowPosition: FlowDeclaration<UpdateBorrowPositionRequest> 
       },
 
       async verify(ctx, hash) {
-        await verifyTroveUpdate(ctx.wagmiConfig, hash, ctx.request.loan);
+        await verifyTransaction(ctx.wagmiConfig, hash, ctx.isSafe);
       },
     },
 
@@ -287,7 +287,7 @@ export const updateBorrowPosition: FlowDeclaration<UpdateBorrowPositionRequest> 
       },
 
       async verify(ctx, hash) {
-        await verifyTroveUpdate(ctx.wagmiConfig, hash, ctx.request.loan);
+        await verifyTransaction(ctx.wagmiConfig, hash, ctx.isSafe);
       },
     },
 
@@ -316,7 +316,7 @@ export const updateBorrowPosition: FlowDeclaration<UpdateBorrowPositionRequest> 
       },
 
       async verify(ctx, hash) {
-        await verifyTroveUpdate(ctx.wagmiConfig, hash, ctx.request.loan);
+        await verifyTransaction(ctx.wagmiConfig, hash, ctx.isSafe);
       },
     },
 
@@ -345,7 +345,7 @@ export const updateBorrowPosition: FlowDeclaration<UpdateBorrowPositionRequest> 
       },
 
       async verify(ctx, hash) {
-        await verifyTroveUpdate(ctx.wagmiConfig, hash, ctx.request.loan);
+        await verifyTransaction(ctx.wagmiConfig, hash, ctx.isSafe);
       },
     },
   },

--- a/frontend/app/src/tx-flows/updateLeveragePosition.tsx
+++ b/frontend/app/src/tx-flows/updateLeveragePosition.tsx
@@ -17,7 +17,7 @@ import * as dn from "dnum";
 import { match, P } from "ts-pattern";
 import * as v from "valibot";
 import { maxUint256 } from "viem";
-import { createRequestSchema, verifyTransaction, verifyTroveUpdate } from "./shared";
+import { createRequestSchema, verifyTransaction } from "./shared";
 
 const RequestSchema = createRequestSchema(
   "updateLeveragePosition",
@@ -239,7 +239,7 @@ export const updateLeveragePosition: FlowDeclaration<UpdateLeveragePositionReque
       },
 
       async verify(ctx, hash) {
-        await verifyTroveUpdate(ctx.wagmiConfig, hash, ctx.request.loan);
+        await verifyTransaction(ctx.wagmiConfig, hash, ctx.isSafe);
       },
     },
 
@@ -277,7 +277,7 @@ export const updateLeveragePosition: FlowDeclaration<UpdateLeveragePositionReque
       },
 
       async verify(ctx, hash) {
-        await verifyTroveUpdate(ctx.wagmiConfig, hash, ctx.request.loan);
+        await verifyTransaction(ctx.wagmiConfig, hash, ctx.isSafe);
       },
     },
 
@@ -327,7 +327,7 @@ export const updateLeveragePosition: FlowDeclaration<UpdateLeveragePositionReque
       },
 
       async verify(ctx, hash) {
-        await verifyTroveUpdate(ctx.wagmiConfig, hash, ctx.request.loan);
+        await verifyTransaction(ctx.wagmiConfig, hash, ctx.isSafe);
       },
     },
 
@@ -374,7 +374,7 @@ export const updateLeveragePosition: FlowDeclaration<UpdateLeveragePositionReque
       },
 
       async verify(ctx, hash) {
-        await verifyTroveUpdate(ctx.wagmiConfig, hash, ctx.request.loan);
+        await verifyTransaction(ctx.wagmiConfig, hash, ctx.isSafe);
       },
     },
   },

--- a/frontend/app/src/tx-flows/updateLoanInterestRate.tsx
+++ b/frontend/app/src/tx-flows/updateLoanInterestRate.tsx
@@ -21,7 +21,7 @@ import * as dn from "dnum";
 import { match, P } from "ts-pattern";
 import * as v from "valibot";
 import { maxUint256 } from "viem";
-import { createRequestSchema, verifyTroveUpdate } from "./shared";
+import { createRequestSchema, verifyTransaction } from "./shared";
 
 const RequestSchema = createRequestSchema(
   "updateLoanInterestRate",
@@ -262,7 +262,7 @@ export const updateLoanInterestRate: FlowDeclaration<UpdateLoanInterestRateReque
       },
 
       async verify(ctx, hash) {
-        await verifyTroveUpdate(ctx.wagmiConfig, hash, ctx.request.loan);
+        await verifyTransaction(ctx.wagmiConfig, hash, ctx.isSafe);
       },
     },
 
@@ -299,7 +299,7 @@ export const updateLoanInterestRate: FlowDeclaration<UpdateLoanInterestRateReque
       },
 
       async verify(ctx, hash) {
-        await verifyTroveUpdate(ctx.wagmiConfig, hash, ctx.request.loan);
+        await verifyTransaction(ctx.wagmiConfig, hash, ctx.isSafe);
       },
     },
 
@@ -352,7 +352,7 @@ export const updateLoanInterestRate: FlowDeclaration<UpdateLoanInterestRateReque
       },
 
       async verify(ctx, hash) {
-        await verifyTroveUpdate(ctx.wagmiConfig, hash, ctx.request.loan);
+        await verifyTransaction(ctx.wagmiConfig, hash, ctx.isSafe);
       },
     },
 
@@ -385,7 +385,7 @@ export const updateLoanInterestRate: FlowDeclaration<UpdateLoanInterestRateReque
       },
 
       async verify(ctx, hash) {
-        await verifyTroveUpdate(ctx.wagmiConfig, hash, ctx.request.loan);
+        await verifyTransaction(ctx.wagmiConfig, hash, ctx.isSafe);
       },
     },
   },


### PR DESCRIPTION
This removes the need to have specific checks like `verifyTroveUpdate()`.