### PR TITLE
Fix voting power calculation

### DIFF
--- a/frontend/app/src/comps/EarnPositionSummary/EarnPositionSummary.tsx
+++ b/frontend/app/src/comps/EarnPositionSummary/EarnPositionSummary.tsx
@@ -29,7 +29,7 @@ export function EarnPositionSummary({
   }
   & (
     | { poolDeposit: Dnum; prevPoolDeposit: Dnum }
-    | { poolDeposit: undefined; prevPoolDeposit: undefined }
+    | { poolDeposit?: undefined; prevPoolDeposit?: undefined }
   ))
 {
   const collToken = getCollToken(branchId);

--- a/frontend/app/src/comps/Positions/PositionCardStake.tsx
+++ b/frontend/app/src/comps/Positions/PositionCardStake.tsx
@@ -1,22 +1,41 @@
 import type { PositionStake } from "@/src/types";
 
 import { Amount } from "@/src/comps/Amount/Amount";
+import { fmtnum } from "@/src/formatting";
+import { useVotingPower } from "@/src/liquity-governance";
 import { css } from "@/styled-system/css";
 import { HFlex, IconStake, TokenIcon } from "@liquity2/uikit";
 import Link from "next/link";
+import { useRef } from "react";
 import { PositionCard } from "./PositionCard";
 import { CardRow, CardRows } from "./shared";
 
 export function PositionCardStake({
   deposit,
+  owner,
   rewards,
-  share,
 }: Pick<
   PositionStake,
   | "deposit"
+  | "owner"
   | "rewards"
-  | "share"
 >) {
+  const votingPowerRef = useRef<HTMLDivElement>(null);
+  useVotingPower(owner, (share) => {
+    if (!votingPowerRef.current) {
+      return;
+    }
+
+    if (!share) {
+      votingPowerRef.current.innerHTML = "−";
+      votingPowerRef.current.title = "";
+      return;
+    }
+
+    const shareFormatted = fmtnum(share, { preset: "12z", scale: 100 }) + "%";
+    votingPowerRef.current.innerHTML = fmtnum(share, "pct2z") + "%";
+    votingPowerRef.current.title = shareFormatted;
+  });
   return (
     <Link
       href="/stake"
@@ -82,10 +101,7 @@ export function PositionCardStake({
                       color: "positionContent",
                     })}
                   >
-                    <Amount
-                      value={share}
-                      percentage
-                    />
+                    <div ref={votingPowerRef} />
                   </div>
                 </div>
               }

--- a/frontend/app/src/comps/StakePositionSummary/StakePositionSummary.tsx
+++ b/frontend/app/src/comps/StakePositionSummary/StakePositionSummary.tsx
@@ -5,10 +5,11 @@ import { useAppear } from "@/src/anim-utils";
 import { Amount } from "@/src/comps/Amount/Amount";
 import { TagPreview } from "@/src/comps/TagPreview/TagPreview";
 import { fmtnum } from "@/src/formatting";
-import { useGovernanceStats, useGovernanceUser } from "@/src/subgraph-hooks";
+import { useVotingPower } from "@/src/liquity-governance";
+import { useGovernanceUser } from "@/src/subgraph-hooks";
 import { useAccount } from "@/src/wagmi-utils";
 import { css } from "@/styled-system/css";
-import { HFlex, IconStake, InfoTooltip, TokenIcon, useRaf } from "@liquity2/uikit";
+import { HFlex, IconStake, InfoTooltip, TokenIcon } from "@liquity2/uikit";
 import { a } from "@react-spring/web";
 import * as dn from "dnum";
 import { useRef } from "react";
@@ -25,7 +26,6 @@ export function StakePositionSummary({
   txPreviewMode?: boolean;
 }) {
   const govUser = useGovernanceUser(stakePosition?.owner ?? null);
-  const govStats = useGovernanceStats();
 
   const account = useAccount();
 
@@ -35,65 +35,29 @@ export function StakePositionSummary({
     ),
   );
 
-  // totalVotingPower(t) = governanceStats.totalLQTYStaked * t - governanceStats.totalOffset
-  const totalVotingPower = (t: bigint) => {
-    if (!govStats.data) return null;
-    const { totalLQTYStaked, totalOffset } = govStats.data;
-    return BigInt(totalLQTYStaked) * t - BigInt(totalOffset);
-  };
-
-  // userVotingPower(t) = lqty * t - offset
-  const userVotingPower = (t: bigint) => {
-    if (!govUser.data) return null;
-    const { stakedLQTY, stakedOffset } = govUser.data;
-    return BigInt(stakedLQTY) * t - BigInt(stakedOffset);
-  };
-
   const votingPowerRef = useRef<HTMLDivElement>(null);
   const votingPowerTooltipRef = useRef<HTMLDivElement>(null);
 
-  useRaf(() => {
+  useVotingPower(stakePosition?.owner ?? null, (share) => {
     if (!votingPowerRef.current) {
       return;
     }
 
-    const now = Date.now();
-    const nowInSeconds = BigInt(Math.floor(now / 1000));
-
-    const userVp = userVotingPower(nowInSeconds);
-    const userVpNext = userVotingPower(nowInSeconds + 1n);
-
-    const totalVP = totalVotingPower(nowInSeconds);
-    const totalVPNext = totalVotingPower(nowInSeconds + 1n);
-
-    if (
-      userVp === null
-      || userVpNext === null
-      || totalVP === null
-      || totalVPNext === null
-    ) {
+    if (!share) {
       votingPowerRef.current.innerHTML = "−";
       votingPowerRef.current.title = "";
       return;
     }
 
-    const liveProgress = (now % 1000) / 1000;
-    const userVpLive = userVp + (userVpNext - userVp) * BigInt(Math.floor(liveProgress * 1000)) / 1000n;
-    const totalVpLive = totalVP + (totalVPNext - totalVP) * BigInt(Math.floor(liveProgress * 1000)) / 1000n;
+    const shareFormatted = fmtnum(share, { preset: "12z", scale: 100 }) + "%";
 
-    // pctShare(t) = userVotingPower(t) / totalVotingPower(t)
-    const share = dn.div([userVpLive, 18], [totalVpLive, 18]);
-
-    const sharePctFormatted = fmtnum(share, { preset: "12z", scale: 100 }) + "%";
-    const sharePctRoundedFormatted = fmtnum(share, "pct2z") + "%";
-
-    votingPowerRef.current.innerHTML = sharePctRoundedFormatted;
-    votingPowerRef.current.title = sharePctFormatted;
+    votingPowerRef.current.innerHTML = fmtnum(share, "pct2z") + "%";
+    votingPowerRef.current.title = shareFormatted;
 
     if (votingPowerTooltipRef.current) {
-      votingPowerTooltipRef.current.innerHTML = sharePctFormatted;
+      votingPowerTooltipRef.current.innerHTML = shareFormatted;
     }
-  }, 30);
+  });
 
   return (
     <div
@@ -314,7 +278,6 @@ export function StakePositionSummary({
               >
                 Voting power
               </div>
-
               {appear((style, show) => (
                 show && (
                   <a.div
@@ -330,31 +293,8 @@ export function StakePositionSummary({
                       className={css({
                         fontVariantNumeric: "tabular-nums",
                       })}
-                      style={{
-                        color: txPreviewMode
-                            && prevStakePosition
-                            && stakePosition?.share
-                            && !dn.eq(prevStakePosition.share, stakePosition.share)
-                          ? "var(--update-color)"
-                          : "inherit",
-                      }}
                     >
                     </div>
-                    {prevStakePosition
-                      && stakePosition
-                      && !dn.eq(prevStakePosition.share, stakePosition.share) && (
-                      <div
-                        className={css({
-                          color: "contentAlt",
-                          textDecoration: "line-through",
-                        })}
-                      >
-                        <Amount
-                          percentage
-                          value={prevStakePosition?.share ?? 0}
-                        />
-                      </div>
-                    )}
                     {!txPreviewMode && (
                       <InfoTooltip
                         content={{

--- a/frontend/app/src/demo-mode/demo-data.ts
+++ b/frontend/app/src/demo-mode/demo-data.ts
@@ -74,7 +74,6 @@ export const ACCOUNT_POSITIONS: Exclude<Position, PositionLoanUncommitted>[] = [
     type: "stake",
     owner: DEMO_ACCOUNT,
     deposit: dn.from(3414, 18),
-    share: dn.div(dn.from(3414, 18), STAKED_LQTY_TOTAL),
     totalStaked: STAKED_LQTY_TOTAL,
     rewards: {
       lusd: dn.from(789.438, 18),

--- a/frontend/app/src/liquity-utils.ts
+++ b/frontend/app/src/liquity-utils.ts
@@ -29,8 +29,6 @@ import { CHAIN_BLOCK_EXPLORER, ENV_BRANCHES, LIQUITY_STATS_URL } from "@/src/env
 import { useContinuousBoldGains } from "@/src/liquity-stability-pool";
 import {
   useAllInterestRateBrackets,
-  useGovernanceStats,
-  useGovernanceUser,
   useInterestRateBrackets,
   useLoanById,
   useStabilityPool,
@@ -229,31 +227,7 @@ export function useEarnPosition(
   });
 }
 
-export function useAccountVotingPower(account: Address | null, lqtyDiff: bigint = 0n) {
-  const govUser = useGovernanceUser(account);
-  const govStats = useGovernanceStats();
-
-  return useMemo(() => {
-    if (!govStats.data || !govUser.data) {
-      return null;
-    }
-
-    const t = BigInt(Math.floor(Date.now() / 1000));
-
-    const { totalLQTYStaked, totalOffset } = govStats.data;
-    const totalVp = (BigInt(totalLQTYStaked) + lqtyDiff) * t - BigInt(totalOffset);
-
-    const { stakedLQTY, stakedOffset } = govUser.data;
-    const userVp = (BigInt(stakedLQTY) + lqtyDiff) * t - BigInt(stakedOffset);
-
-    // pctShare(t) = userVotingPower(t) / totalVotingPower(t)
-    return dn.div([userVp, 18], [totalVp, 18]);
-  }, [govUser.data, govStats.data, lqtyDiff]);
-}
-
 export function useStakePosition(address: null | Address) {
-  const votingPower = useAccountVotingPower(address);
-
   const LqtyStaking = getProtocolContract("LqtyStaking");
   const LusdToken = getProtocolContract("LusdToken");
   const Governance = getProtocolContract("Governance");
@@ -325,15 +299,12 @@ export function useStakePosition(address: null | Address) {
             eth: dnum18(pendingEthGainResult.result + (userProxyBalance.data?.value ?? 0n)),
             lusd: dnum18(pendingLusdGainResult.result + lusdBalanceResult.result),
           },
-          share: DNUM_0,
         };
       },
     },
   });
 
-  return stakePosition.data && votingPower
-    ? { ...stakePosition, data: { ...stakePosition.data, share: votingPower } }
-    : stakePosition;
+  return stakePosition;
 }
 
 export function useTroveNftUrl(branchId: null | BranchId, troveId: null | TroveId) {

--- a/frontend/app/src/screens/BorrowScreen/BorrowScreen.tsx
+++ b/frontend/app/src/screens/BorrowScreen/BorrowScreen.tsx
@@ -382,7 +382,8 @@ export function BorrowScreen() {
             wide
             onClick={() => {
               if (
-                deposit.parsed
+                interestRate
+                && deposit.parsed
                 && debt.parsed
                 && account.address
                 && typeof nextOwnerIndex.data === "number"

--- a/frontend/app/src/subgraph-hooks.ts
+++ b/frontend/app/src/subgraph-hooks.ts
@@ -468,7 +468,12 @@ export function useGovernanceUser(account: Address | null, options?: Options) {
 export function useGovernanceStats(options?: Options) {
   let queryFn = async () => {
     const { governanceStats } = await graphQuery(GovernanceStats);
-    return governanceStats;
+    return governanceStats && {
+      ...governanceStats,
+      totalLQTYStaked: BigInt(governanceStats.totalLQTYStaked),
+      totalOffset: BigInt(governanceStats.totalOffset),
+      totalInitiatives: BigInt(governanceStats.totalInitiatives),
+    };
   };
 
   // TODO: demo mode

--- a/frontend/app/src/types.ts
+++ b/frontend/app/src/types.ts
@@ -110,7 +110,6 @@ export type PositionStake = {
   type: "stake";
   owner: Address;
   deposit: Dnum;
-  share: Dnum;
   totalStaked: Dnum;
   rewards: {
     lusd: Dnum;

--- a/frontend/app/src/valibot-utils.ts
+++ b/frontend/app/src/valibot-utils.ts
@@ -167,7 +167,6 @@ export function vPositionStake() {
     type: v.literal("stake"),
     owner: vAddress(),
     deposit: vDnum(),
-    share: vDnum(),
     totalStaked: vDnum(),
     rewards: v.object({
       lusd: vDnum(),


### PR DESCRIPTION
Fixes https://github.com/liquity/bold/issues/757
Fixes https://github.com/liquity/bold/issues/756


- share has been removed from PositionStake, since it is calculated live.
- a new hook, useVotingPower(), is now used to calculate the voting power of a given account in realtime on the dashboard and the staking position summary card.
- re-enable the voting power preview on the staking position update panel.