### PR TITLE
Staking: less reliance on the subgraph + voting power updates

### DIFF
--- a/frontend/app/src/comps/StakePositionSummary/StakePositionSummary.tsx
+++ b/frontend/app/src/comps/StakePositionSummary/StakePositionSummary.tsx
@@ -24,12 +24,12 @@ export function StakePositionSummary({
   stakePosition: null | PositionStake;
   txPreviewMode?: boolean;
 }) {
-  const govUser = useGovernanceUser(stakePosition?.owner ?? null);
-
   const account = useAccount();
 
+  const govUser = useGovernanceUser(stakePosition?.owner ?? null);
+
   const appear = useAppear(
-    account.isDisconnected || (
+    !account.isConnected || (
       loadingState === "success" && govUser.status === "success"
     ),
   );
@@ -310,7 +310,7 @@ export function StakePositionSummary({
                                 Your relative voting power changes over time, depending on your and others deposits of
                                 LQTY.
                               </p>
-                              {account.address && (govUser.data?.stakedLQTY ?? 0n) > 0n && (
+                              {account.address && (govUser.data?.allocatedLQTY ?? 0n) > 0n && (
                                 <div
                                   className={css({
                                     display: "flex",

--- a/frontend/app/src/graphql/gql.ts
+++ b/frontend/app/src/graphql/gql.ts
@@ -21,8 +21,6 @@ const documents = {
     "\n  query InterestBatches($ids: [ID!]!) {\n    interestBatches(where: { id_in: $ids }) {\n      collateral {\n        collIndex\n      }\n      batchManager\n      debt\n      coll\n      annualInterestRate\n      annualManagementFee\n    }\n  }\n": types.InterestBatchesDocument,
     "\n  query AllInterestRateBrackets {\n    interestRateBrackets(orderBy: rate) {\n      collateral {\n        collIndex\n      }\n      rate\n      totalDebt\n    }\n  }\n": types.AllInterestRateBracketsDocument,
     "\n  query GovernanceInitiatives {\n    governanceInitiatives {\n      id\n    }\n  }\n": types.GovernanceInitiativesDocument,
-    "\n  query GovernanceUser($id: ID!) {\n    governanceUser(id: $id) {\n      id\n      allocatedLQTY\n      stakedLQTY\n      stakedOffset\n      allocations {\n        id\n        atEpoch\n        vetoLQTY\n        voteLQTY\n        initiative {\n          id\n        }\n      }\n    }\n  }\n": types.GovernanceUserDocument,
-    "\n  query GovernanceStats {\n    governanceStats(id: \"stats\") {\n      id\n      totalLQTYStaked\n      totalOffset\n      totalInitiatives\n    }\n  }\n": types.GovernanceStatsDocument,
     "\n  query GovernanceUserAllocations($id: ID!) {\n    governanceUser(id: $id) {\n      allocated\n    }\n  }\n": types.GovernanceUserAllocationsDocument,
     "\n  query BlockNumber {\n    _meta {\n      block {\n        number\n      }\n    }\n  }\n": types.BlockNumberDocument,
 };
@@ -51,14 +49,6 @@ export function graphql(source: "\n  query AllInterestRateBrackets {\n    intere
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(source: "\n  query GovernanceInitiatives {\n    governanceInitiatives {\n      id\n    }\n  }\n"): typeof import('./graphql').GovernanceInitiativesDocument;
-/**
- * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
- */
-export function graphql(source: "\n  query GovernanceUser($id: ID!) {\n    governanceUser(id: $id) {\n      id\n      allocatedLQTY\n      stakedLQTY\n      stakedOffset\n      allocations {\n        id\n        atEpoch\n        vetoLQTY\n        voteLQTY\n        initiative {\n          id\n        }\n      }\n    }\n  }\n"): typeof import('./graphql').GovernanceUserDocument;
-/**
- * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
- */
-export function graphql(source: "\n  query GovernanceStats {\n    governanceStats(id: \"stats\") {\n      id\n      totalLQTYStaked\n      totalOffset\n      totalInitiatives\n    }\n  }\n"): typeof import('./graphql').GovernanceStatsDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/frontend/app/src/graphql/graphql.ts
+++ b/frontend/app/src/graphql/graphql.ts
@@ -1874,18 +1874,6 @@ export type GovernanceInitiativesQueryVariables = Exact<{ [key: string]: never; 
 
 export type GovernanceInitiativesQuery = { __typename?: 'Query', governanceInitiatives: Array<{ __typename?: 'GovernanceInitiative', id: string }> };
 
-export type GovernanceUserQueryVariables = Exact<{
-  id: Scalars['ID']['input'];
-}>;
-
-
-export type GovernanceUserQuery = { __typename?: 'Query', governanceUser?: { __typename?: 'GovernanceUser', id: string, allocatedLQTY: bigint, stakedLQTY: bigint, stakedOffset: bigint, allocations: Array<{ __typename?: 'GovernanceAllocation', id: string, atEpoch: bigint, vetoLQTY: bigint, voteLQTY: bigint, initiative: { __typename?: 'GovernanceInitiative', id: string } }> } | null };
-
-export type GovernanceStatsQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type GovernanceStatsQuery = { __typename?: 'Query', governanceStats?: { __typename?: 'GovernanceStats', id: string, totalLQTYStaked: bigint, totalOffset: bigint, totalInitiatives: number } | null };
-
 export type GovernanceUserAllocationsQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
@@ -1980,35 +1968,6 @@ export const GovernanceInitiativesDocument = new TypedDocumentString(`
   }
 }
     `) as unknown as TypedDocumentString<GovernanceInitiativesQuery, GovernanceInitiativesQueryVariables>;
-export const GovernanceUserDocument = new TypedDocumentString(`
-    query GovernanceUser($id: ID!) {
-  governanceUser(id: $id) {
-    id
-    allocatedLQTY
-    stakedLQTY
-    stakedOffset
-    allocations {
-      id
-      atEpoch
-      vetoLQTY
-      voteLQTY
-      initiative {
-        id
-      }
-    }
-  }
-}
-    `) as unknown as TypedDocumentString<GovernanceUserQuery, GovernanceUserQueryVariables>;
-export const GovernanceStatsDocument = new TypedDocumentString(`
-    query GovernanceStats {
-  governanceStats(id: "stats") {
-    id
-    totalLQTYStaked
-    totalOffset
-    totalInitiatives
-  }
-}
-    `) as unknown as TypedDocumentString<GovernanceStatsQuery, GovernanceStatsQueryVariables>;
 export const GovernanceUserAllocationsDocument = new TypedDocumentString(`
     query GovernanceUserAllocations($id: ID!) {
   governanceUser(id: $id) {

--- a/frontend/app/src/screens/StakeScreen/PanelVoting.tsx
+++ b/frontend/app/src/screens/StakeScreen/PanelVoting.tsx
@@ -7,6 +7,7 @@ import { Spinner } from "@/src/comps/Spinner/Spinner";
 import { Tag } from "@/src/comps/Tag/Tag";
 import { VoteInput } from "@/src/comps/VoteInput/VoteInput";
 import content from "@/src/content";
+import { DNUM_0 } from "@/src/dnum-utils";
 import { CHAIN_BLOCK_EXPLORER } from "@/src/env";
 import { fmtnum, formatDate } from "@/src/formatting";
 import { useGovernanceState, useGovernanceUser, useInitiatives, useInitiativesStates } from "@/src/liquity-governance";
@@ -130,7 +131,7 @@ export function PanelVoting() {
       ];
 
       allocations[allocation.initiative] = {
-        value: dn.div(qty, stakedLQTY),
+        value: dn.eq(stakedLQTY, 0) ? DNUM_0 : dn.div(qty, stakedLQTY),
         vote,
       };
     }
@@ -732,7 +733,10 @@ function InitiativeRow({
                     }, 0);
                   }}
                   disabled={disabled}
-                  share={dn.div(voteAllocation?.value ?? [0n, 18], totalStaked)}
+                  share={dn.eq(totalStaked, 0) ? DNUM_0 : dn.div(
+                    voteAllocation?.value ?? DNUM_0,
+                    totalStaked,
+                  )}
                   vote={voteAllocation?.vote ?? null}
                 />
               )

--- a/frontend/app/src/subgraph-hooks.ts
+++ b/frontend/app/src/subgraph-hooks.ts
@@ -10,13 +10,7 @@ import { DEMO_MODE } from "@/src/env";
 import { isPositionLoanCommitted } from "@/src/types";
 import { useQuery } from "@tanstack/react-query";
 import { useCallback } from "react";
-import {
-  AllInterestRateBracketsQuery,
-  BorrowerInfoQuery,
-  GovernanceInitiatives,
-  GovernanceStats,
-  graphQuery,
-} from "./subgraph-queries";
+import { AllInterestRateBracketsQuery, BorrowerInfoQuery, GovernanceInitiatives, graphQuery } from "./subgraph-queries";
 
 type Options = {
   refetchInterval?: number;
@@ -140,29 +134,6 @@ export function useGovernanceInitiatives(options?: Options) {
 
   return useQuery({
     queryKey: ["GovernanceInitiatives"],
-    queryFn,
-    ...prepareOptions(options),
-  });
-}
-
-export function useGovernanceStats(options?: Options) {
-  let queryFn = async () => {
-    const { governanceStats } = await graphQuery(GovernanceStats);
-    return governanceStats && {
-      ...governanceStats,
-      totalLQTYStaked: BigInt(governanceStats.totalLQTYStaked),
-      totalOffset: BigInt(governanceStats.totalOffset),
-      totalInitiatives: BigInt(governanceStats.totalInitiatives),
-    };
-  };
-
-  // TODO: demo mode
-  if (DEMO_MODE) {
-    queryFn = async () => null;
-  }
-
-  return useQuery({
-    queryKey: ["GovernanceStats"],
     queryFn,
     ...prepareOptions(options),
   });

--- a/frontend/app/src/subgraph-queries.ts
+++ b/frontend/app/src/subgraph-queries.ts
@@ -108,37 +108,6 @@ export const GovernanceInitiatives = graphql(`
   }
 `);
 
-export const GovernanceUser = graphql(`
-  query GovernanceUser($id: ID!) {
-    governanceUser(id: $id) {
-      id
-      allocatedLQTY
-      stakedLQTY
-      stakedOffset
-      allocations {
-        id
-        atEpoch
-        vetoLQTY
-        voteLQTY
-        initiative {
-          id
-        }
-      }
-    }
-  }
-`);
-
-export const GovernanceStats = graphql(`
-  query GovernanceStats {
-    governanceStats(id: "stats") {
-      id
-      totalLQTYStaked
-      totalOffset
-      totalInitiatives
-    }
-  }
-`);
-
 export const GovernanceUserAllocated = graphql(`
   query GovernanceUserAllocations($id: ID!) {
     governanceUser(id: $id) {

--- a/frontend/app/src/tx-flows/allocateVotingPower.tsx
+++ b/frontend/app/src/tx-flows/allocateVotingPower.tsx
@@ -221,7 +221,7 @@ export const allocateVotingPower: FlowDeclaration<AllocateVotingPowerRequest> = 
           ...ctx.contracts.Governance,
           functionName: "allocateLQTY",
           args: [
-            (allocated.governanceUser?.allocated ?? []) as Address[],
+            (allocated.governanceUser?.allocated ?? []) as Address[], // to reset
             allocationArgs.initiatives,
             allocationArgs.votes,
             allocationArgs.vetos,

--- a/frontend/app/src/tx-flows/legacyUnstakeAll.tsx
+++ b/frontend/app/src/tx-flows/legacyUnstakeAll.tsx
@@ -57,7 +57,12 @@ export const legacyUnstakeAll: FlowDeclaration<LegacyUnstakeAllRequest> = {
           throw new Error("LEGACY_CHECK is not defined");
         }
 
-        const initiativesFromSnapshotResult = await fetch(LEGACY_CHECK.INITIATIVES_SNAPSHOT_URL);
+        const initiativesFromSnapshotResult = await fetch(LEGACY_CHECK.INITIATIVES_SNAPSHOT_URL).catch((err) => {
+          console.error("Error fetching initiatives from snapshot.");
+          console.error("LEGACY_CHECK.INITIATIVES_SNAPSHOT_URL:", LEGACY_CHECK?.INITIATIVES_SNAPSHOT_URL);
+          throw err;
+        });
+
         const initiativesFromSnapshot = v.parse(
           v.array(vAddress()),
           await initiativesFromSnapshotResult.json(),

--- a/frontend/app/src/tx-flows/shared.ts
+++ b/frontend/app/src/tx-flows/shared.ts
@@ -32,6 +32,7 @@ export async function verifyTransaction(
   wagmiConfig: WagmiConfig,
   hash: string,
   isSafe: boolean,
+  waitForSubgraphIndexation: boolean = true,
 ) {
   const tx = await (
     isSafe
@@ -47,7 +48,9 @@ export async function verifyTransaction(
   );
 
   // wait for the block number to be indexed by the subgraph
-  await verifyBlockNumberIndexation(tx.blockNumber);
+  if (waitForSubgraphIndexation) {
+    await verifyBlockNumberIndexation(tx.blockNumber);
+  }
 
   return tx;
 }


### PR DESCRIPTION
- `useGovernanceStats()` is now fetched from the contracts directly (rather than the subgraph).
- Remove the `GovernanceUser` and `GovernanceStats` GraphQL queries.
- Voting power is now only based on allocated LQTY.
- The “voting power” label below the LQTY deposit field is now called “voting share”.

Also:

- `legacyUnstakeAll.tsx`: improved error if fetching the JSON snapshot fails.
- `StakePositionSummary`: improved loading state.
- `verifyTransaction()`: add a new `waitForSubgraphIndexation` parameter.