### PR TITLE
App: fix getNextOwnerIndex()

### DIFF
--- a/frontend/app/src/liquity-utils.ts
+++ b/frontend/app/src/liquity-utils.ts
@@ -1224,5 +1224,6 @@ export function useNextOwnerIndex(
   return useQuery({
     queryKey: ["NextTroveId", borrower, branchId],
     queryFn,
+    enabled: borrower !== null && branchId !== null,
   });
 }

--- a/frontend/app/src/subgraph.ts
+++ b/frontend/app/src/subgraph.ts
@@ -63,9 +63,6 @@ export async function getNextOwnerIndex(
   branchId: BranchId,
   borrower: Address,
 ): Promise<number> {
-  if (!borrower || !branchId) {
-    return 0;
-  }
   const { borrowerInfo } = await graphQuery(
     NextOwnerIndexesByBorrower,
     { id: borrower.toLowerCase() },


### PR DESCRIPTION
- getNextOwnerIndex() does not check for borrower and branchId falsyness anymore, as they should always be non-null. This fixes a bug when `branchId` was `0`.
- in useNextOwnerIndex(), only enable the query whenboth borrower and branchId are not null