### PR TITLE
BorrowScreen: fix header typo (BOLD <> ETH)

### DIFF
--- a/frontend/app/src/screens/BorrowScreen/BorrowScreen.tsx
+++ b/frontend/app/src/screens/BorrowScreen/BorrowScreen.tsx
@@ -175,7 +175,7 @@ export function BorrowScreen() {
                     />
                   ))}
                 </TokenIcon.Group>
-                {NBSP}BOLD
+                {NBSP}ETH
               </div>,
               <div
                 className={css({
@@ -184,7 +184,7 @@ export function BorrowScreen() {
                 })}
               >
                 <TokenIcon symbol="BOLD" />
-                {NBSP}ETH
+                {NBSP}BOLD
               </div>,
             )}
           </div>


### PR DESCRIPTION
before:

![image](https://github.com/user-attachments/assets/2be83221-264e-4f36-9309-f5fb77f3aa52)

after:
![image](https://github.com/user-attachments/assets/79c65422-1cc2-4886-ab18-8d10db42f5b5)
