### PR TITLE
Modal: fix overlay click

### DIFF
--- a/frontend/uikit/src/Modal/Modal.tsx
+++ b/frontend/uikit/src/Modal/Modal.tsx
@@ -70,7 +70,7 @@ export function Modal({
         transform,
       }, item) => (
         item && (
-          <div
+          <a.section
             onMouseDown={({ target, currentTarget }) => {
               if (target === currentTarget) {
                 onClose();
@@ -80,119 +80,111 @@ export function Modal({
               position: "fixed",
               inset: 0,
               zIndex: 2,
+              display: "grid",
+              placeItems: "start center",
+              overflowX: "auto",
+              background: "transparent",
+              medium: {
+                placeItems: "center",
+                background: "rgba(18, 27, 68, 0.7)",
+              },
             })}
+            style={{
+              overflowY: visible ? "scroll" : "hidden",
+              opacity: overlayOpacity,
+              pointerEvents: visible ? "auto" : "none",
+            }}
           >
-            <a.section
+            <div
               className={css({
-                position: "fixed",
-                inset: 0,
-                zIndex: 2,
-                display: "grid",
-                placeItems: "start center",
-                overflowX: "auto",
-                background: "transparent",
-                medium: {
-                  placeItems: "center",
-                  background: "rgba(18, 27, 68, 0.7)",
-                },
+                display: "flex",
+                justifyContent: "center",
+                // this is to let the overlay handle the onMouseDown event
+                pointerEvents: "none",
               })}
-              style={{
-                overflowY: visible ? "scroll" : "hidden",
-                opacity: overlayOpacity,
-                pointerEvents: visible ? "auto" : "none",
-              }}
             >
-              <div
-                className={css({
-                  display: "flex",
-                  justifyContent: "center",
-                  // this is to let the overlay handle the onMouseDown event
-                  pointerEvents: "none",
-                })}
+              <FocusTrap
+                active={visible}
+                focusTrapOptions={{
+                  onDeactivate: onClose,
+                  allowOutsideClick: true,
+                }}
               >
-                <FocusTrap
-                  active={visible}
-                  focusTrapOptions={{
-                    onDeactivate: onClose,
-                    allowOutsideClick: true,
+                <div
+                  onMouseDown={({ target, currentTarget }) => {
+                    if (target === currentTarget) {
+                      onClose();
+                    }
                   }}
+                  className={css({
+                    height: {
+                      base: "100%",
+                      medium: "auto",
+                    },
+                    padding: {
+                      base: 0,
+                      medium: 64,
+                    },
+                    // and this is to re-enable the onMouseDown event
+                    pointerEvents: "auto",
+                  })}
                 >
-                  <div
-                    onMouseDown={({ target, currentTarget }) => {
-                      if (target === currentTarget) {
-                        onClose();
-                      }
-                    }}
+                  <a.div
                     className={css({
+                      position: "relative",
+                      width: "100%",
                       height: {
                         base: "100%",
                         medium: "auto",
                       },
-                      padding: {
+                      padding: 24,
+                      outline: "2px solid accent",
+                      background: "background",
+                      borderRadius: {
                         base: 0,
-                        medium: 64,
+                        medium: 8,
                       },
-                      // and this is to re-enable the onMouseDown event
-                      pointerEvents: "auto",
                     })}
+                    style={{
+                      maxWidth,
+                      opacity,
+                      transform,
+                    }}
                   >
-                    <a.div
-                      className={css({
-                        position: "relative",
-                        width: "100%",
-                        height: {
-                          base: "100%",
-                          medium: "auto",
-                        },
-                        padding: 24,
-                        outline: "2px solid accent",
-                        background: "background",
-                        borderRadius: {
-                          base: 0,
-                          medium: 8,
-                        },
-                      })}
-                      style={{
-                        maxWidth,
-                        opacity,
-                        transform,
-                      }}
-                    >
-                      <div>
-                        {title && (
-                          <h1
-                            className={css({
-                              paddingBottom: 8,
-                              fontSize: 24,
-                            })}
-                          >
-                            {title}
-                          </h1>
-                        )}
-                        {children}
-                      </div>
-                      <div
-                        className={css({
-                          position: "absolute",
-                          top: 24,
-                          right: 24,
-                          display: "flex",
-                        })}
-                      >
-                        <TextButton
-                          label={<IconCross size={32} />}
-                          onClick={onClose}
+                    <div>
+                      {title && (
+                        <h1
                           className={css({
-                            color: "content!",
+                            paddingBottom: 8,
+                            fontSize: 24,
                           })}
-                        />
-                      </div>
-                    </a.div>
-                  </div>
-                </FocusTrap>
-              </div>
-            </a.section>
-          </div>
+                        >
+                          {title}
+                        </h1>
+                      )}
+                      {children}
+                    </div>
+                    <div
+                      className={css({
+                        position: "absolute",
+                        top: 24,
+                        right: 24,
+                        display: "flex",
+                      })}
+                    >
+                      <TextButton
+                        label={<IconCross size={32} />}
+                        onClick={onClose}
+                        className={css({
+                          color: "content!",
+                        })}
+                      />
+                    </div>
+                  </a.div>
+                </div>
+              </FocusTrap>
+            </div>
+          </a.section>
         )
       ))}
     </Root>

--- a/frontend/uikit/src/react-spring-web.d.ts
+++ b/frontend/uikit/src/react-spring-web.d.ts
@@ -1,22 +1,27 @@
 import "@react-spring/web";
+import { SpringValue } from "@react-spring/core";
+import { CSSProperties, ForwardRefExoticComponent, HTMLAttributes, Ref, RefObject, SVGAttributes } from "react";
 
 declare module "@react-spring/web" {
-  import { ComponentPropsWithRef, ElementType, ForwardRefExoticComponent } from "react";
+  type CreateAnimatedProps<Props, Element> =
+    & Omit<Props, "style">
+    & {
+      ref?: Ref<Element> | RefObject<Element>;
+      style?: { [K in keyof CSSProperties]?: CSSProperties[K] | SpringValue<CSSProperties[K]> };
+    };
 
-  interface AnimatedComponent<T extends ElementType> {
-    <P extends ComponentPropsWithRef<T>>(props: P): JSX.Element;
-  }
+  type AnimatedHTMLProps<E extends HTMLElement = HTMLElement> = CreateAnimatedProps<HTMLAttributes<E>, E>;
+  type AnimatedSVGProps<E extends SVGElement = SVGElement> = CreateAnimatedProps<SVGAttributes<E>, E>;
 
-  type AnimatedTag<T extends ElementType> = AnimatedComponent<T>;
+  export const a: {
+    // HTML
+    button: ForwardRefExoticComponent<AnimatedHTMLProps<HTMLButtonElement>>;
+    div: ForwardRefExoticComponent<AnimatedHTMLProps<HTMLDivElement>>;
+    section: ForwardRefExoticComponent<AnimatedHTMLProps<HTMLElement>>;
 
-  interface AnimatedAPI {
-    button: AnimatedTag<"button"> & HTMLButtonElement;
-    div: AnimatedTag<"div"> & HTMLDivElement;
-    rect: AnimatedTag<"rect"> & SVGRectElement;
-    section: AnimatedTag<"section"> & HTMLElement;
-    <T extends ElementType>(component: T): AnimatedTag<T>;
-  }
+    // SVG
+    rect: ForwardRefExoticComponent<AnimatedSVGProps<SVGRectElement>>;
+  };
 
-  export const a: AnimatedAPI;
-  export const animated: AnimatedAPI;
+  export const animated: typeof a;
 }


### PR DESCRIPTION
The react-spring type override have been updated to fix onMouseDown()
and other events, allowing to remove the extra wrapper that was causing
the issue on Modal.
