### PR TITLE
Staking screen + tx flow update

### DIFF
--- a/frontend/app/src/comps/Amount/Amount.tsx
+++ b/frontend/app/src/comps/Amount/Amount.tsx
@@ -6,6 +6,7 @@ import { a, useTransition } from "@react-spring/web";
 
 export function Amount({
   fallback = "",
+  fixed = false, // fixed numbers width
   format,
   percentage = false,
   prefix = "",
@@ -14,6 +15,7 @@ export function Amount({
   value,
 }: {
   fallback?: string;
+  fixed?: boolean;
   format?: FmtnumPresetName | number;
   percentage?: boolean;
   prefix?: string;
@@ -97,7 +99,10 @@ export function Amount({
         transformOrigin: "50% 50%",
         textDecoration: "inherit",
       })}
-      style={style}
+      style={{
+        transform: style.transform,
+        fontVariantNumeric: fixed ? "tabular-nums" : undefined,
+      }}
     >
       {content}
     </a.div>

--- a/frontend/app/src/comps/VoteInput/VoteInput.tsx
+++ b/frontend/app/src/comps/VoteInput/VoteInput.tsx
@@ -117,18 +117,21 @@ export function VoteInput({
         }}
         onBlur={() => {
           setIsFocused(false);
+
+          // invalid input => reset to current value
           const parsed = parseInputFloat(inputValue.replace("%", ""));
-          if (parsed) {
-            onChange(
-              dnumMax(dnumMin(dn.from(100, 18), parsed), dn.from(0, 18)),
-            );
-          } else {
-            // invalid input => reset to current value
+          if (!parsed) {
             setInputValue(value ? dn.toString(dn.mul(value, 100)) : "0");
           }
         }}
         onChange={(event) => {
           setInputValue(event.target.value);
+          const parsed = parseInputFloat(event.target.value);
+          if (parsed) {
+            onChange(
+              dnumMax(dnumMin(dn.from(100, 18), parsed), dn.from(0, 18)),
+            );
+          }
         }}
         value={displayValue}
         placeholder="0%"

--- a/frontend/app/src/content.tsx
+++ b/frontend/app/src/content.tsx
@@ -421,7 +421,10 @@ export default {
         By staking LQTY you can vote on incentives for Liquity V2, while still earning Liquity V1 fees.
       </>
     ),
-    learnMore: ["https://docs.liquity.org/faq/staking", "Learn more"],
+    learnMore: [
+      "https://docs.liquity.org/v2-faq/lqty-staking",
+      "Learn more",
+    ],
     accountDetails: {
       myDeposit: "My deposit",
       votingPower: "Voting power",
@@ -467,6 +470,17 @@ export default {
           Rewards will be paid out as part of the update transaction.
         </>,
       ],
+      votingShare: (
+        <>
+          Your voting share is the amount of LQTY you have staked and that is available to vote, divided by the total
+          amount of LQTY staked via the governance contract.
+        </>
+      ),
+      votingPower: (
+        <>
+          Your relative voting power changes over time, depending on your and others allocations of LQTY.
+        </>
+      ),
     },
   },
 } as const;

--- a/frontend/app/src/dnum-utils.ts
+++ b/frontend/app/src/dnum-utils.ts
@@ -2,8 +2,11 @@ import type { Dnum, Numberish } from "dnum";
 
 import * as dn from "dnum";
 
-export function dnum18(value: string | bigint | number): Dnum {
-  return [BigInt(value), 18];
+export function dnum18(value: null | undefined): null;
+export function dnum18(value: string | bigint | number): Dnum;
+export function dnum18(value: string | bigint | number | null | undefined): Dnum | null;
+export function dnum18(value: string | bigint | number | null | undefined): Dnum | null {
+  return value === undefined || value === null ? null : [BigInt(value), 18];
 }
 
 export function dnumOrNull(value: Numberish | null | undefined, decimals: number): Dnum | null {

--- a/frontend/app/src/dnum-utils.ts
+++ b/frontend/app/src/dnum-utils.ts
@@ -2,6 +2,9 @@ import type { Dnum, Numberish } from "dnum";
 
 import * as dn from "dnum";
 
+export const DNUM_0 = dn.from(0, 18);
+export const DNUM_1 = dn.from(1, 18);
+
 export function dnum18(value: null | undefined): null;
 export function dnum18(value: string | bigint | number): Dnum;
 export function dnum18(value: string | bigint | number | null | undefined): Dnum | null;
@@ -27,9 +30,6 @@ export function dnumMax(a: Dnum, ...rest: Dnum[]) {
 export function dnumMin(a: Dnum, ...rest: Dnum[]) {
   return rest.reduce((min, value) => dn.lt(value, min) ? value : min, a);
 }
-
-export const DNUM_0 = dn.from(0, 18);
-export const DNUM_1 = dn.from(1, 18);
 
 export const jsonStringifyWithDnum: typeof JSON.stringify = (data, replacer, space) => {
   return JSON.stringify(

--- a/frontend/app/src/liquity-governance.ts
+++ b/frontend/app/src/liquity-governance.ts
@@ -152,12 +152,30 @@ const KnownInitiativesSchema = v.record(
     vAddress(),
     v.transform((address) => address.toLowerCase()),
   ),
-  v.object({ name: v.string(), group: v.string() }),
+  v.pipe(
+    v.object({
+      name: v.string(),
+      name_link: v.optional(v.pipe(v.string(), v.url())),
+      group: v.string(),
+    }),
+    v.transform(({ name_link = null, ...initiative }) => ({
+      ...initiative,
+      url: name_link,
+    })),
+  ),
 );
 
-export async function getKnownInitiatives(knownInitiativesUrl: string) {
-  const response = await fetch(knownInitiativesUrl);
-  return v.parse(KnownInitiativesSchema, await response.json());
+export async function getKnownInitiatives(knownInitiativesUrl: string): Promise<
+  | v.InferOutput<typeof KnownInitiativesSchema>
+  | null
+> {
+  try {
+    const response = await fetch(knownInitiativesUrl);
+    const data = await response.json();
+    return v.parse(KnownInitiativesSchema, data);
+  } catch (_) {
+    return null;
+  }
 }
 
 export function useNamedInitiatives() {
@@ -171,13 +189,14 @@ export function useNamedInitiatives() {
           : null,
       ]);
       return initiatives.map((address): Initiative => {
-        const knownInitiative = knownInitiatives?.[address];
+        const ki = knownInitiatives?.[address];
         return {
           address,
-          name: knownInitiative?.name ?? null,
+          name: ki?.name ?? null,
           pairVolume: null,
-          protocol: knownInitiative?.group ?? null,
+          protocol: ki?.group ?? null,
           tvl: null,
+          url: ki?.url ?? null,
           votesDistribution: null,
         };
       });
@@ -232,25 +251,39 @@ export function useInitiativesStates(initiatives: Address[]) {
 export async function getUserAllocations(
   wagmiConfig: WagmiConfig,
   account: Address,
-  initiatives: Initiative[],
+  initiatives?: Address[],
 ) {
+  if (!initiatives) {
+    initiatives = await getIndexedInitiatives();
+  }
+
   const Governance = getProtocolContract("Governance");
 
   const allocationsByInitiative = await readContracts(wagmiConfig, {
     allowFailure: false,
-    contracts: initiatives.map((initiative) => ({
+    contracts: initiatives.map((address) => ({
       ...Governance,
       functionName: "lqtyAllocatedByUserToInitiative",
-      args: [account, initiative.address],
+      args: [account, address],
     } as const)),
   });
 
   return allocationsByInitiative.map((allocation, index) => {
-    const initiative = initiatives[index]?.address;
+    const initiative = initiatives[index];
     if (!initiative) throw new Error(); // should never happen
-    const [voteLQTY, _voteOffset, vetoLQTY, _vetoOffset] = allocation;
+    const [voteLQTY, _, vetoLQTY] = allocation;
     return { vetoLQTY, voteLQTY, initiative };
   });
+}
+
+export async function getUserAllocatedInitiatives(
+  wagmiConfig: WagmiConfig,
+  account: Address,
+  initiatives?: Address[],
+) {
+  return (await getUserAllocations(wagmiConfig, account, initiatives))
+    .filter(({ voteLQTY, vetoLQTY }) => (voteLQTY + vetoLQTY) > 0n)
+    .map(({ initiative }) => initiative);
 }
 
 export async function getUserState(
@@ -288,7 +321,11 @@ export function useGovernanceUser(account: Address | null) {
 
     const [userState, allocations] = await Promise.all([
       getUserStates(wagmiConfig, account),
-      getUserAllocations(wagmiConfig, account, initiatives.data),
+      getUserAllocations(
+        wagmiConfig,
+        account,
+        initiatives.data.map((i) => i.address),
+      ),
     ]);
 
     return { ...userState, allocations };

--- a/frontend/app/src/liquity-utils.ts
+++ b/frontend/app/src/liquity-utils.ts
@@ -299,56 +299,44 @@ export function useStakePosition(address: null | Address) {
     },
   });
 
-  const stakePosition = useReadContracts({
-    contracts: [
-      {
-        ...LqtyStaking,
-        functionName: "stakes",
-        args: [userProxyAddress.data ?? "0x"],
-      },
-      {
-        ...LqtyStaking,
-        functionName: "totalLQTYStaked",
-      },
-      {
-        ...LqtyStaking,
-        functionName: "getPendingETHGain",
-        args: [userProxyAddress.data ?? "0x"],
-      },
-      {
-        ...LqtyStaking,
-        functionName: "getPendingLUSDGain",
-        args: [userProxyAddress.data ?? "0x"],
-      },
-      {
-        ...LusdToken,
-        functionName: "balanceOf",
-        args: [userProxyAddress.data ?? "0x"],
-      },
-    ],
+  return useReadContracts({
+    contracts: [{
+      ...LqtyStaking,
+      functionName: "stakes",
+      args: [userProxyAddress.data ?? "0x"],
+    }, {
+      ...LqtyStaking,
+      functionName: "getPendingETHGain",
+      args: [userProxyAddress.data ?? "0x"],
+    }, {
+      ...LqtyStaking,
+      functionName: "getPendingLUSDGain",
+      args: [userProxyAddress.data ?? "0x"],
+    }, {
+      ...LusdToken,
+      functionName: "balanceOf",
+      args: [userProxyAddress.data ?? "0x"],
+    }],
     query: {
       enabled: Boolean(address) && userProxyAddress.isSuccess && userProxyBalance.isSuccess,
       select: ([
         depositResult,
-        totalStakedResult,
         pendingEthGainResult,
         pendingLusdGainResult,
         lusdBalanceResult,
       ]): PositionStake | null => {
         if (
-          depositResult.status === "failure" || totalStakedResult.status === "failure"
+          depositResult.status === "failure"
           || pendingEthGainResult.status === "failure" || pendingLusdGainResult.status === "failure"
           || lusdBalanceResult.status === "failure"
         ) {
           return null;
         }
         const deposit = dnum18(depositResult.result);
-        const totalStaked = dnum18(totalStakedResult.result);
         return {
           type: "stake",
           deposit,
           owner: address ?? "0x",
-          totalStaked,
           rewards: {
             eth: dnum18(pendingEthGainResult.result + (userProxyBalance.data?.value ?? 0n)),
             lusd: dnum18(pendingLusdGainResult.result + lusdBalanceResult.result),
@@ -357,8 +345,6 @@ export function useStakePosition(address: null | Address) {
       },
     },
   });
-
-  return stakePosition;
 }
 
 export function useTroveNftUrl(branchId: null | BranchId, troveId: null | TroveId) {

--- a/frontend/app/src/screens/StakeScreen/PanelVoting.tsx
+++ b/frontend/app/src/screens/StakeScreen/PanelVoting.tsx
@@ -1,5 +1,6 @@
 import type { InitiativeStatus } from "@/src/liquity-governance";
 import type { Address, Dnum, Entries, Initiative, Vote, VoteAllocation, VoteAllocations } from "@/src/types";
+import type { ReactNode } from "react";
 
 import { Amount } from "@/src/comps/Amount/Amount";
 import { FlowButton } from "@/src/comps/FlowButton/FlowButton";
@@ -684,45 +685,25 @@ export function PanelVoting() {
           ),
         }}
       />
-
-      {!allowSubmit && hasAnyAllocationChange && (
-        <div
-          className={css({
-            fontSize: 14,
-            textAlign: "center",
-          })}
-        >
-          {dn.eq(stakedLQTY, 0)
-            ? (
-              <>
-                You have no voting power to allocate. Please stake LQTY before voting.
-              </>
-            )
-            : hasAnyAllocations
-            ? (
-              <>
-                You must either allocate 100% of your voting power to upvote or downvote initiatives, or 0% to
-                deallocate your votes.
-              </>
-            )
-            : (
-              <>
-                You must allocate 100% of your voting power to upvote or downvote initiatives.
-              </>
-            )}
-        </div>
-      )}
-      {allowSubmit && dn.eq(remainingVotingPower, 1) && (
-        <div
-          className={css({
-            padding: "0 16px",
-            fontSize: 14,
-            textAlign: "center",
-          })}
-        >
-          Your votes will be reset to 0% for all initiatives.
-        </div>
-      )}
+      {!allowSubmit && dn.eq(stakedLQTY, 0)
+        ? (
+          <FlowButtonNote>
+            You have no voting power to allocate. Please stake LQTY before voting.
+          </FlowButtonNote>
+        )
+        : !allowSubmit && hasAnyAllocations
+        ? (
+          <FlowButtonNote>
+            You can reset your votes by allocating 0% to all initiatives.
+          </FlowButtonNote>
+        )
+        : allowSubmit && dn.eq(remainingVotingPower, 1)
+        ? (
+          <FlowButtonNote>
+            Your votes will be reset to 0% for all initiatives.
+          </FlowButtonNote>
+        )
+        : null}
     </section>
   );
 }
@@ -777,7 +758,22 @@ function InitiativeRow({
                 maxWidth: 200,
               })}
             >
-              {initiative.name ?? "Initiative"}
+              {initiative.url
+                ? (
+                  <LinkTextButton
+                    external
+                    href={initiative.url}
+                    label={
+                      <>
+                        {initiative.name ?? "Initiative"}
+                        <IconExternal size={16} />
+                      </>
+                    }
+                  />
+                )
+                : (
+                  initiative.name ?? "Initiative"
+                )}
             </div>
             {initiativesStatus && (
               <div
@@ -794,8 +790,9 @@ function InitiativeRow({
                   borderRadius: 8,
                   userSelect: "none",
                   textTransform: "lowercase",
+                  transform: "translateY(1px)",
 
-                  "--color-warning": "#121B44",
+                  "--color-warning": "token(colors.warningAltContent)",
                   "--background-warning": "token(colors.warningAlt)",
                 })}
                 style={{
@@ -907,18 +904,36 @@ function Vote({
             display: "flex",
             alignItems: "center",
             gap: 4,
+            "--color-disabled": "token(colors.disabledContent)",
           })}
         >
           {vote === "for" && <IconUpvote size={24} />}
-          {vote === "against" && <IconDownvote size={24} />}
-          <div>
-            {fmtnum(share, "pct2")}%
+          {vote === "against" && (
+            <div
+              className={css({
+                transform: "translateY(2px)",
+                color: disabled ? "var(--color-disabled)" : undefined,
+              })}
+            >
+              <IconDownvote size={24} />
+            </div>
+          )}
+          <div
+            className={css({
+              width: 30,
+            })}
+            style={{
+              textDecoration: disabled ? "line-through" : undefined,
+              color: disabled ? "var(--color-disabled)" : undefined,
+            }}
+          >
+            {fmtnum(share, { preset: "pct2", suffix: "%" })}
           </div>
         </div>
         <Button
           disabled={disabled}
           size="mini"
-          title="Change"
+          title={disabled ? "Initiative disabled" : "Change allocation"}
           label={<IconEdit size={20} />}
           onClick={onEdit}
           className={css({
@@ -926,6 +941,23 @@ function Vote({
           })}
         />
       </div>
+    </div>
+  );
+}
+
+function FlowButtonNote({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <div
+      className={css({
+        fontSize: 14,
+        textAlign: "center",
+      })}
+    >
+      {children}
     </div>
   );
 }

--- a/frontend/app/src/subgraph.ts
+++ b/frontend/app/src/subgraph.ts
@@ -227,19 +227,3 @@ export async function getIndexedInitiatives() {
   const { governanceInitiatives } = await graphQuery(GovernanceInitiatives);
   return governanceInitiatives.map((initiative) => initiative.id as Address);
 }
-
-const GovernanceUserAllocated = graphql(`
-  query GovernanceUserAllocations($id: ID!) {
-    governanceUser(id: $id) {
-      allocated
-    }
-  }
-`);
-
-// get the allocated initiatives for a given account
-export async function getIndexedUserAllocated(account: Address) {
-  const allocated = await graphQuery(GovernanceUserAllocated, {
-    id: account.toLowerCase(),
-  });
-  return (allocated.governanceUser?.allocated ?? []) as Address[];
-}

--- a/frontend/app/src/tx-flows/allocateVotingPower.tsx
+++ b/frontend/app/src/tx-flows/allocateVotingPower.tsx
@@ -4,10 +4,10 @@ import type { Address, Dnum, Initiative, VoteAllocation } from "@/src/types";
 import { AddressLink } from "@/src/comps/AddressLink/AddressLink";
 import { Amount } from "@/src/comps/Amount/Amount";
 import { GAS_ALLOCATE_LQTY_MIN_HEADROOM } from "@/src/constants";
+import { getUserAllocatedInitiatives } from "@/src/liquity-governance";
 import { getUserStates, useGovernanceUser, useNamedInitiatives } from "@/src/liquity-governance";
 import { TransactionDetailsRow } from "@/src/screens/TransactionsScreen/TransactionsScreen";
 import { TransactionStatus } from "@/src/screens/TransactionsScreen/TransactionStatus";
-import { getIndexedUserAllocated } from "@/src/subgraph";
 import { vVoteAllocations } from "@/src/valibot-utils";
 import { css } from "@/styled-system/css";
 import { IconDownvote, IconStake, IconUpvote } from "@liquity2/uikit";
@@ -219,7 +219,10 @@ export const allocateVotingPower: FlowDeclaration<AllocateVotingPowerRequest> = 
           }
         }
 
-        const allocated = await getIndexedUserAllocated(ctx.account);
+        const allocated = await getUserAllocatedInitiatives(
+          ctx.wagmiConfig,
+          ctx.account,
+        );
 
         return ctx.writeContract({
           ...ctx.contracts.Governance,

--- a/frontend/app/src/types.ts
+++ b/frontend/app/src/types.ts
@@ -111,7 +111,6 @@ export type PositionStake = {
   type: "stake";
   owner: Address;
   deposit: Dnum;
-  totalStaked: Dnum;
   rewards: {
     lusd: Dnum;
     eth: Dnum;
@@ -168,6 +167,7 @@ export type Initiative =
     address: Address;
     name: string | null;
     protocol: string | null;
+    url: string | null;
   }
   & (
     | { tvl: Dnum; pairVolume: Dnum; votesDistribution: Dnum }

--- a/frontend/app/src/valibot-utils.ts
+++ b/frontend/app/src/valibot-utils.ts
@@ -167,7 +167,6 @@ export function vPositionStake() {
     type: v.literal("stake"),
     owner: vAddress(),
     deposit: vDnum(),
-    totalStaked: vDnum(),
     rewards: v.object({
       lusd: vDnum(),
       eth: vDnum(),

--- a/frontend/uikit/src/Theme/Theme.tsx
+++ b/frontend/uikit/src/Theme/Theme.tsx
@@ -168,6 +168,7 @@ export const lightTheme = {
     tableBorder: "gray:100",
     warning: "yellow:400",
     warningAlt: "yellow:300",
+    warningAltContent: "blue:950",
     disabledBorder: "gray:200",
     disabledContent: "gray:500",
     disabledSurface: "gray:50",


### PR DESCRIPTION
User allocations (Stake screen):

- The user allocations amounts are now coming from the contract rather than the subgraph.
- The voting share is nw calculated against the LQTY staked through the Governance contract only, rather than all the LQTY staked.
- The totalStaked property has been removed from the PositionStake type.
- Stake summary: add the voting share too (rather than the voting power only).
- Stake summary: add a “partial” tag to indicate a partial allocation.
- Stake summary: add a two column layout on small viewports.
- Staking panel: improve the messages below the flow start button.

Initiatives:

- Known initiatives: add support for custom URLs (using "name_link").
- Improve the representation of disabled initiatives.
- Various minor changes.

Deposit stake tx flow:

- Votes are not deallocated anymore.

Withdraw stake tx flow:

- A message has been added to communicate that unstaking will reset the voting power.

Also:

- Amount: add a `fixed` prop to use a fixed numbers width
- dnum18(): accept null / undefined
- VoteInput: update on change rather than on blur
- Move more content to content.tsx
