### PR TITLE
Subgraph: add previousOwner

### DIFF
--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -46,6 +46,7 @@ type Trove @entity(immutable: false) {
   interestRate: BigInt!
   stake: BigInt!
   troveId: String!
+  previousOwner: Bytes!
 }
 
 type BorrowerInfo @entity(immutable: false) {
@@ -87,3 +88,4 @@ type GovernanceAllocation @entity(immutable: false) {
 type GovernanceInitiative @entity(immutable: false) {
   id: ID! # "initiativeAddress", e.g. "0x0000000000000000000000000000000000000000"
 }
+

--- a/subgraph/src/TroveManager.mapping.ts
+++ b/subgraph/src/TroveManager.mapping.ts
@@ -311,6 +311,7 @@ function createTrove(
   trove.status = "active";
   trove.troveId = troveId.toHexString();
   trove.updatedAt = timestamp;
+  trove.previousOwner = Address.zero();
 
   // batches are handled separately, not
   // when creating the trove but right after

--- a/subgraph/src/TroveNFT.mapping.ts
+++ b/subgraph/src/TroveNFT.mapping.ts
@@ -36,6 +36,7 @@ export function handleTransfer(event: TransferEvent): void {
   );
 
   // update the trove borrower
+  trove.previousOwner = trove.borrower;
   trove.borrower = event.params.to;
   trove.save();
 }


### PR DESCRIPTION
When the NFT gets transferred to 0x0, knowing if this is part of a liquidation or a normal transfer is difficult, since the transfer event happens before the `TroveOperation` event.

So instead of trying to detect that a transfer is part of a liquidation, `previousOwner` always reflects the previous owner before the last transfer.

This will allow to query the liquidated troves of given account by querying `{ status: liquidated, previousOwner: $account }`.