### PR TITLE
App: rely on the subgraph for the borrower of a liquidated position

### DIFF
--- a/frontend/app/src/comps/Positions/PositionCardLeverage.tsx
+++ b/frontend/app/src/comps/Positions/PositionCardLeverage.tsx
@@ -19,18 +19,20 @@ export function PositionCardLeverage({
   branchId,
   deposit,
   interestRate,
+  liquidated = false,
   statusTag,
   troveId,
 }:
   & Pick<
     PositionLoanCommitted,
     | "branchId"
-    | "deposit"
     | "interestRate"
     | "troveId"
   >
   & {
     debt: null | Dnum;
+    deposit: null | Dnum;
+    liquidated?: boolean;
     statusTag?: ReactNode;
   })
 {
@@ -42,7 +44,7 @@ export function PositionCardLeverage({
   const collateralPriceUsd = usePrice(token.symbol);
 
   const maxLtv = dn.from(1 / token.collateralRatio, 18);
-  const ltv = debt && collateralPriceUsd.data
+  const ltv = debt && deposit && collateralPriceUsd.data
     && getLtv(deposit, debt, collateralPriceUsd.data);
   const liquidationRisk = ltv && getLiquidationRisk(ltv, maxLtv);
   const redemptionRisk = getRedemptionRisk(interestRate);

--- a/frontend/app/src/comps/Positions/PositionCardLoan.tsx
+++ b/frontend/app/src/comps/Positions/PositionCardLoan.tsx
@@ -31,7 +31,13 @@ export function PositionCardLoan(
   return (
     <Card
       {...props}
-      debt={loan.data?.borrowed ?? null}
+      debt={!loan.data?.borrowed || loan.data.status === "liquidated"
+        ? null
+        : loan.data.borrowed}
+      deposit={!loan.data?.deposit || loan.data.status === "liquidated"
+        ? null
+        : loan.data.deposit}
+      liquidated={loan.data?.status === "liquidated"}
       statusTag={props.status === "liquidated"
         ? <LoanStatusTag status="liquidated" />
         : props.status === "redeemed"

--- a/frontend/app/src/graphql/gql.ts
+++ b/frontend/app/src/graphql/gql.ts
@@ -16,18 +16,18 @@ import * as types from './graphql';
  */
 type Documents = {
     "\n  query BlockNumber {\n    _meta {\n      block {\n        number\n      }\n    }\n  }\n": typeof types.BlockNumberDocument,
-    "\n  query BorrowerInfo($id: ID!) {\n    borrowerInfo(id: $id) {\n      nextOwnerIndexes\n    }\n  }\n": typeof types.BorrowerInfoDocument,
-    "\n  query TroveStatusesByAccount($account: Bytes!) {\n    troves(\n      where: {\n        or: [\n          { previousOwner: $account, status: liquidated },\n          { borrower: $account, status_in: [active,redeemed] }\n        ],\n      }\n      orderBy: updatedAt\n      orderDirection: desc\n    ) {\n      id\n      closedAt\n      createdAt\n      mightBeLeveraged\n      status\n    }\n  }\n": typeof types.TroveStatusesByAccountDocument,
-    "\n  query TroveStatusById($id: ID!) {\n    trove(id: $id) {\n      id\n      closedAt\n      createdAt\n      mightBeLeveraged\n      status\n    }\n  }\n": typeof types.TroveStatusByIdDocument,
+    "\n  query NextOwnerIndexesByBorrower($id: ID!) {\n    borrowerInfo(id: $id) {\n      nextOwnerIndexes\n    }\n  }\n": typeof types.NextOwnerIndexesByBorrowerDocument,
+    "\n  query TrovesByAccount($account: Bytes!) {\n    troves(\n      where: {\n        or: [\n          { previousOwner: $account, status: liquidated },\n          { borrower: $account, status_in: [active,redeemed] }\n        ],\n      }\n      orderBy: updatedAt\n      orderDirection: desc\n    ) {\n      id\n      closedAt\n      createdAt\n      mightBeLeveraged\n      status\n    }\n  }\n": typeof types.TrovesByAccountDocument,
+    "\n  query TroveById($id: ID!) {\n    trove(id: $id) {\n      id\n      borrower\n      closedAt\n      createdAt\n      mightBeLeveraged\n      previousOwner\n      status\n    }\n  }\n": typeof types.TroveByIdDocument,
     "\n  query InterestBatches($ids: [ID!]!) {\n    interestBatches(where: { id_in: $ids }) {\n      collateral {\n        collIndex\n      }\n      batchManager\n      debt\n      coll\n      annualInterestRate\n      annualManagementFee\n    }\n  }\n": typeof types.InterestBatchesDocument,
     "\n  query AllInterestRateBrackets {\n    interestRateBrackets(orderBy: rate) {\n      collateral {\n        collIndex\n      }\n      rate\n      totalDebt\n    }\n  }\n": typeof types.AllInterestRateBracketsDocument,
     "\n  query GovernanceInitiatives {\n    governanceInitiatives {\n      id\n    }\n  }\n": typeof types.GovernanceInitiativesDocument,
 };
 const documents: Documents = {
     "\n  query BlockNumber {\n    _meta {\n      block {\n        number\n      }\n    }\n  }\n": types.BlockNumberDocument,
-    "\n  query BorrowerInfo($id: ID!) {\n    borrowerInfo(id: $id) {\n      nextOwnerIndexes\n    }\n  }\n": types.BorrowerInfoDocument,
-    "\n  query TroveStatusesByAccount($account: Bytes!) {\n    troves(\n      where: {\n        or: [\n          { previousOwner: $account, status: liquidated },\n          { borrower: $account, status_in: [active,redeemed] }\n        ],\n      }\n      orderBy: updatedAt\n      orderDirection: desc\n    ) {\n      id\n      closedAt\n      createdAt\n      mightBeLeveraged\n      status\n    }\n  }\n": types.TroveStatusesByAccountDocument,
-    "\n  query TroveStatusById($id: ID!) {\n    trove(id: $id) {\n      id\n      closedAt\n      createdAt\n      mightBeLeveraged\n      status\n    }\n  }\n": types.TroveStatusByIdDocument,
+    "\n  query NextOwnerIndexesByBorrower($id: ID!) {\n    borrowerInfo(id: $id) {\n      nextOwnerIndexes\n    }\n  }\n": types.NextOwnerIndexesByBorrowerDocument,
+    "\n  query TrovesByAccount($account: Bytes!) {\n    troves(\n      where: {\n        or: [\n          { previousOwner: $account, status: liquidated },\n          { borrower: $account, status_in: [active,redeemed] }\n        ],\n      }\n      orderBy: updatedAt\n      orderDirection: desc\n    ) {\n      id\n      closedAt\n      createdAt\n      mightBeLeveraged\n      status\n    }\n  }\n": types.TrovesByAccountDocument,
+    "\n  query TroveById($id: ID!) {\n    trove(id: $id) {\n      id\n      borrower\n      closedAt\n      createdAt\n      mightBeLeveraged\n      previousOwner\n      status\n    }\n  }\n": types.TroveByIdDocument,
     "\n  query InterestBatches($ids: [ID!]!) {\n    interestBatches(where: { id_in: $ids }) {\n      collateral {\n        collIndex\n      }\n      batchManager\n      debt\n      coll\n      annualInterestRate\n      annualManagementFee\n    }\n  }\n": types.InterestBatchesDocument,
     "\n  query AllInterestRateBrackets {\n    interestRateBrackets(orderBy: rate) {\n      collateral {\n        collIndex\n      }\n      rate\n      totalDebt\n    }\n  }\n": types.AllInterestRateBracketsDocument,
     "\n  query GovernanceInitiatives {\n    governanceInitiatives {\n      id\n    }\n  }\n": types.GovernanceInitiativesDocument,
@@ -40,15 +40,15 @@ export function graphql(source: "\n  query BlockNumber {\n    _meta {\n      blo
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
-export function graphql(source: "\n  query BorrowerInfo($id: ID!) {\n    borrowerInfo(id: $id) {\n      nextOwnerIndexes\n    }\n  }\n"): typeof import('./graphql').BorrowerInfoDocument;
+export function graphql(source: "\n  query NextOwnerIndexesByBorrower($id: ID!) {\n    borrowerInfo(id: $id) {\n      nextOwnerIndexes\n    }\n  }\n"): typeof import('./graphql').NextOwnerIndexesByBorrowerDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
-export function graphql(source: "\n  query TroveStatusesByAccount($account: Bytes!) {\n    troves(\n      where: {\n        or: [\n          { previousOwner: $account, status: liquidated },\n          { borrower: $account, status_in: [active,redeemed] }\n        ],\n      }\n      orderBy: updatedAt\n      orderDirection: desc\n    ) {\n      id\n      closedAt\n      createdAt\n      mightBeLeveraged\n      status\n    }\n  }\n"): typeof import('./graphql').TroveStatusesByAccountDocument;
+export function graphql(source: "\n  query TrovesByAccount($account: Bytes!) {\n    troves(\n      where: {\n        or: [\n          { previousOwner: $account, status: liquidated },\n          { borrower: $account, status_in: [active,redeemed] }\n        ],\n      }\n      orderBy: updatedAt\n      orderDirection: desc\n    ) {\n      id\n      closedAt\n      createdAt\n      mightBeLeveraged\n      status\n    }\n  }\n"): typeof import('./graphql').TrovesByAccountDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
-export function graphql(source: "\n  query TroveStatusById($id: ID!) {\n    trove(id: $id) {\n      id\n      closedAt\n      createdAt\n      mightBeLeveraged\n      status\n    }\n  }\n"): typeof import('./graphql').TroveStatusByIdDocument;
+export function graphql(source: "\n  query TroveById($id: ID!) {\n    trove(id: $id) {\n      id\n      borrower\n      closedAt\n      createdAt\n      mightBeLeveraged\n      previousOwner\n      status\n    }\n  }\n"): typeof import('./graphql').TroveByIdDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/frontend/app/src/graphql/graphql.ts
+++ b/frontend/app/src/graphql/graphql.ts
@@ -1121,26 +1121,26 @@ export type BlockNumberQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type BlockNumberQuery = { __typename?: 'Query', _meta?: { __typename?: '_Meta_', block: { __typename?: '_Block_', number: number } } | null };
 
-export type BorrowerInfoQueryVariables = Exact<{
+export type NextOwnerIndexesByBorrowerQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
 
 
-export type BorrowerInfoQuery = { __typename?: 'Query', borrowerInfo?: { __typename?: 'BorrowerInfo', nextOwnerIndexes: Array<number> } | null };
+export type NextOwnerIndexesByBorrowerQuery = { __typename?: 'Query', borrowerInfo?: { __typename?: 'BorrowerInfo', nextOwnerIndexes: Array<number> } | null };
 
-export type TroveStatusesByAccountQueryVariables = Exact<{
+export type TrovesByAccountQueryVariables = Exact<{
   account: Scalars['Bytes']['input'];
 }>;
 
 
-export type TroveStatusesByAccountQuery = { __typename?: 'Query', troves: Array<{ __typename?: 'Trove', id: string, closedAt?: bigint | null, createdAt: bigint, mightBeLeveraged: boolean, status: TroveStatus }> };
+export type TrovesByAccountQuery = { __typename?: 'Query', troves: Array<{ __typename?: 'Trove', id: string, closedAt?: bigint | null, createdAt: bigint, mightBeLeveraged: boolean, status: TroveStatus }> };
 
-export type TroveStatusByIdQueryVariables = Exact<{
+export type TroveByIdQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
 
 
-export type TroveStatusByIdQuery = { __typename?: 'Query', trove?: { __typename?: 'Trove', id: string, closedAt?: bigint | null, createdAt: bigint, mightBeLeveraged: boolean, status: TroveStatus } | null };
+export type TroveByIdQuery = { __typename?: 'Query', trove?: { __typename?: 'Trove', id: string, borrower: string, closedAt?: bigint | null, createdAt: bigint, mightBeLeveraged: boolean, previousOwner: string, status: TroveStatus } | null };
 
 export type InterestBatchesQueryVariables = Exact<{
   ids: Array<Scalars['ID']['input']> | Scalars['ID']['input'];
@@ -1187,15 +1187,15 @@ export const BlockNumberDocument = new TypedDocumentString(`
   }
 }
     `) as unknown as TypedDocumentString<BlockNumberQuery, BlockNumberQueryVariables>;
-export const BorrowerInfoDocument = new TypedDocumentString(`
-    query BorrowerInfo($id: ID!) {
+export const NextOwnerIndexesByBorrowerDocument = new TypedDocumentString(`
+    query NextOwnerIndexesByBorrower($id: ID!) {
   borrowerInfo(id: $id) {
     nextOwnerIndexes
   }
 }
-    `) as unknown as TypedDocumentString<BorrowerInfoQuery, BorrowerInfoQueryVariables>;
-export const TroveStatusesByAccountDocument = new TypedDocumentString(`
-    query TroveStatusesByAccount($account: Bytes!) {
+    `) as unknown as TypedDocumentString<NextOwnerIndexesByBorrowerQuery, NextOwnerIndexesByBorrowerQueryVariables>;
+export const TrovesByAccountDocument = new TypedDocumentString(`
+    query TrovesByAccount($account: Bytes!) {
   troves(
     where: {or: [{previousOwner: $account, status: liquidated}, {borrower: $account, status_in: [active, redeemed]}]}
     orderBy: updatedAt
@@ -1208,18 +1208,20 @@ export const TroveStatusesByAccountDocument = new TypedDocumentString(`
     status
   }
 }
-    `) as unknown as TypedDocumentString<TroveStatusesByAccountQuery, TroveStatusesByAccountQueryVariables>;
-export const TroveStatusByIdDocument = new TypedDocumentString(`
-    query TroveStatusById($id: ID!) {
+    `) as unknown as TypedDocumentString<TrovesByAccountQuery, TrovesByAccountQueryVariables>;
+export const TroveByIdDocument = new TypedDocumentString(`
+    query TroveById($id: ID!) {
   trove(id: $id) {
     id
+    borrower
     closedAt
     createdAt
     mightBeLeveraged
+    previousOwner
     status
   }
 }
-    `) as unknown as TypedDocumentString<TroveStatusByIdQuery, TroveStatusByIdQueryVariables>;
+    `) as unknown as TypedDocumentString<TroveByIdQuery, TroveByIdQueryVariables>;
 export const InterestBatchesDocument = new TypedDocumentString(`
     query InterestBatches($ids: [ID!]!) {
   interestBatches(where: {id_in: $ids}) {

--- a/frontend/app/src/subgraph.ts
+++ b/frontend/app/src/subgraph.ts
@@ -6,6 +6,15 @@ import { SUBGRAPH_URL } from "@/src/env";
 import { graphql } from "@/src/graphql";
 import { getPrefixedTroveId } from "@/src/liquity-utils";
 
+type IndexedTrove = {
+  id: string;
+  borrower: Address;
+  closedAt: number | null;
+  createdAt: number;
+  mightBeLeveraged: boolean;
+  status: string;
+};
+
 async function graphQuery<TResult, TVariables>(
   query: TypedDocumentString<TResult, TVariables>,
   ...[variables]: TVariables extends Record<string, never> ? [] : [TVariables]
@@ -51,8 +60,8 @@ export async function getIndexedBlockNumber() {
   return BigInt(result._meta?.block.number ?? -1);
 }
 
-const NextOwnerIndexesByBorrower = graphql(`
-  query BorrowerInfo($id: ID!) {
+const NextOwnerIndexesByBorrowerQuery = graphql(`
+  query NextOwnerIndexesByBorrower($id: ID!) {
     borrowerInfo(id: $id) {
       nextOwnerIndexes
     }
@@ -64,14 +73,14 @@ export async function getNextOwnerIndex(
   borrower: Address,
 ): Promise<number> {
   const { borrowerInfo } = await graphQuery(
-    NextOwnerIndexesByBorrower,
+    NextOwnerIndexesByBorrowerQuery,
     { id: borrower.toLowerCase() },
   );
   return Number(borrowerInfo?.nextOwnerIndexes[branchId] ?? 0);
 }
 
 const TrovesByAccountQuery = graphql(`
-  query TroveStatusesByAccount($account: Bytes!) {
+  query TrovesByAccount($account: Bytes!) {
     troves(
       where: {
         or: [
@@ -91,20 +100,13 @@ const TrovesByAccountQuery = graphql(`
   }
 `);
 
-export async function getIndexedTrovesByAccount(
-  account: Address,
-): Promise<{
-  id: string;
-  closedAt: number | null;
-  createdAt: number;
-  mightBeLeveraged: boolean;
-  status: string;
-}[]> {
+export async function getIndexedTrovesByAccount(account: Address): Promise<IndexedTrove[]> {
   const { troves } = await graphQuery(TrovesByAccountQuery, {
     account: account.toLowerCase(),
   });
   return troves.map((trove) => ({
     id: trove.id,
+    borrower: account,
     closedAt: trove.closedAt === null || trove.closedAt === undefined
       ? null
       : Number(trove.closedAt) * 1000,
@@ -115,22 +117,30 @@ export async function getIndexedTrovesByAccount(
 }
 
 const TroveByIdQuery = graphql(`
-  query TroveStatusById($id: ID!) {
+  query TroveById($id: ID!) {
     trove(id: $id) {
       id
+      borrower
       closedAt
       createdAt
       mightBeLeveraged
+      previousOwner
       status
     }
   }
 `);
 
-export async function getIndexedTroveById(branchId: BranchId, troveId: TroveId) {
+export async function getIndexedTroveById(
+  branchId: BranchId,
+  troveId: TroveId,
+): Promise<IndexedTrove | null> {
   const prefixedTroveId = getPrefixedTroveId(branchId, troveId);
   const { trove } = await graphQuery(TroveByIdQuery, { id: prefixedTroveId });
   return !trove ? null : {
     id: trove.id,
+    borrower: (
+      trove.status === "liquidated" ? trove.previousOwner : trove.borrower
+    ) as Address,
     closedAt: trove.closedAt === null || trove.closedAt === undefined
       ? null
       : Number(trove.closedAt) * 1000,
@@ -216,7 +226,7 @@ export async function getAllInterestRateBrackets() {
     });
 }
 
-const GovernanceInitiatives = graphql(`
+const GovernanceInitiativesQuery = graphql(`
   query GovernanceInitiatives {
     governanceInitiatives {
       id
@@ -226,6 +236,6 @@ const GovernanceInitiatives = graphql(`
 
 // get all the registered initiatives
 export async function getIndexedInitiatives() {
-  const { governanceInitiatives } = await graphQuery(GovernanceInitiatives);
+  const { governanceInitiatives } = await graphQuery(GovernanceInitiativesQuery);
   return governanceInitiatives.map((initiative) => initiative.id as Address);
 }


### PR DESCRIPTION
This fixes an issue where the borrower of a liquidated position was seen
as the zero address (which is always the owner for liquidated positions)
rather than the previous owner, available on the subgraph.

Also:

- Improve the loading state on the LoanScreen when the collateral
  surplus is displayed.
- Add the IndexedTrove type for clarity.
- Improve the position card in liquidated state.
- Unify the subgraph query names.
- On the LoanScreen, fix an error with react-spring trying to add a ref to a fragment.
