### PR TITLE
App: make the redemption risk relative to the debt per rate bucket

### DIFF
--- a/frontend/app/src/comps/InterestRateField/InterestRateField.tsx
+++ b/frontend/app/src/comps/InterestRateField/InterestRateField.tsx
@@ -17,7 +17,7 @@ import { a } from "@react-spring/web";
 import { blo } from "blo";
 import * as dn from "dnum";
 import Image from "next/image";
-import { memo, useEffect, useId, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { match } from "ts-pattern";
 import { DelegateModal } from "./DelegateModal";
 import { IcStrategiesModal } from "./IcStrategiesModal";
@@ -32,6 +32,10 @@ const DELEGATE_MODES = [
 ] as const;
 
 export type DelegateMode = typeof DELEGATE_MODES[number];
+
+const SHOW_AVERAGE_BUTTON_MODES: DelegateMode[] = [
+  "manual",
+] as const;
 
 export const InterestRateField = memo(
   function InterestRateField({
@@ -245,7 +249,7 @@ export const InterestRateField = memo(
                 })}
               >
                 <div>Interest rate</div>
-                {averageInterestRate.data && (
+                {averageInterestRate.data && SHOW_AVERAGE_BUTTON_MODES.includes(mode) && (
                   <div>
                     <TextButton
                       size="small"
@@ -435,9 +439,7 @@ function ManualInterestRateSlider({
   interestChartData: ReturnType<typeof useInterestRateChartData>;
   interestRate: Dnum | null;
 }) {
-  const value = useMemo(() => {
-    const rate = interestRate?.[0] ?? 0n;
-    const chartRates = interestChartData.data?.map(({ rate }) => rate[0]);
+  const rateToSliderPosition = useCallback((rate: bigint, chartRates: bigint[]) => {
     if (!rate || !chartRates || chartRates.length === 0) return 0;
 
     const firstRate = chartRates.at(0) ?? 0n;
@@ -447,24 +449,65 @@ function ManualInterestRateSlider({
     if (rate >= lastRate) return 1;
 
     return findClosestRateIndex(chartRates, rate) / chartRates.length;
+  }, []);
+
+  const value = useMemo(() => {
+    const rate = interestRate?.[0] ?? 0n;
+    const chartRates = interestChartData.data?.map(({ rate }) => rate[0]);
+    if (!chartRates) return 0;
+
+    return rateToSliderPosition(rate, chartRates);
   }, [
     jsonStringifyWithDnum(interestChartData.data),
     jsonStringifyWithDnum(interestRate),
+    rateToSliderPosition,
   ]);
 
-  const gradientStops = useMemo((): [number, number] => {
+  const gradientStops = useMemo((): [
+    medium: number,
+    low: number,
+  ] => {
     if (!interestChartData.data || interestChartData.data.length === 0) {
       return [0, 0];
     }
-    const rates = interestChartData.data.map((bar) => bar.rate[0]);
-    const stop = (rate: number) => (
-      findClosestRateIndex(rates, BigInt(rate * 10 ** 18)) / rates.length
+
+    const totalDebt = interestChartData.data.reduce(
+      (sum, item) => dn.add(sum, item.debt),
+      DNUM_0,
     );
+
+    if (dn.eq(totalDebt, 0)) {
+      return [0, 0];
+    }
+
+    // find exact rates where debt positioning crosses thresholds
+    let mediumThresholdRate = null;
+    let lowThresholdRate = null;
+
+    for (const [index, item] of interestChartData.data.entries()) {
+      const prevItem = index > 0 ? interestChartData.data[index - 1] : null;
+      const prevRate = prevItem?.rate[0] ?? null;
+
+      const debtInFrontRatio = dn.div(item.debtInFront, totalDebt);
+
+      // place boundary at the rate before crossing threshold (so slider changes at the right position)
+      if (dn.gt(debtInFrontRatio, REDEMPTION_RISK.medium) && !mediumThresholdRate) {
+        mediumThresholdRate = prevRate;
+      }
+
+      if (dn.gt(debtInFrontRatio, REDEMPTION_RISK.low) && !lowThresholdRate) {
+        lowThresholdRate = prevRate;
+        // low threshold found: no need to continue
+        break;
+      }
+    }
+
+    const chartRates = interestChartData.data.map(({ rate }) => rate[0]);
     return [
-      stop(REDEMPTION_RISK.medium),
-      stop(REDEMPTION_RISK.low),
+      mediumThresholdRate ? rateToSliderPosition(mediumThresholdRate, chartRates) : 0,
+      lowThresholdRate ? rateToSliderPosition(lowThresholdRate, chartRates) : 0,
     ];
-  }, [interestChartData.data]);
+  }, [interestChartData.data, rateToSliderPosition]);
 
   const transition = useAppear(value !== -1);
 

--- a/frontend/app/src/constants.ts
+++ b/frontend/app/src/constants.ts
@@ -82,10 +82,10 @@ export const LTV_RISK: Record<Exclude<RiskLevel, "low">, number> = {
   high: 0.73,
 };
 
-// redemption risk levels, as interest rate ratios
+// redemption risk levels, as debt positioning ratios
 export const REDEMPTION_RISK: Record<Exclude<RiskLevel, "high">, number> = {
-  medium: 3.5 / 100,
-  low: 5 / 100,
+  medium: 0.05, // 5% of total debt in front
+  low: 0.60, // 60% of total debt in front
 };
 
 // default LEGACY_CHECKS when not set by the env

--- a/frontend/app/src/screens/BorrowScreen/BorrowScreen.tsx
+++ b/frontend/app/src/screens/BorrowScreen/BorrowScreen.tsx
@@ -15,7 +15,7 @@ import { dnum18, dnumMax, dnumMin } from "@/src/dnum-utils";
 import { useInputFieldValue } from "@/src/form-utils";
 import { fmtnum } from "@/src/formatting";
 import { getLiquidationRisk, getLoanDetails, getLtv } from "@/src/liquity-math";
-import { getBranch, getBranches, getCollToken, useNextOwnerIndex } from "@/src/liquity-utils";
+import { getBranch, getBranches, getCollToken, useDebtPositioning, useNextOwnerIndex } from "@/src/liquity-utils";
 import { usePrice } from "@/src/services/Prices";
 import { infoTooltipProps } from "@/src/uikit-utils";
 import { useAccount, useBalances } from "@/src/wagmi-utils";
@@ -83,6 +83,7 @@ export function BorrowScreen() {
   }
 
   const nextOwnerIndex = useNextOwnerIndex(account.address ?? null, branch.id);
+  const debtPositioning = useDebtPositioning(interestRate);
 
   const loanDetails = getLoanDetails(
     deposit.isEmpty ? null : deposit.parsed,
@@ -90,6 +91,8 @@ export function BorrowScreen() {
     interestRate,
     collateral.collateralRatio,
     collPrice.data ?? null,
+    debtPositioning.debtInFront,
+    debtPositioning.totalDebt,
   );
 
   const debtSuggestions = loanDetails.maxDebt

--- a/frontend/app/src/screens/LoanScreen/PanelInterestRate.tsx
+++ b/frontend/app/src/screens/LoanScreen/PanelInterestRate.tsx
@@ -12,7 +12,7 @@ import { useInputFieldValue } from "@/src/form-utils";
 import { fmtnum, formatRelativeTime } from "@/src/formatting";
 import { formatRisk } from "@/src/formatting";
 import { getLoanDetails } from "@/src/liquity-math";
-import { getBranch, getCollToken, useTroveRateUpdateCooldown } from "@/src/liquity-utils";
+import { getBranch, getCollToken, useDebtPositioning, useTroveRateUpdateCooldown } from "@/src/liquity-utils";
 import { usePrice } from "@/src/services/Prices";
 import { infoTooltipProps, riskLevelToStatusMode } from "@/src/uikit-utils";
 import { useAccount } from "@/src/wagmi-utils";
@@ -57,12 +57,17 @@ export function PanelInterestRate({
 
   const updateRateCooldown = useUpdateRateCooldown(loan.branchId, loan.troveId);
 
+  const currentDebtPositioning = useDebtPositioning(loan.interestRate);
+  const newDebtPositioning = useDebtPositioning(interestRate);
+
   const loanDetails = getLoanDetails(
     loan.deposit,
     loan.borrowed,
     loan.interestRate,
     collToken.collateralRatio,
     collPrice.data ?? null,
+    currentDebtPositioning.debtInFront,
+    currentDebtPositioning.totalDebt,
   );
 
   const newLoanDetails = getLoanDetails(
@@ -71,6 +76,8 @@ export function PanelInterestRate({
     interestRate,
     collToken.collateralRatio,
     collPrice.data ?? null,
+    newDebtPositioning.debtInFront,
+    newDebtPositioning.totalDebt,
   );
 
   const boldInterestPerYear = interestRate


### PR DESCRIPTION
Thresholds:
- medium risk: 5% (or more) of total debt in front
- low risk: 60% (or more) of total debt in front

Also contains a fix to only show the average link button in manual interest mode.