### PR TITLE
App: fix function calls

### DIFF
--- a/frontend/app/src/comps/InterestRateField/DelegateBox.tsx
+++ b/frontend/app/src/comps/InterestRateField/DelegateBox.tsx
@@ -1,8 +1,9 @@
-import type { Delegate } from "@/src/types";
+import type { BranchId, Delegate } from "@/src/types";
 
 import { Amount } from "@/src/comps/Amount/Amount";
 import { fmtnum, formatDuration, formatRedemptionRisk } from "@/src/formatting";
 import { getRedemptionRisk } from "@/src/liquity-math";
+import { useDebtPositioning } from "@/src/liquity-utils";
 import { riskLevelToStatusMode } from "@/src/uikit-utils";
 import { css } from "@/styled-system/css";
 import { Button, IconCopy, StatusDot, TextButton } from "@liquity2/uikit";
@@ -10,15 +11,18 @@ import { MiniChart } from "./MiniChart";
 import { ShadowBox } from "./ShadowBox";
 
 export function DelegateBox({
+  branchId,
   delegate,
   onSelect,
   selectLabel = "Select",
 }: {
+  branchId: BranchId;
   delegate: Delegate;
   onSelect: (delegate: Delegate) => void;
   selectLabel: string;
 }) {
-  const delegationRisk = getRedemptionRisk(delegate.interestRate);
+  const debtPositioning = useDebtPositioning(branchId, delegate.interestRate);
+  const delegationRisk = getRedemptionRisk(debtPositioning.debtInFront, debtPositioning.totalDebt);
   return (
     <ShadowBox key={delegate.id}>
       <section

--- a/frontend/app/src/comps/InterestRateField/DelegateModal.tsx
+++ b/frontend/app/src/comps/InterestRateField/DelegateModal.tsx
@@ -113,6 +113,7 @@ export function DelegateModal({
                   delegate.data
                     ? (
                       <DelegateBox
+                        branchId={branchId}
                         delegate={delegate.data}
                         selectLabel="Choose"
                         onSelect={onSelectDelegate}

--- a/frontend/app/src/comps/InterestRateField/IcStrategiesModal.tsx
+++ b/frontend/app/src/comps/InterestRateField/IcStrategiesModal.tsx
@@ -74,6 +74,7 @@ export function IcStrategiesModal({
           return (
             <DelegateBox
               key={delegate.address}
+              branchId={branchId}
               delegate={delegate}
               selectLabel="Choose"
               onSelect={onSelectDelegate}

--- a/frontend/app/src/comps/Positions/PositionCardBorrow.tsx
+++ b/frontend/app/src/comps/Positions/PositionCardBorrow.tsx
@@ -6,7 +6,7 @@ import { Amount } from "@/src/comps/Amount/Amount";
 import { formatLiquidationRisk } from "@/src/formatting";
 import { fmtnum } from "@/src/formatting";
 import { getLiquidationRisk, getLtv, getRedemptionRisk } from "@/src/liquity-math";
-import { getCollToken, shortenTroveId } from "@/src/liquity-utils";
+import { getCollToken, shortenTroveId, useDebtPositioning } from "@/src/liquity-utils";
 import { usePrice } from "@/src/services/Prices";
 import { riskLevelToStatusMode } from "@/src/uikit-utils";
 import { css } from "@/styled-system/css";
@@ -44,7 +44,8 @@ export function PositionCardBorrow({
 
   const ltv = debt && deposit && collateralPriceUsd.data
     && getLtv(deposit, debt, collateralPriceUsd.data);
-  const redemptionRisk = getRedemptionRisk(interestRate);
+  const debtPositioning = useDebtPositioning(branchId, interestRate);
+  const redemptionRisk = getRedemptionRisk(debtPositioning.debtInFront, debtPositioning.totalDebt);
 
   const maxLtv = token && dn.from(1 / token.collateralRatio, 18);
   const liquidationRisk = ltv && maxLtv && getLiquidationRisk(ltv, maxLtv);

--- a/frontend/app/src/comps/Positions/PositionCardLeverage.tsx
+++ b/frontend/app/src/comps/Positions/PositionCardLeverage.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from "react";
 import { formatRedemptionRisk } from "@/src/formatting";
 import { fmtnum } from "@/src/formatting";
 import { getLiquidationRisk, getLtv, getRedemptionRisk } from "@/src/liquity-math";
-import { getCollToken } from "@/src/liquity-utils";
+import { getCollToken, useDebtPositioning } from "@/src/liquity-utils";
 import { usePrice } from "@/src/services/Prices";
 import { riskLevelToStatusMode } from "@/src/uikit-utils";
 import { css } from "@/styled-system/css";
@@ -47,7 +47,8 @@ export function PositionCardLeverage({
   const ltv = debt && deposit && collateralPriceUsd.data
     && getLtv(deposit, debt, collateralPriceUsd.data);
   const liquidationRisk = ltv && getLiquidationRisk(ltv, maxLtv);
-  const redemptionRisk = getRedemptionRisk(interestRate);
+  const debtPositioning = useDebtPositioning(branchId, interestRate);
+  const redemptionRisk = getRedemptionRisk(debtPositioning.debtInFront, debtPositioning.totalDebt);
 
   return (
     <PositionCard

--- a/frontend/app/src/liquity-math.test.ts
+++ b/frontend/app/src/liquity-math.test.ts
@@ -31,27 +31,23 @@ const d = (value: number | bigint): Dnum => (
 );
 
 test("getRedemptionRisk() works", () => {
-  // From constants.ts:
-  //  up to 3.5% => high
-  //  >3.5% up to 5% = medium
-  //  >5% = low
+  const totalDebt = d(1_000_000); // 1M total debt
 
-  const interest = (value: number) => d(value / 100);
+  expect(getRedemptionRisk(null, totalDebt)).toBe(null);
+  expect(getRedemptionRisk(d(100_000), null)).toBe(null);
+  expect(getRedemptionRisk(null, null)).toBe(null);
+  expect(getRedemptionRisk(d(100_000), d(0))).toBe(null);
 
-  expect(getRedemptionRisk(null)).toBe(null);
+  // high risk: low debtInFront ratio
+  expect(getRedemptionRisk(d(0), totalDebt)).toBe("high");
+  expect(getRedemptionRisk(d(10_000), totalDebt)).toBe("high"); // 1% ratio
 
-  expect(getRedemptionRisk(interest(-1))).toBe("high");
-  expect(getRedemptionRisk(interest(0))).toBe("high");
+  // medium risk: medium debtInFront ratio
+  expect(getRedemptionRisk(d(400_000), totalDebt)).toBe("medium"); // 40% ratio
 
-  expect(getRedemptionRisk(interest(3.49))).toBe("high");
-  expect(getRedemptionRisk(interest(3.50))).toBe("high");
-  expect(getRedemptionRisk(interest(3.51))).toBe("medium");
-
-  expect(getRedemptionRisk(interest(4.99))).toBe("medium");
-  expect(getRedemptionRisk(interest(5.00))).toBe("medium");
-  expect(getRedemptionRisk(interest(5.01))).toBe("low");
-
-  expect(getRedemptionRisk(interest(10))).toBe("low");
+  // low risk: high debtInFront ratio
+  expect(getRedemptionRisk(d(800_000), totalDebt)).toBe("low"); // 80% ratio
+  expect(getRedemptionRisk(d(900_000), totalDebt)).toBe("low"); // 90% ratio
 });
 
 test("getLiquidationRisk() works", () => {

--- a/frontend/app/src/liquity-math.ts
+++ b/frontend/app/src/liquity-math.ts
@@ -3,7 +3,7 @@ import type { Dnum } from "dnum";
 
 import { LTV_RISK, MAX_LTV_ALLOWED_RATIO, REDEMPTION_RISK } from "@/src/constants";
 import * as dn from "dnum";
-import { match, P } from "ts-pattern";
+import { match } from "ts-pattern";
 
 export function getRedemptionRisk(
   debtInFront: Dnum | null,
@@ -14,7 +14,7 @@ export function getRedemptionRisk(
   }
 
   const debtInFrontRatio = dn.div(debtInFront, totalDebt);
-  
+
   return match(debtInFrontRatio)
     .returnType<RiskLevel>()
     .when((ratio) => dn.gt(ratio, REDEMPTION_RISK.low), () => "low")

--- a/frontend/app/src/liquity-utils.ts
+++ b/frontend/app/src/liquity-utils.ts
@@ -1184,8 +1184,8 @@ export function useNextOwnerIndex(
   });
 }
 
-export function useDebtPositioning(interestRate: Dnum | null) {
-  const chartData = useInterestRateChartData();
+export function useDebtPositioning(branchId: BranchId, interestRate: Dnum | null) {
+  const chartData = useInterestRateChartData(branchId);
 
   return useMemo(() => {
     if (!chartData.data || !interestRate) {

--- a/frontend/app/src/screens/BorrowScreen/BorrowScreen.tsx
+++ b/frontend/app/src/screens/BorrowScreen/BorrowScreen.tsx
@@ -83,7 +83,7 @@ export function BorrowScreen() {
   }
 
   const nextOwnerIndex = useNextOwnerIndex(account.address ?? null, branch.id);
-  const debtPositioning = useDebtPositioning(interestRate);
+  const debtPositioning = useDebtPositioning(branch.id, interestRate);
 
   const loanDetails = getLoanDetails(
     deposit.isEmpty ? null : deposit.parsed,

--- a/frontend/app/src/screens/LeverageScreen/LeverageScreen.tsx
+++ b/frontend/app/src/screens/LeverageScreen/LeverageScreen.tsx
@@ -17,7 +17,7 @@ import { useInputFieldValue } from "@/src/form-utils";
 import { fmtnum } from "@/src/formatting";
 import { useCheckLeverageSlippage } from "@/src/liquity-leverage";
 import { getRedemptionRisk } from "@/src/liquity-math";
-import { getBranch, getBranches, getCollToken, useNextOwnerIndex } from "@/src/liquity-utils";
+import { getBranch, getBranches, getCollToken, useNextOwnerIndex, useDebtPositioning } from "@/src/liquity-utils";
 import { usePrice } from "@/src/services/Prices";
 import { useTransactionFlow } from "@/src/services/TransactionFlow";
 import { infoTooltipProps } from "@/src/uikit-utils";
@@ -92,7 +92,8 @@ export function LeverageScreen() {
     leverageField.updateLeverageFactor(leverageField.leverageFactorSuggestions[0] ?? 1.1);
   }, [collateral.symbol, leverageField.leverageFactorSuggestions]);
 
-  const redemptionRisk = getRedemptionRisk(interestRate);
+  const debtPositioning = useDebtPositioning(branch.id, interestRate);
+  const redemptionRisk = getRedemptionRisk(debtPositioning.debtInFront, debtPositioning.totalDebt);
   const depositUsd = depositPreLeverage.parsed && collPrice.data && dn.mul(
     depositPreLeverage.parsed,
     collPrice.data,

--- a/frontend/app/src/screens/LoanScreen/PanelInterestRate.tsx
+++ b/frontend/app/src/screens/LoanScreen/PanelInterestRate.tsx
@@ -57,8 +57,8 @@ export function PanelInterestRate({
 
   const updateRateCooldown = useUpdateRateCooldown(loan.branchId, loan.troveId);
 
-  const currentDebtPositioning = useDebtPositioning(loan.interestRate);
-  const newDebtPositioning = useDebtPositioning(interestRate);
+  const currentDebtPositioning = useDebtPositioning(loan.branchId, loan.interestRate);
+  const newDebtPositioning = useDebtPositioning(loan.branchId, interestRate);
 
   const loanDetails = getLoanDetails(
     loan.deposit,

--- a/frontend/app/src/wagmi-utils.ts
+++ b/frontend/app/src/wagmi-utils.ts
@@ -105,7 +105,6 @@ export function useAccount():
   }
 {
   const account = useWagmiAccount();
-  const connectKitModal = useConnectKitModal();
   const ensName = useEnsName({ address: account?.address });
 
   const safeStatus = useQuery({
@@ -121,6 +120,8 @@ export function useAccount():
     refetchInterval: false, // only needed once
     enabled: Boolean(account.address),
   });
+
+  const connectKitModal = useConnectKitModal();
 
   return {
     ...account,


### PR DESCRIPTION
- Update the `useInterestRateChartData()` call inside of `useDebtPositioning()` to pass the `branchId` parameter.
- Add a `branchId` parameter to `useDebtPositioning()`, and update all the calls.
- Fix some `getRedemptionRisk()` calls that were still passing the interest rate.