### PR TITLE
[App] Fix connection indicators not working

### DIFF
--- a/frontend/app/src/indicators/rpc-indicator.ts
+++ b/frontend/app/src/indicators/rpc-indicator.ts
@@ -2,12 +2,10 @@ import { useIndicator } from "@/src/services/IndicatorManager";
 import { useEffect, useRef } from "react";
 import { useBlockNumber } from "wagmi";
 
-const MAX_CONSECUTIVE_FAILURES = 2;
 const REFETCH_INTERVAL = 10_000;
 
 export function useRpcIndicator() {
   const indicator = useIndicator();
-  const consecutiveFailures = useRef(0);
   const hasError = useRef(false);
 
   const { isError } = useBlockNumber({
@@ -17,8 +15,7 @@ export function useRpcIndicator() {
 
   useEffect(() => {
     if (isError) {
-      consecutiveFailures.current += 1;
-      if (consecutiveFailures.current >= MAX_CONSECUTIVE_FAILURES && !hasError.current) {
+      if (!hasError.current) {
         hasError.current = true;
         indicator.setError(
           "rpc-error",
@@ -27,7 +24,6 @@ export function useRpcIndicator() {
         );
       }
     } else {
-      consecutiveFailures.current = 0;
       if (hasError.current) {
         hasError.current = false;
         indicator.clearError("rpc-error");

--- a/frontend/app/src/subgraph.ts
+++ b/frontend/app/src/subgraph.ts
@@ -16,11 +16,19 @@ type IndexedTrove = {
   status: string;
 };
 
+async function tryFetch(...args: Parameters<typeof fetch>) {
+  try {
+    return await fetch(...args);
+  } catch {
+    return null;
+  }
+}
+
 async function graphQuery<TResult, TVariables>(
   query: TypedDocumentString<TResult, TVariables>,
   ...[variables]: TVariables extends Record<string, never> ? [] : [TVariables]
 ) {
-  const response = await fetch(SUBGRAPH_URL, {
+  const response = await tryFetch(SUBGRAPH_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -32,7 +40,7 @@ async function graphQuery<TResult, TVariables>(
     ),
   });
 
-  if (!response.ok) {
+  if (response === null || !response.ok) {
     subgraphIndicator.setError("Subgraph error: unable to fetch data.");
     throw new Error("Error while fetching data from the subgraph");
   }


### PR DESCRIPTION
### RPC indicator

It seems `useBlockNumber()` won't trigger re-renders past an initial failure, thus our consecutive error counter never reaches higher than 1.

What's more, there already seems to be some built-in logic to retry before returning an error, so it seems redundant to add similar logic.

### Subgraph indicator

The subgraph indicator wasn't working when `fetch()` itself was throwing, for example in case of network issues.