### PR TITLE
chore: remove redundant words in comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,7 +670,7 @@ As can be seen in the above table and proven in generality (TBD), the outside de
 
 In practice, only `SP.getTotalBoldDeposits() - MIN_BOLD_IN_SP` is used for liquidation  - that is, there is always 1 BOLD in the SP of a given branch  - see the [min 1 BOLD in SP section](https://github.com/liquity/bold?tab=readme-ov-file#minimum-1-bold-token-in-the-sp). This 1 BOLD does not count towards the backing of a branch.
 
-Therefore the true unbacked portion of a given branch is slightly larger than the amount used in the calculation above - and in turn, the the “true” ratio of the unbacked portions of all branches is slightly distorted. However, this distortion is only significant for very small system sizes, and considered a non-issue in practice.  
+Therefore the true unbacked portion of a given branch is slightly larger than the amount used in the calculation above - and in turn, the “true” ratio of the unbacked portions of all branches is slightly distorted. However, this distortion is only significant for very small system sizes, and considered a non-issue in practice.  
 
 ## Redemptions at branch level
 

--- a/contracts/src/ActivePool.sol
+++ b/contracts/src/ActivePool.sol
@@ -95,7 +95,7 @@ contract ActivePool is IActivePool {
     /*
     * Returns the Coll state variable.
     *
-    *Not necessarily equal to the the contract's raw Coll balance - ether can be forcibly sent to contracts.
+    *Not necessarily equal to the contract's raw Coll balance - ether can be forcibly sent to contracts.
     */
     function getCollBalance() external view override returns (uint256) {
         return collBalance;

--- a/contracts/src/DefaultPool.sol
+++ b/contracts/src/DefaultPool.sol
@@ -50,7 +50,7 @@ contract DefaultPool is IDefaultPool {
     /*
     * Returns the collBalance state variable.
     *
-    * Not necessarily equal to the the contract's raw Coll balance - ether can be forcibly sent to contracts.
+    * Not necessarily equal to the contract's raw Coll balance - ether can be forcibly sent to contracts.
     */
     function getCollBalance() external view override returns (uint256) {
         return collBalance;

--- a/contracts/test-js/BorrowerOperationsTest.js
+++ b/contracts/test-js/BorrowerOperationsTest.js
@@ -3050,7 +3050,7 @@ contract("BorrowerOperations", async (accounts) => {
         th.assertIsApproximatelyEqual(activePool_Debt_After, dennisDebt);
       });
 
-      it("closeTrove(): updates the the total stakes", async () => {
+      it("closeTrove(): updates the total stakes", async () => {
         const { troveId: dennisTroveId } = await openTrove({
           extraBoldAmount: toBN(dec(10000, 18)),
           ICR: toBN(dec(2, 18)),

--- a/frontend/app/src/comps/LeverageField/LeverageField.tsx
+++ b/frontend/app/src/comps/LeverageField/LeverageField.tsx
@@ -242,7 +242,7 @@ export function useLeverageField({
         isFocused.current = focused;
         onFocusChange?.(focused);
 
-        // Make sure the the input value corresponds to the leverage
+        // Make sure the input value corresponds to the leverage
         // factor matching to the desired liquidation price.
         if (!focused && price) {
           const lf = getLeverageFactorFromLiquidationPriceClamped(price);


### PR DESCRIPTION
 remove redundant words in comment