### PR TITLE
[App] Don't pre-select average interest rate for existing loans

### DIFF
--- a/frontend/app/src/comps/InterestRateField/InterestRateField.tsx
+++ b/frontend/app/src/comps/InterestRateField/InterestRateField.tsx
@@ -104,13 +104,8 @@ export const InterestRateField = memo(
       setDelegatePicker(null);
       onDelegateChange(null);
       onModeChange("manual");
-      if (averageInterestRate.data) {
-        onChange(averageInterestRate.data);
-      }
     }, [
-      averageInterestRate.data,
       branchId,
-      onChange,
       onDelegateChange,
       onModeChange,
     ]);


### PR DESCRIPTION
This was making it hard to read the debt-in-front of existing loans.