### PR TITLE
[App] Allow impersonating an origin when fetching subgraph schema

### DIFF
--- a/frontend/app/README.md
+++ b/frontend/app/README.md
@@ -276,6 +276,15 @@ URL for The Graph protocol subgraph queries.
 NEXT_PUBLIC_SUBGRAPH_URL=https://api.studio.thegraph.com/query/…
 ```
 
+### `NEXT_PUBLIC_SUBGRAPH_ORIGIN`
+
+When using a subgraph URL that's restricted to set of domains which are allowed to execute queries, this must be set to one of the allowed domains. When fetching the schema of the subgraph during build, this domain will be sent as HTTP origin. Otherwise, the build will fail.
+
+```dosini
+# Example
+NEXT_PUBLIC_SUBGRAPH_ORIGIN=https://example.com
+```
+
 ### `NEXT_PUBLIC_VERCEL_ANALYTICS`
 
 Enable or disable Vercel Analytics for tracking application metrics.
@@ -296,6 +305,7 @@ An optional set of names and URLs (of the form `<name>|<url>`) of external apps 
 Currently, only the indices `_0` and `_1` are supported.
 
 Defaults to the following values:
+
 ```dosini
 NEXT_PUBLIC_TROVE_EXPLORER_0=DeFi Explore|https://liquityv2.defiexplore.com/trove/{branch}/{troveId}
 NEXT_PUBLIC_TROVE_EXPLORER_1=Rails|https://rails.finance/explorer/trove/{troveId}/{branch}

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -48,6 +48,7 @@
     "@babel/plugin-transform-private-methods": "^7.27.1",
     "@graphql-codegen/cli": "^5.0.7",
     "@graphql-codegen/schema-ast": "^4.1.0",
+    "@next/env": "^15.5.2",
     "@pandacss/dev": "^0.54.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       '@graphql-codegen/schema-ast':
         specifier: ^4.1.0
         version: 4.1.0(graphql@16.11.0)
+      '@next/env':
+        specifier: ^15.5.2
+        version: 15.5.2
       '@pandacss/dev':
         specifier: ^0.54.0
         version: 0.54.0(jsdom@26.1.0)(typescript@5.8.3)
@@ -4354,6 +4357,10 @@ packages:
   /@next/env@15.3.4:
     resolution: {integrity: sha512-ZkdYzBseS6UjYzz6ylVKPOK+//zLWvD6Ta+vpoye8cW11AjiQjGYVibF0xuvT4L0iJfAPfZLFidaEzAOywyOAQ==}
     dev: false
+
+  /@next/env@15.5.2:
+    resolution: {integrity: sha512-Qe06ew4zt12LeO6N7j8/nULSOe3fMXE4dM6xgpBQNvdzyK1sv5y4oAP3bq4LamrvGCZtmRYnW8URFCeX5nFgGg==}
+    dev: true
 
   /@next/eslint-plugin-next@15.3.4:
     resolution: {integrity: sha512-lBxYdj7TI8phbJcLSAqDt57nIcobEign5NYIKCiy0hXQhrUbTqLqOaSDi568U6vFg4hJfBdZYsG4iP/uKhCqgg==}


### PR DESCRIPTION
This enables frontend operators to restrict their API keys to a set of domains. Previously, doing so would have resulted in a failing build. This is because the subgraph schema is fetched from the subgraph during build time, hence if such a restriction is placed, we must impersonate a domain that is allowed to use the subgraph.