### PR TITLE
[App] Fix bribe info being shown when no bribes are available

### DIFF
--- a/frontend/app/src/screens/StakeScreen/components/PanelVoting/components/EpochInitiativesTable/components/TableBody/components/InitiativeRow/components/BribeInfo/BribeInfo.tsx
+++ b/frontend/app/src/screens/StakeScreen/components/PanelVoting/components/EpochInitiativesTable/components/TableBody/components/InitiativeRow/components/BribeInfo/BribeInfo.tsx
@@ -1,15 +1,14 @@
-import { css } from "@/styled-system/css";
-import { gt, mul } from "dnum";
-import { fmtnum } from "@/src/formatting";
-import { Amount } from "@/src/comps/Amount/Amount";
-import { tokenIconUrl } from "@/src/utils";
-import { CHAIN_ID } from "@/src/env";
-import { usePrice } from "@/src/services/Prices";
-import { useVotingStateContext } from "@/src/screens/StakeScreen/components/PanelVoting/providers/PanelVotingProvider/hooks";
-import { TokenIcon } from "@liquity2/uikit";
-
+import { type Address, TokenIcon } from "@liquity2/uikit";
+import * as dn from "dnum";
 import type { FC } from "react";
-import type { Address } from "@liquity2/uikit";
+
+import { Amount } from "@/src/comps/Amount/Amount";
+import { CHAIN_ID } from "@/src/env";
+import { fmtnum } from "@/src/formatting";
+import { useVotingStateContext } from "@/src/screens/StakeScreen/components/PanelVoting/providers/PanelVotingProvider/hooks";
+import { usePrice } from "@/src/services/Prices";
+import { tokenIconUrl } from "@/src/utils";
+import { css } from "@/styled-system/css";
 
 interface BribeInfoProps {
   initiativeAddress: Address;
@@ -21,11 +20,9 @@ export const BribeInfo: FC<BribeInfoProps> = ({ initiativeAddress }) => {
   const boldPrice = usePrice(bribe ? "BOLD" : null);
   const bribeTokenPrice = usePrice(bribe ? bribe.tokenSymbol : null);
 
-  if (!bribe || (gt(bribe.boldAmount, 0) && gt(bribe.tokenAmount, 0))) {
+  if (!bribe || (dn.eq(bribe.boldAmount, 0) && dn.eq(bribe.tokenAmount, 0))) {
     return null;
   }
-
-  const bribeTokenAmount = gt(bribe.tokenAmount, 0);
 
   return (
     <div
@@ -46,7 +43,7 @@ export const BribeInfo: FC<BribeInfoProps> = ({ initiativeAddress }) => {
           flexWrap: "wrap",
         })}
       >
-        {gt(bribe.boldAmount, 0) && (
+        {dn.gt(bribe.boldAmount, 0) && (
           <div
             title={`${fmtnum(bribe.boldAmount)} BOLD`}
             className={css({
@@ -62,13 +59,13 @@ export const BribeInfo: FC<BribeInfoProps> = ({ initiativeAddress }) => {
                 format="compact"
                 title={null}
                 prefix="($"
-                value={mul(bribe.boldAmount, boldPrice.data)}
+                value={dn.mul(bribe.boldAmount, boldPrice.data)}
                 suffix=")"
               />
             )}
           </div>
         )}
-        {bribeTokenAmount && (
+        {dn.gt(bribe.tokenAmount, 0) && (
           <div
             title={`${fmtnum(bribe.tokenAmount)} ${bribe.tokenSymbol} (${bribe.tokenAddress})`}
             className={css({
@@ -92,7 +89,7 @@ export const BribeInfo: FC<BribeInfoProps> = ({ initiativeAddress }) => {
                 format="compact"
                 title={null}
                 prefix="($"
-                value={mul(bribe.tokenAmount, bribeTokenPrice.data)}
+                value={dn.mul(bribe.tokenAmount, bribeTokenPrice.data)}
                 suffix=")"
               />
             )}


### PR DESCRIPTION
Eliminate the empty "Bribing:" shown for initiatives that aren't bribing:

<img width="558" height="555" alt="image" src="https://github.com/user-attachments/assets/4383c2f2-9039-45e1-aaf1-8f0c3e4d5822" />
